### PR TITLE
refactor(records): support multiple argument dispatching to append

### DIFF
--- a/src/caret_analyze/record/interface.py
+++ b/src/caret_analyze/record/interface.py
@@ -17,7 +17,11 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import Callable, Dict, Iterator, List, Optional, Sequence, Set, Tuple
 
+from multimethod import multimethod as singledispatchmethod
 import pandas as pd
+from record_cpp_impl import RecordBase
+
+from ..exceptions import InvalidArgumentError
 
 
 class RecordInterface:
@@ -201,8 +205,37 @@ class RecordsInterface:
         """
         pass
 
+    @singledispatchmethod
+    def append(self, arg):
+        raise InvalidArgumentError(f'Unknown argument type: {arg}')
+
+    @append.register
+    def __append_record(self, other: RecordInterface) -> None:
+        self._append_record(other)
+
+    @append.register
+    def __append_record_base(self, other: RecordBase) -> None:
+        self._append_record(other)  # type: ignore
+
     @abstractmethod
-    def append(self, other: RecordInterface) -> None:
+    def _append_record(self, other: RecordInterface) -> None:
+        """
+        Append new record.
+
+        Parameters
+        ----------
+        other : RecordInterface
+            record to be added.
+
+        """
+        pass
+
+    @append.register
+    def __append_dict(self, other: Dict[str, int]) -> None:
+        self._append_dict(other)
+
+    @abstractmethod
+    def _append_dict(self, other: Dict[str, int]) -> None:
         """
         Append new record.
 

--- a/src/caret_analyze/record/interface.py
+++ b/src/caret_analyze/record/interface.py
@@ -53,7 +53,7 @@ class RecordInterface:
     @abstractmethod
     def merge(self, other: RecordInterface) -> None:
         """
-        Mege record.
+        Merge record.
 
         Parameters
         ----------
@@ -169,7 +169,7 @@ class RecordInterface:
     @abstractmethod
     def columns(self) -> Set[str]:
         """
-        Get columnnames.
+        Get column names.
 
         Returns
         -------
@@ -307,7 +307,7 @@ class RecordsInterface:
         self, f: Callable[[RecordInterface], bool]
     ) -> None:
         """
-        Get filterd records.
+        Get filtered records.
 
         Parameters
         ----------
@@ -327,7 +327,7 @@ class RecordsInterface:
 
         Returns
         -------
-        Seque[RecordInterface]
+        Sequence[RecordInterface]
             Records list.
 
         """
@@ -392,7 +392,7 @@ class RecordsInterface:
     @abstractmethod
     def columns(self) -> List[str]:
         """
-        Get columnnames.
+        Get column names.
 
         Returns
         -------

--- a/src/caret_analyze/record/interface.py
+++ b/src/caret_analyze/record/interface.py
@@ -19,7 +19,6 @@ from typing import Callable, Dict, Iterator, List, Optional, Sequence, Set, Tupl
 
 from multimethod import multimethod as singledispatchmethod
 import pandas as pd
-from record_cpp_impl import RecordBase
 
 from ..exceptions import InvalidArgumentError
 
@@ -178,6 +177,18 @@ class RecordInterface:
 
         """
         pass
+
+
+try:
+    from record_cpp_impl import RecordBase
+    # RecordBase in C++ implementation cannot inherit RecordInterface,
+    # so RecordBase case should be written separately.
+except ModuleNotFoundError as e:
+    import os
+    if 'GITHUB_ACTION' in os.environ:
+        RecordBase = RecordInterface
+    else:
+        raise e
 
 
 class RecordsInterface:

--- a/src/caret_analyze/record/record.py
+++ b/src/caret_analyze/record/record.py
@@ -183,7 +183,11 @@ class Records(RecordsInterface):
     def data(self) -> List[RecordInterface]:
         return self._data
 
-    def append(self, other: RecordInterface):
+    def _append_dict(self, other: Dict[str, int]):
+        record = Record(other)
+        self._append_record(record)
+
+    def _append_record(self, other: RecordInterface):
         self._data.append(other)
         unknown_columns = set(other.columns) - set(self.columns)
         if len(unknown_columns) > 0:

--- a/src/caret_analyze/record/record_cpp_impl.py
+++ b/src/caret_analyze/record/record_cpp_impl.py
@@ -47,7 +47,14 @@ class RecordsCppImpl(RecordsInterface):
             f.write(s)
         return None
 
-    def append(
+    def _append_dict(
+        self,
+        other: Dict[str, int]
+    ) -> None:
+        record = RecordBase(other)
+        self._records.append(record)
+
+    def _append_record(
         self,
         other: RecordInterface
     ) -> None:

--- a/src/package.xml
+++ b/src/package.xml
@@ -7,6 +7,7 @@
   <maintainer email="hasegawa@isp.co.jp">hsgwa</maintainer>
   <license>Apache License 2.0</license>
 
+  <depend>python3-multimethod-pip</depend>
   <exec_depend>tracetools_analysis</exec_depend>
   <exec_depend>python3-tqdm</exec_depend>
   <exec_depend>python3-yaml</exec_depend>

--- a/src/test/record/test_record.py
+++ b/src/test/record/test_record.py
@@ -270,6 +270,14 @@ class TestRecords:
             assert records.equals(expects)
             assert records.columns == expects.columns
 
+            # tests for multimethod
+            records = records_type(None, ['value', 'stamp'])
+            records.append(expects.data[0].data)
+            records.append(expects.data[1].data)
+            records.append(expects.data[2].data)
+            assert records.equals(expects)
+            assert records.columns == expects.columns
+
     def test_drop_columns(self):
         key = 'stamp'
         value = 'value'


### PR DESCRIPTION
This PR enables multi argument dispaching such as:
```
records = Records()
records.append(Record({'key': 1})) # conventional
records.append({'key': 1}) # new
```

This patch includes additional third-party package [multimethod].
rosdep installation supports multimethod installation though, users may need to run "rosdep update".

