### PR TITLE
fix(lttng): change caret-rclcpp violation as warn

### DIFF
--- a/src/caret_analyze/infra/lttng/event_counter.py
+++ b/src/caret_analyze/infra/lttng/event_counter.py
@@ -81,11 +81,14 @@ class EventCounter:
                 'Measurement results will not be correct. '
                 'The measurement may have been performed without setting LD_PRELOAD.')
 
+        # trace points added to rclcpp may not be recorded, depending on the implementation.
+        # Here, only warnings are given.
         if len(set(recorded_trace_points) & trace_points_added_by_fork_rclcpp) == 0:
-            raise InvalidTraceFormatError(
-                'Failed to found trace point added by forked rclcpp. '
-                'Measurement results will not be correct. '
-                'The binary may have been compiled without using fork-rclcpp.')
+            logger.warning(
+                'Failed to find trace point added by caret-rclcpp. '
+                'To check whether binary are built with caret-rclcpp,'
+                'run CARET CLI : ros2 caret check_caret_rclcpp.'
+            )
 
     @staticmethod
     def _build_count_df(data: Ros2DataModel) -> pd.DataFrame:


### PR DESCRIPTION
Signed-off-by: hsgwa <hasegawa.isp@gmail.com>

caret-rclcpp assertion is checked by whether caret-rclcpp tracepoits are recorded.
However, when all nodes publish with iter-process communication, no caret-rclcpp tracepoints are recorded.

- message_construct
- rclcpp_intra_publish
- dispatch_subwscription_callback
- dispatch_intra_subscription_callback

If target application doesn't have any subscription and intra-process publish, the original implementation incorrectly raises an error.

This PR modifies caret-rclcpp check from assertion to warning.

To reproduce: https://drive.google.com/drive/folders/1og8VNwxQdb8Bo-zoSO6_E2IPiTDWx0TE?usp=sharing
```
from caret_analyze import Lttng
Lttng(''aaa_sample')


InvalidTraceFormatError                   Traceback (most recent call last)
Input In [2], in <cell line: 1>()
----> 1 lttng = Lttng('aaa_sample')

File ~/ros2_caret_ws/build/caret_analyze/caret_analyze/infra/lttng/lttng.py:335, in Lttng.__init__(self, trace_dir_or_events, force_conversion, event_filters, store_events, validate)
    333 self._info = LttngInfo(data)
    334 self._source: RecordsSource = RecordsSource(data, self._info)
--> 335 self._counter = EventCounter(data, validate=validate)
    336 self.events = events
    337 self._begin = begin

File ~/ros2_caret_ws/build/caret_analyze/caret_analyze/infra/lttng/event_counter.py:34, in EventCounter.__init__(self, data, validate)
     32 self._count_df = self._build_count_df(data)
     33 if validate:
---> 34     self._validate()

File ~/ros2_caret_ws/build/caret_analyze/caret_analyze/infra/lttng/event_counter.py:85, in EventCounter._validate(self)
     79     raise InvalidTraceFormatError(
     80         'Failed to found trace point added by LD_PRELOAD. '
     81         'Measurement results will not be correct. '
     82         'The measurement may have been performed without setting LD_PRELOAD.')
     84 if len(set(recorded_trace_points) & trace_points_added_by_fork_rclcpp) == 0:
---> 85     raise InvalidTraceFormatError(
     86         'Failed to found trace point added by forked rclcpp. '
     87         'Measurement results will not be correct. '
     88         'The binary may have been compiled without using fork-rclcpp.')

InvalidTraceFormatError: Failed to found trace point added by forked rclcpp. Measurement results will not be correct. The binary may have been compiled without using fork-rclcpp.
```

