### PR TITLE
perf(response_time): improve ResponseMap creation time

### DIFF
--- a/src/caret_analyze/record/response_time.py
+++ b/src/caret_analyze/record/response_time.py
@@ -19,7 +19,7 @@ from typing import Iterator, Optional, Sequence, Tuple
 import numpy as np
 
 from .column import ColumnValue
-from .interface import RecordInterface, RecordsInterface
+from .interface import RecordsInterface
 from .record_factory import RecordFactory, RecordsFactory
 from ..exceptions import InvalidRecordsError
 
@@ -111,9 +111,7 @@ class ResponseMap():
 
         input_min_time = None
 
-        for i in range(len(records)):
-            data: RecordInterface = records.data[i]
-
+        for data in records.data:
             if input_column not in data.columns or output_column not in data.columns:
                 continue
 


### PR DESCRIPTION
Signed-off-by: takeshi.iwanari <takeshi.iwanari@tier4.jp>

## Why this change is needed
- It takes very long time to create a `ResponseTime` object with the current implementation
- Related link (TIER IV internal) : https://tier4.atlassian.net/browse/T4PB-20037

## What is changed
- Call `records.data` at the outside of loop
- Result for sample trace data (15 min Autoware trace)
    - before this change: 70 minutes
    - after this change: 1 second