### PR TITLE
docs: add pages of API for developer and fix document generation methods

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -1,12 +1,12 @@
 nav:
   - HOME: index.md
   - API for user:
-      - Plot: plot.md
-      - Runtime: runtime.md
-      - Exceptions: exceptions.md
+      - plot: plot.md
+      - runtime: runtime.md
+      - exceptions: exceptions.md
   - API for developer:
-      - Architecture: architecture.md
-      - Common: common.md
-      - Infra: infra.md
-      - Record: record.md
-      - Value_objects: value_objects.md
+      - architecture: architecture.md
+      - common: common.md
+      - infra: infra.md
+      - record: record.md
+      - value_objects: value_objects.md

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,0 +1,12 @@
+nav:
+  - HOME: index.md
+  - API for user:
+      - Plot: plot.md
+      - Runtime: runtime.md
+      - Exceptions: exceptions.md
+  - API for developer:
+      - Architecture: architecture.md
+      - Common: common.md
+      - Infra: infra.md
+      - Record: record.md
+      - Value_objects: value_objects.md

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,12 +1,12 @@
 nav:
   - HOME: index.md
   - API for user:
+      - architecture: architecture.md
+      - infra: infra.md
       - plot: plot.md
       - runtime: runtime.md
       - exceptions: exceptions.md
   - API for developer:
-      - architecture: architecture.md
       - common: common.md
-      - infra: infra.md
       - record: record.md
       - value_objects: value_objects.md

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,1 @@
+::: caret_analyze.architecture

--- a/docs/common.md
+++ b/docs/common.md
@@ -1,0 +1,1 @@
+::: caret_analyze.common

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,14 @@
 
 ## API for user
 
+- [architecture](architecture.md)
+- [infra](infra.md)
 - [plot](plot.md)
 - [runtime](runtime.md)
 - [exceptions](exceptions.md)
 
 ## API for developer
 
-- [architecture](architecture.md)
 - [common](common.md)
-- [infra](infra.md)
 - [record](record.md)
 - [value_objects](value_objects.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,5 @@
 # CARET analyze
 
-TODO
-
 ## API for user
 
 - [Plot](plot.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,16 @@
 
 TODO
 
-## API
+## API for user
 
 - [Plot](plot.md)
 - [Runtime](runtime.md)
 - [Exceptions](exceptions.md)
+
+## API for developer
+
+- [Architecture](architecture.md)
+- [Common](common.md)
+- [Infra](infra.md)
+- [Record](record.md)
+- [Value_objects](value_objects.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,14 @@
 
 ## API for user
 
-- [Plot](plot.md)
-- [Runtime](runtime.md)
-- [Exceptions](exceptions.md)
+- [plot](plot.md)
+- [runtime](runtime.md)
+- [exceptions](exceptions.md)
 
 ## API for developer
 
-- [Architecture](architecture.md)
-- [Common](common.md)
-- [Infra](infra.md)
-- [Record](record.md)
-- [Value_objects](value_objects.md)
+- [architecture](architecture.md)
+- [common](common.md)
+- [infra](infra.md)
+- [record](record.md)
+- [value_objects](value_objects.md)

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -1,0 +1,1 @@
+::: caret_analyze.infra

--- a/docs/record.md
+++ b/docs/record.md
@@ -1,0 +1,1 @@
+::: caret_analyze.record

--- a/docs/value_objects.md
+++ b/docs/value_objects.md
@@ -1,0 +1,1 @@
+::: caret_analyze.value_objects

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -66,14 +66,7 @@ plugins:
           options:
             docstring_style: numpy
             show_source: false
-            show_submodules: true
-
-nav:
-  - HOME: index.md
-  - API:
-      - Plot: plot.md
-      - Runtime: runtime.md
-      - Exceptions: exceptions.md
+            show_submodules: false
 
 markdown_extensions:
   - admonition

--- a/src/caret_analyze/runtime/__init__.py
+++ b/src/caret_analyze/runtime/__init__.py
@@ -20,6 +20,7 @@ from .executor import Executor
 from .node import Node
 from .node_path import NodePath
 from .path import Path
+from .path_base import PathBase
 from .publisher import Publisher
 from .subscription import Subscription
 from .timer import Timer
@@ -36,6 +37,7 @@ __all__ = [
     'NodePath',
     'Node',
     'Path',
+    'PathBase',
     'Publisher',
     'Timer',
     'Subscription',


### PR DESCRIPTION
@hsgwa @takam5f2 
[CARET_analyzeのAPIリストをユーザ向けと開発者向けでセクション分けする](https://tier4.atlassian.net/browse/T4PB-18089) が完了したので、ご確認をお願いいたします。

修正内容は以下です。

- plot, runtime, exceptions 以外のモジュールのページを API for developer セクションに追加
- mkdocs.yaml にあるページレイアウトを .pages に移動する
- mkdocstring プラグインの show_submodule オプションを False に変更 （重複が発生するため）
- PaseBase クラスを runtime モジュールの `_all_` に追加