### PR TITLE
fix(records_cpp): invalid argument error

### DIFF
--- a/src/caret_analyze/record/record_cpp_impl.py
+++ b/src/caret_analyze/record/record_cpp_impl.py
@@ -51,7 +51,7 @@ class RecordsCppImpl(RecordsInterface):
         self,
         other: RecordInterface
     ) -> None:
-        unknown_columns = set(other.columns) ^ set(self.columns)
+        unknown_columns = set(other.columns) - set(self.columns)
         if len(unknown_columns) > 0:
             msg = 'Contains an unknown columns. '
             msg += f'{unknown_columns}'

--- a/src/test/record/test_record.py
+++ b/src/test/record/test_record.py
@@ -246,6 +246,7 @@ class TestRecords:
             [
                 Record({'value': 0, 'stamp': 1}),
                 Record({'value': 2, 'stamp': 4}),
+                Record({'value': 3}),
             ],
             ['value', 'stamp']
         )
@@ -257,6 +258,7 @@ class TestRecords:
             records = records_type(None, ['value', 'stamp'])
             records.append(expects.data[0])
             records.append(expects.data[1])
+            records.append(expects.data[2])
             assert records.equals(expects)
             assert records.columns == expects.columns
 


### PR DESCRIPTION
Signed-off-by: hsgwa <hasegawa.isp@gmail.com>

This PR fix the following error
```
from caret_analyze.record.record_cpp_impl import RecordCppImpl, RecordsCppImpl
records =RecordsCppImpl(None, ['column'])
record = RecordCppImpl()
records.append(record)
```
```
---------------------------------------------------------------------------
InvalidArgumentError                      Traceback (most recent call last)
Input In [4], in <cell line: 1>()
----> 1 records.append(record)

File ~/ros2_caret_ws/build/caret_analyze/caret_analyze/record/record_cpp_impl.py:58, in RecordsCppImpl.append(self, other)
     56     msg = 'Contains an unknown columns. '
     57     msg += f'{unknown_columns}'
---> 58     raise InvalidArgumentError(msg)
     60 self._records.append(other)

InvalidArgumentError: Contains an unknown columns. {'column'}
```

Expect: 
No error occurs.

corresponding table is shown below.

|column|

↓append

|column|
|None|