### PR TITLE
chore: skip mypy tests in github actions

### DIFF
--- a/src/test/test_mypy.py
+++ b/src/test/test_mypy.py
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from ament_mypy.main import main
 
 import pytest
 
 
+reason = '[mypy test is to be officially supported in v0.4 or later.]'
+
+
+@pytest.mark.skipif('GITHUB_ACTION' in os.environ, reason=reason)
 @pytest.mark.mypy
 @pytest.mark.linter
 def test_mypy():


### PR DESCRIPTION
Signed-off-by: hsgwa <hasegawa.isp@gmail.com>

This PR disables mypy tests in github actions since mypy test is to be officially supported in v0.4 or later.