### PR TITLE
fix: negative comm latency

### DIFF
--- a/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1369,8 +1369,8 @@ class FilteredRecordsSource:
         merged = merge(
             left_records=pub_records,
             right_records=sub_records,
-            join_left_key=COLUMN_NAME.MESSAGE_TIMESTAMP,
-            join_right_key=COLUMN_NAME.MESSAGE_TIMESTAMP,
+            join_left_key=COLUMN_NAME.SOURCE_TIMESTAMP,
+            join_right_key=COLUMN_NAME.SOURCE_TIMESTAMP,
             columns=Columns(pub_records.columns + sub_records.columns).as_list(),
             how='left'
         )


### PR DESCRIPTION
Signed-off-by: hsgwa <hasegawa.isp@gmail.com>
When fixing a bug when both intra-process and inter-process communication was used, the latency calculation method was implemented incorrectly.

https://github.com/tier4/CARET_analyze/commit/24a2883296b058c2a87848449e1d9329ee0301e2