### PR TITLE
perf(lttng): improve memory consumption

### DIFF
--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 from __future__ import annotations
-from functools import cached_property
 
-import os
 from abc import ABCMeta, abstractmethod, abstractproperty
 from datetime import datetime
 from logging import getLogger
-from typing import Any, Dict, List, Optional, Sequence, Sized, Tuple, Union, Iterable, Iterator
+import os
 import pickle
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Sized, Tuple, Union
 
 import bt2
 import pandas as pd
@@ -229,9 +228,9 @@ class CtfEventCollection(IterableEvents):
             # Check for traces lost
             elif(type(msg) is bt2._DiscardedEventsMessageConst):
                 msg = ('Tracer discarded '
-                        f'{msg.count} events between '
-                        f'{msg.beginning_default_clock_snapshot.ns_from_origin} and '
-                        f'{msg.end_default_clock_snapshot.ns_from_origin}.')
+                       f'{msg.count} events between '
+                       f'{msg.beginning_default_clock_snapshot.ns_from_origin} and '
+                       f'{msg.end_default_clock_snapshot.ns_from_origin}.')
                 logger.warning(msg)
 
         self._size = event_count

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -153,11 +153,11 @@ class EventDurationFilter(LttngEventFilter):
 
 class EventCollection(Iterable, Sized):
 
-    def __init__(self, trace_dir: str) -> None:
+    def __init__(self, trace_dir: str, force_conversion: bool) -> None:
         self._iterable_events: IterableEvents
         cache_path = self._cache_path(trace_dir)
 
-        if os.path.exists(cache_path):
+        if os.path.exists(cache_path) and not force_conversion:
             logger.info('Found converted file.')
             self._iterable_events = PickleEventCollection(cache_path)
         else:
@@ -292,6 +292,7 @@ class Lttng(InfraBase):
     def __init__(
         self,
         trace_dir_or_events: Union[str, Dict],
+        force_conversion: bool = False,
         *,
         event_filters: Optional[List[LttngEventFilter]] = None,
         store_events: bool = False,
@@ -303,6 +304,7 @@ class Lttng(InfraBase):
 
         data, events = self._parse_lttng_data(
             trace_dir_or_events,
+            force_conversion,
             event_filters or [],
             store_events
         )
@@ -315,6 +317,7 @@ class Lttng(InfraBase):
     @staticmethod
     def _parse_lttng_data(
         trace_dir_or_events: Union[str, Dict],
+        force_conversion: bool,
         event_filters: List[LttngEventFilter],
         store_events: bool
     ) -> Tuple[Any, Dict]:
@@ -325,7 +328,7 @@ class Lttng(InfraBase):
 
         if isinstance(trace_dir_or_events, str):
             Lttng._last_trace_begin_time = None
-            event_collection = EventCollection(trace_dir_or_events)
+            event_collection = EventCollection(trace_dir_or_events, force_conversion)
             print('{} events found.'.format(len(event_collection)))
 
             common = LttngEventFilter.Common()

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -357,6 +357,8 @@ class Lttng(InfraBase):
             if len(event_filters) > 0:
                 print('filtered to {} events.'.format(filtered_event_count))
         else:
+            # Note: giving events as arguments is used only for debugging.
+            filtered_event_count = 0
             events = trace_dir_or_events
             for event in events:
                 if len(event_filters) > 0 and \
@@ -365,8 +367,13 @@ class Lttng(InfraBase):
                 if store_events:
                     events.append(event)
                 filtered_event_count += 1
-                handler_ = handler.handler_map[msg.event.name]
+                event_name = event[LttngEventFilter.NAME]
+                handler_ = handler.handler_map[event_name]
                 handler_(event)
+            data.finalize()
+            Lttng._last_filters = event_filters
+            if len(event_filters) > 0:
+                print('filtered to {} events.'.format(filtered_event_count))
 
         events_ = None if len(events) == 0 else events
         return data, events_

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model.py
@@ -18,11 +18,8 @@
 from caret_analyze.record.record_factory import RecordFactory, RecordsFactory
 import pandas as pd
 
-from tracetools_analysis.data_model import (DataModel,
-                                            DataModelIntermediateStorage)
 
-
-class Ros2DataModel(DataModel):
+class Ros2DataModel():
     """
     Container to model pre-processed ROS 2 data for analysis.
 
@@ -31,37 +28,36 @@ class Ros2DataModel(DataModel):
 
     def __init__(self) -> None:
         """Create a Ros2DataModel."""
-        super().__init__()
         # Objects (one-time events, usually when something is created)
-        self._contexts: DataModelIntermediateStorage = []
-        self._nodes: DataModelIntermediateStorage = []
-        self._publishers: DataModelIntermediateStorage = []
-        self._subscriptions: DataModelIntermediateStorage = []
-        self._subscription_objects: DataModelIntermediateStorage = []
-        self._services: DataModelIntermediateStorage = []
-        self._clients: DataModelIntermediateStorage = []
-        self._timers: DataModelIntermediateStorage = []
-        self._timer_node_links: DataModelIntermediateStorage = []
-        self._callback_objects: DataModelIntermediateStorage = []
-        self._callback_symbols: DataModelIntermediateStorage = []
-        self._lifecycle_state_machines: DataModelIntermediateStorage = []
-        self._executors: DataModelIntermediateStorage = []
-        self._executors_static: DataModelIntermediateStorage = []
-        self._callback_groups: DataModelIntermediateStorage = []
-        self._callback_groups_static: DataModelIntermediateStorage = []
-        self._callback_group_timer: DataModelIntermediateStorage = []
-        self._callback_group_subscription: DataModelIntermediateStorage = []
-        self._callback_group_service: DataModelIntermediateStorage = []
-        self._callback_group_client: DataModelIntermediateStorage = []
-        self._rmw_impl: DataModelIntermediateStorage = []
+        self._contexts = []
+        self._nodes = []
+        self._publishers = []
+        self._subscriptions = []
+        self._subscription_objects = []
+        self._services = []
+        self._clients = []
+        self._timers = []
+        self._timer_node_links = []
+        self._callback_objects = []
+        self._callback_symbols = []
+        self._lifecycle_state_machines = []
+        self._executors = []
+        self._executors_static = []
+        self._callback_groups = []
+        self._callback_groups_static = []
+        self._callback_group_timer = []
+        self._callback_group_subscription = []
+        self._callback_group_service = []
+        self._callback_group_client = []
+        self._rmw_impl = []
 
-        self._tilde_subscriptions: DataModelIntermediateStorage = []
-        self._tilde_publishers: DataModelIntermediateStorage = []
-        self._tilde_subscribe_added: DataModelIntermediateStorage = []
+        self._tilde_subscriptions = []
+        self._tilde_publishers = []
+        self._tilde_subscribe_added = []
 
         # Events (multiple instances, may not have a meaningful index)
         # string argument
-        self._lifecycle_transitions: DataModelIntermediateStorage = []
+        self._lifecycle_transitions = []
 
         # Events (multiple instances, may not have a meaningful index)
         self.callback_start_instances = RecordsFactory.create_instance(
@@ -630,7 +626,7 @@ class Ros2DataModel(DataModel):
         }
         self._callback_group_client.append(record)
 
-    def _finalize(self) -> None:
+    def finalize(self) -> None:
         self.contexts = pd.DataFrame.from_dict(self._contexts)
         if self._contexts:
             self.contexts.set_index('context_handle', inplace=True, drop=True)

--- a/src/caret_analyze/infra/lttng/ros2_tracing/processor.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/processor.py
@@ -24,9 +24,9 @@ from .data_model import Ros2DataModel
 
 def get_field(event, key):
     e = event[key]
-    if type(e) is bt2._StringFieldConst:
+    if isinstance(e, bt2._StringFieldConst):
         return str(e)
-    if type(e) is bt2._UnsignedIntegerFieldConst:
+    if isinstance(e, bt2._IntegerFieldConst):
         return int(e)
     return e
 

--- a/src/test/infra/lttng/test_architecture_reader_lttng.py
+++ b/src/test/infra/lttng/test_architecture_reader_lttng.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Research Institute of Systems Planning, Inc.
+# Copyright 2021 esearch Institute of Systems Planning, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/infra/lttng/test_architecture_reader_lttng.py
+++ b/src/test/infra/lttng/test_architecture_reader_lttng.py
@@ -1,4 +1,4 @@
-# Copyright 2021 esearch Institute of Systems Planning, Inc.
+# Copyright 2021 Research Institute of Systems Planning, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/infra/lttng/test_lttng.py
+++ b/src/test/infra/lttng/test_lttng.py
@@ -17,7 +17,7 @@ from caret_analyze.infra.lttng import Lttng
 from caret_analyze.infra.lttng.event_counter import EventCounter
 from caret_analyze.infra.lttng.lttng_info import LttngInfo
 from caret_analyze.infra.lttng.records_source import RecordsSource
-from caret_analyze.infra.lttng.ros2_tracing.data_model import DataModel, Ros2DataModel
+from caret_analyze.infra.lttng.ros2_tracing.data_model import Ros2DataModel
 from caret_analyze.infra.lttng.value_objects import (PublisherValueLttng,
                                                      SubscriptionCallbackValueLttng,
                                                      TimerCallbackValueLttng)
@@ -29,7 +29,7 @@ from caret_analyze.value_objects.node import NodeValue
 class TestLttng:
 
     def test_get_nodes(self, mocker):
-        data_mock = mocker.Mock(spec=DataModel)
+        data_mock = mocker.Mock(spec=Ros2DataModel)
         mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
@@ -51,7 +51,7 @@ class TestLttng:
         assert nodes == [node]
 
     def test_get_rmw_implementation(self, mocker):
-        data_mock = mocker.Mock(spec=DataModel)
+        data_mock = mocker.Mock(spec=Ros2DataModel)
         mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
@@ -71,7 +71,7 @@ class TestLttng:
         assert lttng.get_rmw_impl() == 'rmw'
 
     def test_get_publishers(self, mocker):
-        data_mock = mocker.Mock(spec=DataModel)
+        data_mock = mocker.Mock(spec=Ros2DataModel)
         mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
@@ -91,7 +91,7 @@ class TestLttng:
         assert lttng.get_publishers(NodeValue('node', None)) == [pub_mock]
 
     def test_get_timer_callbacks(self, mocker):
-        data_mock = mocker.Mock(spec=DataModel)
+        data_mock = mocker.Mock(spec=Ros2DataModel)
         mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
@@ -111,7 +111,7 @@ class TestLttng:
         assert lttng.get_timer_callbacks(NodeValue('node', None)) == [timer_cb_mock]
 
     def test_get_subscription_callbacks(self, mocker):
-        data_mock = mocker.Mock(spec=DataModel)
+        data_mock = mocker.Mock(spec=Ros2DataModel)
         mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
@@ -132,7 +132,7 @@ class TestLttng:
         assert lttng.get_subscription_callbacks(NodeValue('node', None)) == [sub_cb_mock]
 
     def test_get_executors(self, mocker):
-        data_mock = mocker.Mock(spec=DataModel)
+        data_mock = mocker.Mock(spec=Ros2DataModel)
         mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
@@ -153,7 +153,7 @@ class TestLttng:
         assert lttng.get_executors() == [exec_info_mock]
 
     def test_compose_inter_proc_comm_records(self, mocker):
-        data_mock = mocker.Mock(spec=DataModel)
+        data_mock = mocker.Mock(spec=Ros2DataModel)
         mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
@@ -176,7 +176,7 @@ class TestLttng:
         assert lttng.compose_inter_proc_comm_records() == records_mock
 
     def test_compose_intra_proc_comm_records(self, mocker):
-        data_mock = mocker.Mock(spec=DataModel)
+        data_mock = mocker.Mock(spec=Ros2DataModel)
         mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
@@ -199,7 +199,7 @@ class TestLttng:
         assert lttng.compose_intra_proc_comm_records() == records_mock
 
     def test_compose_callback_records(self, mocker):
-        data_mock = mocker.Mock(spec=DataModel)
+        data_mock = mocker.Mock(spec=Ros2DataModel)
         mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)

--- a/src/test/infra/lttng/test_lttng.py
+++ b/src/test/infra/lttng/test_lttng.py
@@ -43,7 +43,7 @@ class TestLttng:
         mocker.patch('caret_analyze.infra.lttng.event_counter.EventCounter',
                      return_value=counter_mock)
 
-        lttng = Lttng('trace_dir', force_conversion=False)
+        lttng = Lttng('trace_dir')
 
         node = NodeValue('/node', None)
         mocker.patch.object(lttng_info_mock, 'get_nodes', return_value=[node])
@@ -65,7 +65,7 @@ class TestLttng:
         mocker.patch('caret_analyze.infra.lttng.event_counter.EventCounter',
                      return_value=counter_mock)
 
-        lttng = Lttng('trace_dir', force_conversion=False)
+        lttng = Lttng('trace_dir')
 
         mocker.patch.object(lttng_info_mock, 'get_rmw_impl', return_value='rmw')
         assert lttng.get_rmw_impl() == 'rmw'
@@ -84,7 +84,7 @@ class TestLttng:
         mocker.patch('caret_analyze.infra.lttng.event_counter.EventCounter',
                      return_value=counter_mock)
 
-        lttng = Lttng('trace_dir', force_conversion=False)
+        lttng = Lttng('trace_dir')
 
         pub_mock = mocker.Mock(spec=PublisherValueLttng)
         mocker.patch.object(lttng_info_mock, 'get_publishers', return_value=[pub_mock])
@@ -103,7 +103,7 @@ class TestLttng:
         counter_mock = mocker.Mock(spec=EventCounter)
         mocker.patch('caret_analyze.infra.lttng.event_counter.EventCounter',
                      return_value=counter_mock)
-        lttng = Lttng('trace_dir', force_conversion=False)
+        lttng = Lttng('trace_dir')
 
         timer_cb_mock = mocker.Mock(spec=TimerCallbackValueLttng)
         mocker.patch.object(lttng_info_mock, 'get_timer_callbacks',
@@ -124,7 +124,7 @@ class TestLttng:
         mocker.patch('caret_analyze.infra.lttng.event_counter.EventCounter',
                      return_value=counter_mock)
 
-        lttng = Lttng('trace_dir', force_conversion=False)
+        lttng = Lttng('trace_dir')
 
         sub_cb_mock = mocker.Mock(spec=SubscriptionCallbackValueLttng)
         mocker.patch.object(lttng_info_mock, 'get_subscription_callbacks',
@@ -145,7 +145,7 @@ class TestLttng:
         mocker.patch('caret_analyze.infra.lttng.event_counter.EventCounter',
                      return_value=counter_mock)
 
-        lttng = Lttng('trace_dir', force_conversion=False)
+        lttng = Lttng('trace_dir')
 
         exec_info_mock = mocker.Mock(spec=ExecutorValue)
         mocker.patch.object(lttng_info_mock, 'get_executors',
@@ -167,7 +167,7 @@ class TestLttng:
         mocker.patch('caret_analyze.infra.lttng.records_source.RecordsSource',
                      return_value=records_source_mock)
 
-        lttng = Lttng('trace_dir', force_conversion=False)
+        lttng = Lttng('trace_dir')
 
         records_mock = mocker.Mock(spec=RecordsInterface)
         mocker.patch.object(records_mock, 'clone', return_value=records_mock)
@@ -190,7 +190,7 @@ class TestLttng:
         mocker.patch('caret_analyze.infra.lttng.event_counter.EventCounter',
                      return_value=counter_mock)
 
-        lttng = Lttng('trace_dir', force_conversion=False)
+        lttng = Lttng('trace_dir')
 
         records_mock = mocker.Mock(spec=RecordsInterface)
         mocker.patch.object(records_mock, 'clone', return_value=records_mock)
@@ -213,7 +213,7 @@ class TestLttng:
         mocker.patch('caret_analyze.infra.lttng.event_counter.EventCounter',
                      return_value=counter_mock)
 
-        lttng = Lttng('trace_dir', force_conversion=False)
+        lttng = Lttng('trace_dir')
 
         records_mock = mocker.Mock(spec=RecordsInterface)
         mocker.patch.object(records_mock, 'clone', return_value=records_mock)


### PR DESCRIPTION
Signed-off-by: hsgwa <hasegawa.isp@gmail.com>

This PR improves processing time and memory usage for Lttng class.

For now, I removed ros2_tracing classes.
memory usage was improved, but processing time was worse than with cache.


[Without event filter]

Before (without cache)
15.8s, 333MB

Before (with cache)
 6.3s, 335MB

After
18.5s, 102MB

[With event filter]
Before (without cache)
13.2s, 274MB

Before(with cache)
3.84s, 245MB

After
13.9 s, 23MB
