### PR TITLE
verify_trace_points

### DIFF
--- a/caret_analyze/infra/interface.py
+++ b/caret_analyze/infra/interface.py
@@ -120,7 +120,14 @@ class RecordsProvider(metaclass=ABCMeta):
     ) -> ClockConverter:
         pass
 
+    @abstractmethod
+    def verify_communication(
+        self,
+        communication: CommunicationStructValue
+    ) -> bool:
+        pass
 
+        
 class RuntimeDataProvider(RecordsProvider):
 
     @abstractmethod

--- a/caret_analyze/infra/interface.py
+++ b/caret_analyze/infra/interface.py
@@ -127,7 +127,7 @@ class RecordsProvider(metaclass=ABCMeta):
     ) -> bool:
         pass
 
-        
+
 class RuntimeDataProvider(RecordsProvider):
 
     @abstractmethod

--- a/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -642,7 +642,6 @@ class RecordsProviderLttng(RuntimeDataProvider):
         else:
             return True
 
-
     def verify_communication(
         self,
         communication: CommunicationStructValue,
@@ -672,8 +671,6 @@ class RecordsProviderLttng(RuntimeDataProvider):
             logger.warning(f"'caret/rclcpp' may not be used in subscriber of '{sub_node}'.")
             return False
         return True
-
-
 
     def _compose_intra_proc_comm_records(
         self,

--- a/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -666,10 +666,10 @@ class RecordsProviderLttng(RuntimeDataProvider):
             )
 
         if not pub_result:
-            print(f"'caret/rclcpp' may not be used in publisher of '{pub_node}'.")
+            logger.warning(f"'caret/rclcpp' may not be used in publisher of '{pub_node}'.")
             return False
         if not sub_result:
-            print(f"'caret/rclcpp' may not be used in subscriber of '{sub_node}'.")
+            logger.warning(f"'caret/rclcpp' may not be used in subscriber of '{sub_node}'.")
             return False
         return True
 

--- a/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -626,7 +626,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         intra_record = self._compose_intra_proc_comm_records(communication_value)
         return len(intra_record) > 0
 
-    def verify_trace_points(
+    def _verify_trace_points(
         self,
         node_name: str,
         trace_points: str
@@ -651,8 +651,8 @@ class RecordsProviderLttng(RuntimeDataProvider):
         if is_intra_proc is True:
             pub_node = communication.publish_node.node_name
             sub_node = communication.subscribe_node.node_name
-            pub_result = self.verify_trace_points(pub_node, 'ros2:rclcpp_intra_publish')
-            sub_result = self.verify_trace_points(
+            pub_result = self._verify_trace_points(pub_node, 'ros2:rclcpp_intra_publish')
+            sub_result = self._verify_trace_points(
                 sub_node,
                 'ros2:dispatch_intra_process_subscription_callback'
             )
@@ -660,7 +660,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         elif is_intra_proc is False:
             pub_result = True
             sub_node = communication.subscribe_node.node_name
-            sub_result = self.verify_trace_points(
+            sub_result = self._verify_trace_points(
                 sub_node,
                 'ros2:dispatch_subscription_callback'
             )

--- a/caret_analyze/runtime/communication.py
+++ b/caret_analyze/runtime/communication.py
@@ -110,6 +110,12 @@ class Communication(PathBase, Summarizable):
         records = self.to_records()
         return records.columns
 
+    def verify(self) -> bool:
+        is_valid = True
+        if self._records_provider is not None:
+            is_valid &= self._records_provider.verify_communication(self._val)
+        return is_valid
+
     def _to_records_core(self) -> RecordsInterface:
         records = self._records_provider.communication_records(self._val)
 

--- a/caret_analyze/runtime/path.py
+++ b/caret_analyze/runtime/path.py
@@ -22,6 +22,7 @@ from .communication import Communication
 from .node_path import NodePath
 from .path_base import PathBase
 from ..common import Columns, Summarizable, Summary, Util
+from ..infra import RecordsProvider
 from ..exceptions import InvalidArgumentError, InvalidRecordsError
 from ..record.record import merge, merge_sequencial, RecordsInterface
 from ..value_objects import CallbackChain, PathStructValue
@@ -234,6 +235,9 @@ class Path(PathBase, Summarizable):
             msg += str(child.summary)
             logger.warning(msg)
             is_valid = False
+
+        for comm in self.communications:
+            is_valid &= comm.verify()
         return is_valid
 
     def get_child(self, name: str):

--- a/caret_analyze/runtime/path.py
+++ b/caret_analyze/runtime/path.py
@@ -22,7 +22,6 @@ from .communication import Communication
 from .node_path import NodePath
 from .path_base import PathBase
 from ..common import Columns, Summarizable, Summary, Util
-from ..infra import RecordsProvider
 from ..exceptions import InvalidArgumentError, InvalidRecordsError
 from ..record.record import merge, merge_sequencial, RecordsInterface
 from ..value_objects import CallbackChain, PathStructValue

--- a/test/runtime/test_path.py
+++ b/test/runtime/test_path.py
@@ -300,14 +300,3 @@ class TestRecordsMerged:
             ]
         )
         assert records.equals(expected)
-
-
-class TestVerify:
-
-    def test_verify(self):
-        from caret_analyze import Architecture, Application, Lttng
-        arch = Architecture('yaml', '/home/emb4/.ros/tracing/arch_universe_gsm8.yaml')
-        lttng = Lttng('/home/emb4/.ros/tracing/trace_no_use_caret_rclcpp_02')
-        app = Application(arch, lttng)
-        path = app.get_path('pandar_cloud-gsm8_interface')
-        path.verify()

--- a/test/runtime/test_path.py
+++ b/test/runtime/test_path.py
@@ -300,3 +300,14 @@ class TestRecordsMerged:
             ]
         )
         assert records.equals(expected)
+
+
+class TestVerify:
+
+    def test_verify(self):
+        from caret_analyze import Architecture, Application, Lttng
+        arch = Architecture('yaml', '/home/emb4/.ros/tracing/arch_universe_gsm8.yaml')
+        lttng = Lttng('/home/emb4/.ros/tracing/trace_no_use_caret_rclcpp_02')
+        app = Application(arch, lttng)
+        path = app.get_path('pandar_cloud-gsm8_interface')
+        path.verify()

--- a/test/temp/value_objects/test_subscription_value_object.py
+++ b/test/temp/value_objects/test_subscription_value_object.py
@@ -14,8 +14,6 @@
 
 from caret_analyze.value_objects import SubscriptionStructValue
 
-import pytest
-
 
 class TestSubscriptionValueObject:
 


### PR DESCRIPTION
@hsgwa 
caret/rclcppで提供されているトレースポイントが入っているかを確認する機能
確認方法は以下
- プロセス内通信の場合
  - Pub側：`ros2:rclcpp_intra_publish`があるか確認
  - Sub側：`ros2:dispatch_intra_process_subscription_callback`があるか確認
- プロセス間通信の場合
  - Pub側：ros/rclcppのトレースポイントで足りるため確認不要
  - Sub側：`ros2:dispatch_subscription_callback`があるか確認

本機能はwarningを出すだけに留まる

ndt_scan_matcherのみros/rclcppでビルドした時のトレースデータ
https://drive.google.com/drive/folders/15QqkOsSvFwj8wGkyUwHNxijxqaeA1-CK