### PR TITLE
fix(plot): sigill error during bokeh plotting

### DIFF
--- a/src/caret_analyze/plot/bokeh/util.py
+++ b/src/caret_analyze/plot/bokeh/util.py
@@ -119,7 +119,13 @@ def get_range(
 
     po_dfs = [po.to_dataframe(remove_dropped=True) for po in plot_objects]
     po_dfs_valid = [po_df for po_df in po_dfs if len(po_df) > 0]
-    po_min = min(min(df.min()) for df in po_dfs_valid)
-    po_max = max(max(df.max()) for df in po_dfs_valid)
+
+    # NOTE:
+    # The first column is system time for now.
+    # The other columns could be other than system time.
+    # Only the system time is picked out here.
+    base_series = [df.iloc[:, 0] for df in po_dfs_valid]
+    po_min = min(series.min() for series in base_series)
+    po_max = max(series.max() for series in base_series)
 
     return po_min, po_max


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

![bokeh_sigill_error](https://user-images.githubusercontent.com/19860128/190345448-3bede8ca-296d-4e00-bdaa-44fec9377d5b.gif)

In bokeh, fixing the tick width will cause a SIGILL error when scaling down.

In the current implementation, this same thing happens when visualizing.
This is because there are cases where the minimum value for to_dataframe() contains columns with zeros.

This patch fixes the SIGILL error during visualization.

BUG: SIGILL error raises.
EXPECT: no error.
