### PR TITLE
test(records_cpp): enable ModuleNotFoundError in local environment

### DIFF
--- a/src/test/record/test_record.py
+++ b/src/test/record/test_record.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from copy import deepcopy
+import os
 from typing import Any, Optional
 
 from caret_analyze.exceptions import InvalidArgumentError
@@ -31,10 +32,14 @@ try:
     RecordCppImpl = cpp_impl.RecordCppImpl
     RecordsCppImpl = cpp_impl.RecordsCppImpl
     CppImplEnabled = True
-except ModuleNotFoundError:
-    RecordCppImpl = None
-    RecordsCppImpl = None
-    CppImplEnabled = False
+except ModuleNotFoundError as e:
+    if 'GITHUB_ACTION' in os.environ:
+        # skip cpp_impl tests
+        RecordCppImpl = None
+        RecordsCppImpl = None
+        CppImplEnabled = False
+    else:
+        raise(e)
 
 
 def to_cpp_record(record: RecordInterface) -> Optional[RecordCppImpl]:

--- a/src/test/record/test_record.py
+++ b/src/test/record/test_record.py
@@ -35,11 +35,14 @@ try:
 except ModuleNotFoundError as e:
     if 'GITHUB_ACTION' in os.environ:
         # skip cpp_impl tests
+        # Because CARET_analyze does not use CARET_analyze_cpp_Impl on GithubAction.
         RecordCppImpl = None
         RecordsCppImpl = None
         CppImplEnabled = False
     else:
-        raise(e)
+        raise ModuleNotFoundError(
+            'Failed to load RecordsCppImpl, ',
+            'possibly due to missing information in the PYTHONPATH environment variable.') from e
 
 
 def to_cpp_record(record: RecordInterface) -> Optional[RecordCppImpl]:


### PR DESCRIPTION
Signed-off-by: hsgwa <hasegawa.isp@gmail.com>

This PR changes test scope.

In github action, records_cpp-related tests are skipped.
In local, test raises ModuleNotFoundError.