### PR TITLE
fix(lttng): unsupported operand type error with cache.

### DIFF
--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -284,8 +284,6 @@ class Lttng(InfraBase):
 
     """
 
-    _last_load_dir: Optional[str] = None
-    _last_filters: Optional[List[LttngEventFilter]] = None
     _last_trace_begin_time: Optional[int] = None
     _last_trace_end_time: Optional[int] = None
 
@@ -354,8 +352,6 @@ class Lttng(InfraBase):
                 handler_(event)
 
             data.finalize()
-            Lttng._last_load_dir = trace_dir_or_events
-            Lttng._last_filters = event_filters
             if len(event_filters) > 0:
                 print('filtered to {} events.'.format(filtered_event_count))
         else:
@@ -373,7 +369,6 @@ class Lttng(InfraBase):
                 handler_ = handler.handler_map[event_name]
                 handler_(event)
             data.finalize()
-            Lttng._last_filters = event_filters
             if len(event_filters) > 0:
                 print('filtered to {} events.'.format(filtered_event_count))
 

--- a/src/test/infra/lttng/test_latency_definitions.py
+++ b/src/test/infra/lttng/test_latency_definitions.py
@@ -65,7 +65,7 @@ def create_lttng(
 ):
     def _lttng(data: Ros2DataModel):
         mocker.patch.object(Lttng, '_parse_lttng_data',
-                            return_value=(data, None))
+                            return_value=(data, None, 0, 1))
         lttng = Lttng('', validate=False)
         # mocker.patch.object(lttng, '_bridge',  bridge_mock)
         return lttng

--- a/src/test/infra/lttng/test_lttng.py
+++ b/src/test/infra/lttng/test_lttng.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+from datetime import datetime
+
 from caret_analyze.infra.lttng import Lttng
 from caret_analyze.infra.lttng.event_counter import EventCounter
 from caret_analyze.infra.lttng.lttng_info import LttngInfo
@@ -30,7 +32,8 @@ class TestLttng:
 
     def test_get_nodes(self, mocker):
         data_mock = mocker.Mock(spec=Ros2DataModel)
-        mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
+        mocker.patch.object(Lttng, '_parse_lttng_data',
+                            return_value=(data_mock, {}, 0, 1))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
         mocker.patch('caret_analyze.infra.lttng.lttng_info.LttngInfo',
@@ -52,7 +55,8 @@ class TestLttng:
 
     def test_get_rmw_implementation(self, mocker):
         data_mock = mocker.Mock(spec=Ros2DataModel)
-        mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
+        mocker.patch.object(Lttng, '_parse_lttng_data',
+                            return_value=(data_mock, {}, 0, 1))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
         mocker.patch('caret_analyze.infra.lttng.lttng_info.LttngInfo',
@@ -72,7 +76,8 @@ class TestLttng:
 
     def test_get_publishers(self, mocker):
         data_mock = mocker.Mock(spec=Ros2DataModel)
-        mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
+        mocker.patch.object(Lttng, '_parse_lttng_data',
+                            return_value=(data_mock, {}, 0, 1))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
         mocker.patch('caret_analyze.infra.lttng.lttng_info.LttngInfo',
@@ -92,7 +97,8 @@ class TestLttng:
 
     def test_get_timer_callbacks(self, mocker):
         data_mock = mocker.Mock(spec=Ros2DataModel)
-        mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
+        mocker.patch.object(Lttng, '_parse_lttng_data',
+                            return_value=(data_mock, {}, 0, 1))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
         mocker.patch('caret_analyze.infra.lttng.lttng_info.LttngInfo',
@@ -112,7 +118,8 @@ class TestLttng:
 
     def test_get_subscription_callbacks(self, mocker):
         data_mock = mocker.Mock(spec=Ros2DataModel)
-        mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
+        mocker.patch.object(Lttng, '_parse_lttng_data',
+                            return_value=(data_mock, {}, 0, 1))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
         mocker.patch('caret_analyze.infra.lttng.lttng_info.LttngInfo',
@@ -133,7 +140,8 @@ class TestLttng:
 
     def test_get_executors(self, mocker):
         data_mock = mocker.Mock(spec=Ros2DataModel)
-        mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
+        mocker.patch.object(Lttng, '_parse_lttng_data',
+                            return_value=(data_mock, {}, 0, 1))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
         mocker.patch('caret_analyze.infra.lttng.lttng_info.LttngInfo',
@@ -154,7 +162,8 @@ class TestLttng:
 
     def test_compose_inter_proc_comm_records(self, mocker):
         data_mock = mocker.Mock(spec=Ros2DataModel)
-        mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
+        mocker.patch.object(Lttng, '_parse_lttng_data',
+                            return_value=(data_mock, {}, 0, 1))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
         mocker.patch('caret_analyze.infra.lttng.lttng_info.LttngInfo',
@@ -177,7 +186,8 @@ class TestLttng:
 
     def test_compose_intra_proc_comm_records(self, mocker):
         data_mock = mocker.Mock(spec=Ros2DataModel)
-        mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
+        mocker.patch.object(Lttng, '_parse_lttng_data',
+                            return_value=(data_mock, {}, 0, 1))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
         mocker.patch('caret_analyze.infra.lttng.lttng_info.LttngInfo',
@@ -200,7 +210,8 @@ class TestLttng:
 
     def test_compose_callback_records(self, mocker):
         data_mock = mocker.Mock(spec=Ros2DataModel)
-        mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_mock, {}))
+        mocker.patch.object(Lttng, '_parse_lttng_data',
+                            return_value=(data_mock, {}, 0, 1))
 
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
         mocker.patch('caret_analyze.infra.lttng.lttng_info.LttngInfo',
@@ -225,7 +236,8 @@ class TestLttng:
         data = Ros2DataModel()
         data.finalize()
         events = {'b': None}
-        mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data, events))
+        mocker.patch.object(Lttng, '_parse_lttng_data',
+                            return_value=(data, events, 0, 0))
         lttng_info_mock = mocker.Mock(spec=LttngInfo)
         mocker.patch('caret_analyze.infra.lttng.lttng_info.LttngInfo',
                      return_value=lttng_info_mock)
@@ -234,8 +246,12 @@ class TestLttng:
         data_ = Ros2DataModel()
         data_.finalize()
         events_ = {'a': None}
-        mocker.patch.object(Lttng, '_parse_lttng_data', return_value=(data_, events_))
+        mocker.patch.object(Lttng, '_parse_lttng_data',
+                            return_value=(data_, events_, 0, 1*10**9))
         lttng_ = Lttng('', validate=False, store_events=True)
+        begin, end = lttng_.get_trace_range()
+        assert begin == datetime.fromtimestamp(0)
+        assert end == datetime.fromtimestamp(1)
         assert lttng.events == events
         assert lttng_.events == events_
         assert lttng.events != lttng_.events


### PR DESCRIPTION
**Note: This patch should be applied after #117** 

In some cases, an error occurred when loading the cache and LttngEventFilter.

To reproduce, used data are located here : 
https://drive.google.com/drive/folders/1Zw-V8jvlC22EJC87gEqSsQJqjU5KFYoA?usp=sharing


This patch fixes:

```
461386 events found.
loading:   0%|                                                                                        | 2/461386 [00:00<00:30, 15114.61it/s]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Input In [6], in <cell line: 1>()
----> 1 lttng = Lttng(tracing_log_path, event_filters=[LttngEventFilter.duration_filter(5, 10)])
      3 arch = Architecture('yaml', architecture_path)
      4 app = Application(arch, lttng)

File ~/ros2_caret_ws/build/caret_analyze/caret_analyze/infra/lttng/lttng.py:303, in Lttng.__init__(self, trace_dir_or_events, force_conversion, event_filters, store_events, validate)
    300 from .records_source import RecordsSource
    301 from .event_counter import EventCounter
--> 303 data, events = self._parse_lttng_data(
    304     trace_dir_or_events,
    305     force_conversion,
    306     event_filters or [],
    307     store_events
    308 )
    309 self.data = data
    310 self._info = LttngInfo(data)

File ~/ros2_caret_ws/build/caret_analyze/caret_analyze/infra/lttng/lttng.py:342, in Lttng._parse_lttng_data(trace_dir_or_events, force_conversion, event_filters, store_events)
    336 filtered_event_count = 0
    337 for event in tqdm(
    338         iter(event_collection),
    339         total=len(event_collection),
    340         desc='loading'):
    341     if len(event_filters) > 0 and \
--> 342             any(not f.accept(event, common) for f in event_filters):
    343         continue
    344     if store_events:

File ~/ros2_caret_ws/build/caret_analyze/caret_analyze/infra/lttng/lttng.py:342, in <genexpr>(.0)
    336 filtered_event_count = 0
    337 for event in tqdm(
    338         iter(event_collection),
    339         total=len(event_collection),
    340         desc='loading'):
    341     if len(event_filters) > 0 and \
--> 342             any(not f.accept(event, common) for f in event_filters):
    343         continue
    344     if store_events:

File ~/ros2_caret_ws/build/caret_analyze/caret_analyze/infra/lttng/lttng.py:149, in EventDurationFilter.accept(self, event, common)
    146 if self._init_events.accept(event, common):
    147     return True
--> 149 elapsed_ns = event[self.TIMESTAMP] - common.start_time
    150 elapsed_s = elapsed_ns * 1.0e-9
    151 return self._offset <= elapsed_s and elapsed_s < (self._offset + self._duration)

TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'

```