### PR TITLE
chore(value_objects): add node name to summary dict

### DIFF
--- a/src/caret_analyze/value_objects/callback.py
+++ b/src/caret_analyze/value_objects/callback.py
@@ -391,6 +391,7 @@ class SubscriptionCallbackStructValue(CallbackStructValue, ValueObject):
     def summary(self) -> Summary:
         return Summary({
             'name': self.callback_name,
+            'node': self.node_name,
             'type': self.callback_type_name,
             'topic': self.subscribe_topic_name
         })

--- a/src/caret_analyze/value_objects/publisher.py
+++ b/src/caret_analyze/value_objects/publisher.py
@@ -97,6 +97,7 @@ class PublisherStructValue(ValueObject, Summarizable):
     @property
     def summary(self) -> Summary:
         return Summary({
+            'node': self.node_name,
             'topic_name': self.topic_name,
             'callbacks': self.callback_names
         })

--- a/src/caret_analyze/value_objects/subscription.py
+++ b/src/caret_analyze/value_objects/subscription.py
@@ -93,6 +93,7 @@ class SubscriptionStructValue(ValueObject, Summarizable):
     @property
     def summary(self) -> Summary:
         return Summary({
+            'node': self.node_name,
             'topic_name': self.topic_name,
             'callback': self.callback_name
         })

--- a/src/caret_analyze/value_objects/timer.py
+++ b/src/caret_analyze/value_objects/timer.py
@@ -82,6 +82,7 @@ class TimerStructValue(ValueObject, Summarizable):
     @property
     def summary(self) -> Summary:
         return Summary({
+            'node': self.node_name,
             'period_ns': self.period_ns,
             'callback': self.callback_name
         })


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

This PR adds node name to summary info.
Summary class is UserDict class and it helps developers to understand the primary information of the instance.
node name is necessary for these classes to identify.