### PR TITLE
fix(record): pandas.Dataframe error 'columns cannot be a set error'

### DIFF
--- a/src/caret_analyze/record/record.py
+++ b/src/caret_analyze/record/record.py
@@ -316,7 +316,7 @@ class Records(RecordsInterface):
 
         df = pd.DataFrame(df_dict, dtype='Int64')
 
-        missing_columns = set(columns) - set(df.columns)
+        missing_columns = list(set(columns) - set(df.columns))
         df_miss = pd.DataFrame(columns=missing_columns)
         df = pd.concat([df, df_miss])
         return df[columns]


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

This PR fixes the following error during pandas.Dataframe().
```
E           ValueError: columns cannot be a set
```

The reason for the error is that the version of pandas on PyPI has been increased to 1.5.0.