### PR TITLE
chore: rename 'jitter' to 'period' in Plot

### DIFF
--- a/src/caret_analyze/plot/__init__.py
+++ b/src/caret_analyze/plot/__init__.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 from .bokeh.callback_info import (CallbackFrequencyPlot,
-                                  CallbackPeriodPlot,
-                                  CallbackLatencyPlot)
+                                  CallbackLatencyPlot,
+                                  CallbackPeriodPlot)
 from .bokeh.callback_info_factory import Plot
 from .bokeh.callback_info_interface import TimeSeriesPlot
 from .bokeh.callback_sched import callback_sched

--- a/src/caret_analyze/plot/__init__.py
+++ b/src/caret_analyze/plot/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .bokeh.callback_info import (CallbackFrequencyPlot,
-                                  CallbackJitterPlot,
+                                  CallbackPeriodPlot,
                                   CallbackLatencyPlot)
 from .bokeh.callback_info_factory import Plot
 from .bokeh.callback_info_interface import TimeSeriesPlot
@@ -26,7 +26,7 @@ from .graphviz.node_graph import node_graph
 __all__ = [
     'Plot',
     'CallbackLatencyPlot',
-    'CallbackJitterPlot',
+    'CallbackPeriodPlot',
     'CallbackFrequencyPlot',
     'TimeSeriesPlot',
     'callback_graph',

--- a/src/caret_analyze/plot/bokeh/callback_info.py
+++ b/src/caret_analyze/plot/bokeh/callback_info.py
@@ -58,11 +58,11 @@ class CallbackLatencyPlot(TimeSeriesPlot):
         return latency_df
 
 
-class CallbackJitterPlot(TimeSeriesPlot):
+class CallbackPeriodPlot(TimeSeriesPlot):
     """
-    Class that provides API for callback jitter.
+    Class that provides API for callback period.
 
-    This class provides the API to visualize the jitter per unit of time
+    This class provides the API to visualize the period per unit of time
     for each callback and to obtain it in the pandas DataFrame format.
     """
 
@@ -81,18 +81,18 @@ class CallbackJitterPlot(TimeSeriesPlot):
         if(xaxis_type == 'sim_time'):
             self._df_convert_to_sim_time(latency_table)
 
-        jitter_df = pd.DataFrame(columns=pd.MultiIndex.from_product([
+        period_df = pd.DataFrame(columns=pd.MultiIndex.from_product([
                 latency_table.columns,
                 ['callback_start_timestamp [ns]', 'period [ms]']]))
         for cb_name in latency_table.columns:
-            jitter_df[(cb_name, 'callback_start_timestamp [ns]')] = \
+            period_df[(cb_name, 'callback_start_timestamp [ns]')] = \
                     latency_table[cb_name]
-            jitter_df[(cb_name,
+            period_df[(cb_name,
                        'period [ms]')] = latency_table[cb_name].diff()*10**(-6)
-        jitter_df = jitter_df.drop(jitter_df.index[0])
-        jitter_df = jitter_df.reset_index(drop=True)
+        period_df = period_df.drop(period_df.index[0])
+        period_df = period_df.reset_index(drop=True)
 
-        return jitter_df
+        return period_df
 
 
 class CallbackFrequencyPlot(TimeSeriesPlot):

--- a/src/caret_analyze/plot/bokeh/callback_info_factory.py
+++ b/src/caret_analyze/plot/bokeh/callback_info_factory.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from logging import getLogger
 from typing import List, Union
 
 from .callback_info import (CallbackFrequencyPlot,
@@ -23,6 +24,8 @@ from ...runtime import Application, CallbackBase, CallbackGroup, Executor, Node
 
 CallbacksType = Union[Application, Executor,
                       Node, CallbackGroup, List[CallbackBase]]
+
+logger = getLogger(__name__)
 
 
 class Plot:
@@ -50,6 +53,14 @@ class Plot:
 
         """
         return CallbackFrequencyPlot(callbacks)
+
+    @staticmethod
+    def create_callback_jitter_plot(
+        callbacks: CallbacksType
+    ) -> TimeSeriesPlot:
+        logger.warning('create_callback_jitter_plot is deprecated.'
+                       'Use create_callback_period_plot')
+        return Plot.create_callback_period_plot(callbacks)
 
     @staticmethod
     def create_callback_period_plot(

--- a/src/caret_analyze/plot/bokeh/callback_info_factory.py
+++ b/src/caret_analyze/plot/bokeh/callback_info_factory.py
@@ -15,7 +15,7 @@
 from typing import List, Union
 
 from .callback_info import (CallbackFrequencyPlot,
-                            CallbackJitterPlot,
+                            CallbackPeriodPlot,
                             CallbackLatencyPlot)
 from .callback_info_interface import TimeSeriesPlot
 from ...runtime import Application, CallbackBase, CallbackGroup, Executor, Node
@@ -52,11 +52,11 @@ class Plot:
         return CallbackFrequencyPlot(callbacks)
 
     @staticmethod
-    def create_callback_jitter_plot(
+    def create_callback_period_plot(
         callbacks: CallbacksType
     ) -> TimeSeriesPlot:
         """
-        Get CallbackJitterPlot instance.
+        Get CallbackPeriodPlot instance.
 
         Parameters
         ----------
@@ -70,10 +70,10 @@ class Plot:
 
         Returns
         -------
-        CallbackJitterPlot
+        CallbackPeriodPlot
 
         """
-        return CallbackJitterPlot(callbacks)
+        return CallbackPeriodPlot(callbacks)
 
     @staticmethod
     def create_callback_latency_plot(

--- a/src/caret_analyze/plot/bokeh/callback_info_factory.py
+++ b/src/caret_analyze/plot/bokeh/callback_info_factory.py
@@ -15,8 +15,8 @@
 from typing import List, Union
 
 from .callback_info import (CallbackFrequencyPlot,
-                            CallbackPeriodPlot,
-                            CallbackLatencyPlot)
+                            CallbackLatencyPlot,
+                            CallbackPeriodPlot)
 from .callback_info_interface import TimeSeriesPlot
 from ...runtime import Application, CallbackBase, CallbackGroup, Executor, Node
 


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

[CARET_analyze で jitter としてしまった箇所を period に統一する](https://tier4.atlassian.net/browse/T4PB-19289) の作業が完了したので、ご確認をお願いいたします。
作業としては、機械的に jitter を period にリネームしただけです。

テストコードを添付させていただきます。
- [Yano環境の出力結果](https://drive.google.com/file/d/1CpPPN9zb2llZGi9aE4omely4Wp4-MAVS/view?usp=sharing)
- [テストコード(ipynb)](https://drive.google.com/file/d/1SrlN7QVh6dICg4v0IQ9wBYGMUXPw8stx/view?usp=sharing)
- [使用したアーキテクチャファイル](https://drive.google.com/file/d/1dRInIE2HquYziQ-qLakVL3_nAyrUMeh5/view?usp=sharing)
- [使用したトレースデータ](https://drive.google.com/file/d/1hALgv-iwjy54nJ_M_W3f0Kgkvc0OlEEx/view?usp=sharing)