### PR TITLE
fix(plot): add handling of cases where there is no node/callback name

### DIFF
--- a/src/caret_analyze/plot/bokeh/pub_sub_info_interface.py
+++ b/src/caret_analyze/plot/bokeh/pub_sub_info_interface.py
@@ -168,12 +168,22 @@ class PubSubTimeSeriesPlot(metaclass=ABCMeta):
         def get_node_name(
             line_source_df: pd.DataFrame
         ) -> str:
-            return line_source_df.columns.to_list()[0].split('/')[1]
+            ts_column_name_splitted = \
+                line_source_df.columns.to_list()[0].split('/')
+            if len(ts_column_name_splitted) == 1:
+                return ''
+            else:
+                return ts_column_name_splitted[1]
 
         def get_callback_name(
             line_source_df: pd.DataFrame
         ) -> str:
-            return line_source_df.columns.to_list()[0].split('/')[2]
+            ts_column_name_splitted = \
+                line_source_df.columns.to_list()[0].split('/')
+            if len(ts_column_name_splitted) == 1:
+                return ''
+            else:
+                return ts_column_name_splitted[2]
 
         if xaxis_type == 'system_time':
             x_item = ((line_source_df.iloc[:, 0] - frame_min)
@@ -239,7 +249,7 @@ class PubSubTimeSeriesPlot(metaclass=ABCMeta):
                 ts_column_name = (f'{pub_sub.callback_names[0]}'
                                   '/rclcpp_publish_timestamp [ns]')
             else:
-                ts_column_name = '/rclcpp_publish_timestamp [ns]'
+                ts_column_name = 'rclcpp_publish_timestamp [ns]'
         else:
             ts_column_name = f'{pub_sub.column_names[0]} [ns]'
 

--- a/src/test/plot/bokeh/test_pub_sub_info_interface.py
+++ b/src/test/plot/bokeh/test_pub_sub_info_interface.py
@@ -23,7 +23,7 @@ class TestPubSubTimeSeriesPlot:
         mocker.patch.object(pub_mock, 'callback_names', [])
 
         assert (PubSubTimeSeriesPlot._get_ts_column_name(pub_mock)
-                == '/rclcpp_publish_timestamp [ns]')
+                == 'rclcpp_publish_timestamp [ns]')
 
     def test_get_ts_column_name_normal_case(self, mocker):
         pub_mock = mocker.Mock(spec=Publisher)


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

This PR fixes an IndexError that occurred in the get_node_name() and get_callback_name() functions in pub_sub_plot_interface.py.