### PR TITLE
chore(plot): rename TimeSeriesPlot to CallbackTimeSeriesPlot

### DIFF
--- a/src/caret_analyze/plot/__init__.py
+++ b/src/caret_analyze/plot/__init__.py
@@ -15,7 +15,7 @@
 from .bokeh.callback_info import (CallbackFrequencyPlot,
                                   CallbackLatencyPlot,
                                   CallbackPeriodPlot)
-from .bokeh.callback_info_interface import TimeSeriesPlot
+from .bokeh.callback_info_interface import CallbackTimeSeriesPlot
 from .bokeh.callback_sched import callback_sched
 from .bokeh.communication_info_interface import CommunicationTimeSeriesPlot
 from .bokeh.message_flow import message_flow
@@ -30,7 +30,7 @@ __all__ = [
     'CallbackLatencyPlot',
     'CallbackPeriodPlot',
     'CallbackFrequencyPlot',
-    'TimeSeriesPlot',
+    'CallbackTimeSeriesPlot',
     'PubSubTimeSeriesPlot',
     'CommunicationTimeSeriesPlot',
     'callback_graph',

--- a/src/caret_analyze/plot/bokeh/callback_info.py
+++ b/src/caret_analyze/plot/bokeh/callback_info.py
@@ -17,7 +17,7 @@ from typing import List, Union
 
 import pandas as pd
 
-from .callback_info_interface import TimeSeriesPlot
+from .callback_info_interface import CallbackTimeSeriesPlot
 from .plot_util import (add_top_level_column, convert_df_to_sim_time,
                         get_freq_with_timestamp)
 from ...runtime import (Application, CallbackBase, CallbackGroup,
@@ -29,7 +29,7 @@ CallbacksType = Union[Application, Path, Executor, Node,
                       CallbackGroup, CallbackBase, List[CallbackBase]]
 
 
-class CallbackLatencyPlot(TimeSeriesPlot):
+class CallbackLatencyPlot(CallbackTimeSeriesPlot):
     """
     Class that provides API for callback latency.
 
@@ -83,7 +83,7 @@ class CallbackLatencyPlot(TimeSeriesPlot):
         return latency_df
 
 
-class CallbackPeriodPlot(TimeSeriesPlot):
+class CallbackPeriodPlot(CallbackTimeSeriesPlot):
     """
     Class that provides API for callback period.
 
@@ -138,7 +138,7 @@ class CallbackPeriodPlot(TimeSeriesPlot):
         return period_df
 
 
-class CallbackFrequencyPlot(TimeSeriesPlot):
+class CallbackFrequencyPlot(CallbackTimeSeriesPlot):
     """
     Class that provides API for callback execution frequency.
 

--- a/src/caret_analyze/plot/bokeh/callback_info_interface.py
+++ b/src/caret_analyze/plot/bokeh/callback_info_interface.py
@@ -37,7 +37,7 @@ CallbacksType = Union[Application, Path, Executor, Node,
                       CallbackGroup, CallbackBase, List[CallbackBase]]
 
 
-class TimeSeriesPlot(metaclass=ABCMeta):
+class CallbackTimeSeriesPlot(metaclass=ABCMeta):
     def __init__(
         self,
         target: CallbacksType

--- a/src/caret_analyze/plot/bokeh/plot_factory.py
+++ b/src/caret_analyze/plot/bokeh/plot_factory.py
@@ -18,7 +18,7 @@ from typing import List, Union
 from .callback_info import (CallbackFrequencyPlot,
                             CallbackLatencyPlot,
                             CallbackPeriodPlot)
-from .callback_info_interface import TimeSeriesPlot
+from .callback_info_interface import CallbackTimeSeriesPlot
 from .communication_info import (CommunicationFrequencyPlot,
                                  CommunicationLatencyPlot,
                                  CommunicationPeriodPlot)
@@ -41,7 +41,7 @@ class Plot:
     @staticmethod
     def create_callback_frequency_plot(
         callbacks: CallbacksType
-    ) -> TimeSeriesPlot:
+    ) -> CallbackTimeSeriesPlot:
         """
         Get CallbackFrequencyPlot instance.
 
@@ -67,7 +67,7 @@ class Plot:
     @staticmethod
     def create_callback_jitter_plot(
         callbacks: CallbacksType
-    ) -> TimeSeriesPlot:
+    ) -> CallbackTimeSeriesPlot:
         logger.warning('create_callback_jitter_plot is deprecated.'
                        'Use create_callback_period_plot')
         return Plot.create_callback_period_plot(callbacks)
@@ -75,7 +75,7 @@ class Plot:
     @staticmethod
     def create_callback_period_plot(
         callbacks: CallbacksType
-    ) -> TimeSeriesPlot:
+    ) -> CallbackTimeSeriesPlot:
         """
         Get CallbackPeriodPlot instance.
 
@@ -101,7 +101,7 @@ class Plot:
     @staticmethod
     def create_callback_latency_plot(
         callbacks: CallbacksType
-    ) -> TimeSeriesPlot:
+    ) -> CallbackTimeSeriesPlot:
         """
         Get CallbackLatencyPlot instance.
 


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

This PR renames from TimeSeriesPlot to CallbackTimeSeriesPlot.
The reason is that other time-series data plotting APIs are named `[TARGET_OBJECT]TimeSeriesPlot` as shown below.
- [CommunicationTimeSeriesPlot](https://github.com/tier4/CARET_analyze/blob/60c540c605c3cdda686914f681c414154006e6c8/src/caret_analyze/plot/bokeh/communication_info_interface.py#L33)
- [PubSubTimeSeriesPlot](https://github.com/tier4/CARET_analyze/blob/60c540c605c3cdda686914f681c414154006e6c8/src/caret_analyze/plot/bokeh/pub_sub_info_interface.py#L33)

To reproduce: https://drive.google.com/drive/folders/1Jb4BsYzFwOkygkpmJnEZeJ58-gsgNIUK?usp=sharing