### PR TITLE
feat: check LD_PRELOAD setting by process id

### DIFF
--- a/caret_analyze/infra/lttng/event_counter.py
+++ b/caret_analyze/infra/lttng/event_counter.py
@@ -427,6 +427,9 @@ class EventCounter:
             CountRule('ros2_caret:tilde_subscription_init',
                       data.tilde_subscription_init,
                       'subscription'),
+            CountRule('ros2_caret:rcl_init_caret',
+                      data.rcl_init_caret,
+                      'pid'),
 
             # measurement tracepoints
             CountRule('ros2:callback_end',

--- a/caret_analyze/infra/lttng/lttng_info.py
+++ b/caret_analyze/infra/lttng/lttng_info.py
@@ -399,6 +399,15 @@ class LttngInfo:
 
         for i in range(len(nodes_df)):
             node_name = nodes_df.get(i, 'node_name')
+
+            # Check LD_PRELOAD setting
+            lib_caret_version = nodes_df.get(i, 'lib_caret_version')
+            if not lib_caret_version:
+                msg = ('Failed to found trace point added by LD_PRELOAD. '
+                       'Measurement results will not be correct. '
+                       'The measurement may have been performed without setting LD_PRELOAD.')
+                logger.warning(msg)
+
             if str(node_name).startswith('_ros2_cli'):
                 continue
             node_id = nodes_df.get(i, 'node_id')
@@ -409,7 +418,7 @@ class LttngInfo:
             added_nodes.add(node_name)
             pid = nodes_df.get(i, 'pid')
             nodes.append(
-                NodeValueLttng(pid, node_name, node_handle, node_id)
+                NodeValueLttng(pid, node_name, node_handle, node_id, lib_caret_version)
             )
 
         for duplicate_node in duplicate_nodes:
@@ -2278,7 +2287,7 @@ class DataFrameFormatted:
     def _build_nodes_df(
         data: Ros2DataModel
     ) -> RecordsInterface:
-        columns = ['pid', 'node_id', 'node_handle', 'node_name']
+        columns = ['pid', 'node_id', 'node_handle', 'node_name', 'lib_caret_version']
 
         node_records = data.rcl_node_init.clone()
 
@@ -2299,8 +2308,18 @@ class DataFrameFormatted:
 
         DataFrameFormatted._add_column(node_records, 'node_id', to_node_id)
 
+        rcl_caret_inits = data.rcl_init_caret.clone()
+        node_records = merge(
+            node_records,
+            rcl_caret_inits,
+            'pid',
+            'pid',
+            how='outer'
+        )
+
         node_records.columns.drop(set(node_records.column_names) - set(columns))
         node_records.columns.reindex(columns)
+
         return node_records
 
 

--- a/caret_analyze/infra/lttng/ros2_tracing/data_model.py
+++ b/caret_analyze/infra/lttng/ros2_tracing/data_model.py
@@ -34,6 +34,17 @@ class Ros2DataModel(DataModel):
         """Create a Ros2DataModel."""
         super().__init__()
         # Objects (one-time events, usually when something is created)
+
+        self.rcl_init_caret = RecordsFactory.create_instance(
+            None,
+            [
+                ColumnValue('timestamp'),
+                ColumnValue('pid'),
+                ColumnValue('tid'),
+                ColumnValue('lib_caret_version', mapper=ColumnMapper())
+            ]
+        )
+
         self.rcl_init = RecordsFactory.create_instance(
             None,
             [
@@ -828,6 +839,22 @@ class Ros2DataModel(DataModel):
     def _to_system_time(self, raw_timestamp: int) -> int:
         assert self._raw_offset is not None
         return raw_timestamp + self._raw_offset
+
+    def add_rcl_init_caret(self, lib_caret_version, timestamp, pid, tid) -> None:
+        version_idx = len(self.rcl_init_caret)
+        mapper = self.rcl_init_caret.columns.get('lib_caret_version').mapper
+        assert mapper is not None
+        mapper.add(version_idx, lib_caret_version)
+        self.rcl_init_caret.append(
+            RecordFactory.create_instance(
+                {
+                    'timestamp': timestamp,
+                    'pid': pid,
+                    'tid': tid,
+                    'lib_caret_version': version_idx,
+                }
+            )
+        )
 
     def add_rcl_init(self, pid, tid, context_handle, timestamp, version) -> None:
         version_idx = len(self.rcl_init)

--- a/caret_analyze/infra/lttng/ros2_tracing/processor.py
+++ b/caret_analyze/infra/lttng/ros2_tracing/processor.py
@@ -147,6 +147,8 @@ class Ros2Handler(EventHandler):
             self._handle_inter_publish
         handler_map['ros2_caret:tf_lookup_transform'] = \
             self._handle_tf_lookup_transform
+        handler_map['ros2_caret:rcl_init_caret'] = \
+            self._handle_rcl_init_caret
 
         # for v0.2 compatibility
         handler_map['ros2:callback_start'] = self._handle_callback_start
@@ -219,6 +221,7 @@ class Ros2Handler(EventHandler):
             'ros2_caret:tilde_publish',
             'ros2_caret:tilde_subscribe_added',
             'ros2_caret:sim_time',
+            'ros2_caret:rcl_init_caret',
         ]
 
     @staticmethod
@@ -230,6 +233,17 @@ class Ros2Handler(EventHandler):
     @property
     def data(self) -> Ros2DataModel:
         return super().data  # type: ignore
+
+    def _handle_rcl_init_caret(
+        self,
+        event: Dict,
+        metadata: EventMetadata,
+    ) -> None:
+        lib_caret_version = get_field(event, 'lib_caret_version')
+        timestamp = metadata.timestamp
+        pid = metadata.pid
+        tid = metadata.tid
+        self.data.add_rcl_init_caret(lib_caret_version, timestamp, pid, tid)
 
     def _handle_rcl_init(
         self,

--- a/caret_analyze/infra/lttng/value_objects/node.py
+++ b/caret_analyze/infra/lttng/value_objects/node.py
@@ -24,11 +24,13 @@ class NodeValueLttng(NodeValue):
         node_name: str,
         node_handle: int,
         node_id: str,
+        lib_caret_version: str,
     ):
         super().__init__(node_name, node_id)
         self._pid = pid
         self._node_id = node_id
         self._node_handle = node_handle
+        self._lib_caret_version = lib_caret_version
 
     @property
     def pid(self) -> int:
@@ -41,3 +43,7 @@ class NodeValueLttng(NodeValue):
     @property
     def node_id(self) -> str:
         return self._node_id
+    
+    @property
+    def lib_caret_version(self) -> str:
+        return self._lib_caret_version


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

@hsgwa 
お疲れ様です。
LD_PRELOADチェック＆バージョンチェック用のトレースポイント (ros2_caret:rcl_init_caret) の、
ノードが宣言されたpidに対する有無のチェック実装が完了したので、ご確認をお願いいたします。

以下は [LD_PRELOAD を設定せずに計測したトレースデータ](https://drive.google.com/file/d/1qXyOmo8dWFCnWODWTEwwvv6BcLiVCSUL/view?usp=sharing)に対する、lttng クラス初期化時のログです。

> Succeed to find record_cpp_impl. the C++ version will be used.
converting trace directory: /home/saitamaemb4/ros2_ws/evaluate/no_ld_preload
converted 222 events in 19 ms
output written to: /home/saitamaemb4/ros2_ws/evaluate/no_ld_preload/converted
222 events found.
 [100%] [Ros2Handler]
WARNING : 2022-05-25 07:25:16 | Failed to found trace point added by LD_PRELOAD. Measurement results will not be correct. The measurement may have been performed without setting LD_PRELOAD.
WARNING : 2022-05-25 07:25:16 | Failed to found trace point added by LD_PRELOAD. Measurement results will not be correct. The measurement may have been performed without setting LD_PRELOAD.