### PR TITLE
feat: clarify the reason for the warning in CallbackChain.verify

### DIFF
--- a/src/caret_analyze/value_objects/message_context.py
+++ b/src/caret_analyze/value_objects/message_context.py
@@ -267,7 +267,7 @@ class CallbackChain(MessageContext):
                 )
             else:
                 logger.warning(
-                    'callback-chain is empty. variable_passings are not set.'
+                    'callback-chain is empty. variable_passings are not set. '
                     f'node name: {self.node_name}')
 
         return is_valid

--- a/src/caret_analyze/value_objects/message_context.py
+++ b/src/caret_analyze/value_objects/message_context.py
@@ -52,8 +52,10 @@ class MessageContextType(ValueObject):
         return self.type_name
 
 
-MessageContextType.USE_LATEST_MESSAGE = MessageContextType('use_latest_message')
-MessageContextType.INHERIT_UNIQUE_STAMP = MessageContextType('inherit_unique_stamp')
+MessageContextType.USE_LATEST_MESSAGE = \
+        MessageContextType('use_latest_message')
+MessageContextType.INHERIT_UNIQUE_STAMP = \
+        MessageContextType('inherit_unique_stamp')
 MessageContextType.CALLBACK_CHAIN = MessageContextType('callback_chain')
 MessageContextType.TILDE = MessageContextType('tilde')
 
@@ -144,16 +146,31 @@ class MessageContext(ValueObject, Summarizable):
         child: Optional[Tuple[CallbackStructValue, ...]]
     ) -> MessageContext:
         if context_type_name == str(MessageContextType.CALLBACK_CHAIN):
-            return CallbackChain(node_name, context_dict, subscription, publisher, child)
+            return CallbackChain(node_name,
+                                 context_dict,
+                                 subscription,
+                                 publisher, child)
         if context_type_name == str(MessageContextType.INHERIT_UNIQUE_STAMP):
-            return InheritUniqueStamp(node_name, context_dict, subscription, publisher, child)
+            return InheritUniqueStamp(node_name,
+                                      context_dict,
+                                      subscription,
+                                      publisher,
+                                      child)
         if context_type_name == str(MessageContextType.USE_LATEST_MESSAGE):
-            return UseLatestMessage(node_name, context_dict, subscription, publisher, child)
+            return UseLatestMessage(node_name,
+                                    context_dict,
+                                    subscription,
+                                    publisher,
+                                    child)
         if context_type_name == str(MessageContextType.TILDE):
-            return Tilde(node_name, context_dict, subscription, publisher, child)
+            return Tilde(node_name,
+                         context_dict,
+                         subscription,
+                         publisher,
+                         child)
 
-        raise UnsupportedTypeError(
-            f'Failed to load message context. message_context={context_type_name}')
+        raise UnsupportedTypeError(f'Failed to load message context. \
+                                   message_context={context_type_name}')
 
 
 class UseLatestMessage(MessageContext):
@@ -195,9 +212,10 @@ class CallbackChain(MessageContext):
 
     Latency is calculated from callback durations in the node path.
     When a path within a node passes through multiple callbacks,
-    it is assumed that messages are passed between callbacks by a buffer of queue size 1
-    (ex. a member variable that stores a single message).
-    If the queue size is larger than 1, the node latency may be calculated to be small.
+    it is assumed that messages are passed between callbacks by a buffer of
+    queue size 1 (ex. a member variable that stores a single message).
+    If the queue size is larger than 1,
+    the node latency may be calculated to be small.
 
     """
 
@@ -209,7 +227,11 @@ class CallbackChain(MessageContext):
         publisher: Optional[PublisherStructValue],
         callbacks: Optional[Tuple[CallbackStructValue, ...]]
     ) -> None:
-        super().__init__(node_name, message_context_dict, subscription, publisher, callbacks)
+        super().__init__(node_name,
+                         message_context_dict,
+                         subscription,
+                         publisher,
+                         callbacks)
 
     @property
     def context_type(self) -> MessageContextType:
@@ -260,7 +282,11 @@ class Tilde(MessageContext):
         publisher: Optional[PublisherStructValue],
         callbacks: Optional[Tuple[CallbackStructValue, ...]]
     ) -> None:
-        super().__init__(node_name, message_context_dict, subscription, publisher, callbacks)
+        super().__init__(node_name,
+                         message_context_dict,
+                         subscription,
+                         publisher,
+                         callbacks)
 
     @property
     def context_type(self) -> MessageContextType:

--- a/src/caret_analyze/value_objects/message_context.py
+++ b/src/caret_analyze/value_objects/message_context.py
@@ -257,9 +257,18 @@ class CallbackChain(MessageContext):
         is_valid = True
         if self.callbacks is None or len(self.callbacks) == 0:
             is_valid = False
-            logger.warning(
-                'callback-chain is empty. variable_passings may be not set.'
-                f'{self.node_name}')
+
+            # Check binding between callback and publisher
+            if not self._pub.summary['callbacks']:
+                logger.warning(
+                    'callback-chain is empty. '
+                    'The callback is not associated with the publisher. '
+                    f'publisher topic name: {self.publisher_topic_name}'
+                )
+            else:
+                logger.warning(
+                    'callback-chain is empty. variable_passings are not set.'
+                    f'node name: {self.node_name}')
 
         return is_valid
 

--- a/src/test/value_objects/test_message_context.py
+++ b/src/test/value_objects/test_message_context.py
@@ -70,5 +70,5 @@ class TestCallbackChain:
         )
         caplog.clear()
         assert callback_chain.verify() is False
-        assert ('callback-chain is empty. variable_passings are not set.'
+        assert ('callback-chain is empty. variable_passings are not set. '
                 'node name:') in caplog.text

--- a/src/test/value_objects/test_message_context.py
+++ b/src/test/value_objects/test_message_context.py
@@ -1,0 +1,74 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from logging import getLogger, WARNING
+
+from caret_analyze.value_objects import (PublisherStructValue,
+                                         SubscriptionCallbackStructValue,
+                                         TimerCallbackStructValue)
+from caret_analyze.value_objects.message_context import CallbackChain
+
+
+class TestCallbackChain:
+
+    def test_verify(self, mocker, caplog):
+        sub_callback_mock = mocker.Mock(spec=SubscriptionCallbackStructValue)
+        timer_callback_mock = mocker.Mock(spec=TimerCallbackStructValue)
+        publisher_mock = mocker.Mock(spec=PublisherStructValue)
+
+        mocker.patch.object(timer_callback_mock, 'callback_name',
+                            '/node_name/callback_0')
+        mocker.patch.object(publisher_mock, 'topic_name',
+                            'publisher_topic_name')
+
+        caplog.set_level(WARNING)
+        logger = getLogger('caret_analyze.value_objects.message_context')
+        logger.addHandler(caplog.handler)
+
+        # True case
+        callback_chain = CallbackChain(
+            '/node_name', {}, None, publisher_mock,
+            (sub_callback_mock, timer_callback_mock)
+        )
+        caplog.clear()
+        assert callback_chain.verify() is True
+        assert len(caplog.record_tuples) == 0
+
+        # No association between callback and publisher
+        callback_chain = CallbackChain(
+            '/node_name', {}, None, publisher_mock, None
+        )
+        mocker.patch.object(
+            publisher_mock, 'summary',
+            {'topic_name': 'publisher_topic_name', 'callbacks': ()}
+        )
+        caplog.clear()
+        assert callback_chain.verify() is False
+        assert ('callback-chain is empty. '
+                'The callback is not associated with the publisher. '
+                'publisher topic name:') in caplog.text
+
+        # No setting variable_passing
+        callback_chain = CallbackChain(
+            '/node_name', {}, None, publisher_mock, None
+        )
+        mocker.patch.object(
+            publisher_mock, 'summary',
+            {'topic_name': 'publisher_topic_name',
+             'callbacks': ('/node_name/callback_0',)}
+        )
+        caplog.clear()
+        assert callback_chain.verify() is False
+        assert ('callback-chain is empty. variable_passings are not set.'
+                'node name:') in caplog.text


### PR DESCRIPTION
@hsgwa 
[Path.verify() 関数の実装見直し・修正](https://tier4.atlassian.net/browse/T4PB-17110) の作業が完了したので、ご確認をお願いいたします。

既存の path.verify 関数で、以下２つの検知はできていたため、原因を細分化して警告メッセージを出すように変更しました。
- ノードのコールバックと Publish するトピックの紐づけが出来ていない
- Variable_passings が指定されてない

以下は、「[message_context に 'callback_chain' を使用 ∧ コールバックとpublisher の紐づけができていないアーキテクチャファイル](https://drive.google.com/file/d/1OkSAc9prn3IfnCxV1K2XCKE0jsXZELeu/view?usp=sharing)」に対する警告文です。

> WARNING : 2022-06-28 11:04:15 | callback-chain is empty. The callback is not associated with the publisher. publisher topic name: /topic4