### PR TITLE
feat(ros2_tracing): add API to get node name from callback group address based on Ros2DataModel.

### DIFF
--- a/src/caret_analyze/exceptions.py
+++ b/src/caret_analyze/exceptions.py
@@ -86,3 +86,10 @@ class UnsupportedNodeRecordsError(Error):
 
     def __init__(self, message: str) -> None:
         self.message = message
+
+
+class InvalidCtfDataError(Error):
+    """Given CTF data is invalid."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message

--- a/src/caret_analyze/exceptions.py
+++ b/src/caret_analyze/exceptions.py
@@ -86,10 +86,3 @@ class UnsupportedNodeRecordsError(Error):
 
     def __init__(self, message: str) -> None:
         self.message = message
-
-
-class InvalidCtfDataError(Error):
-    """Given CTF data is invalid."""
-
-    def __init__(self, message: str) -> None:
-        self.message = message

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -39,10 +39,100 @@ class DataModelService:
         self,
         cbg_addr: int
     ) -> Optional[str]:
-        raise NotImplementedError
+        node_name = self._get_node_name_from_cbg_timer(cbg_addr)
+        if node_name:
+            return node_name
+
+        node_name = self._get_node_name_from_cbg_sub(cbg_addr)
+        if node_name:
+            return node_name
+
+        return None
+
+    def _get_node_name_from_cbg_timer(self, cbg_addr: int) -> Optional[str]:
+        print('a')
+        match_cbg_timer = self._data.callback_group_timer.query(
+            f'callback_group_addr == {cbg_addr}'
+        )
+        if match_cbg_timer.empty:
+            return None
+
+        assert len(match_cbg_timer) == 1
+        timer_handle = match_cbg_timer.iloc[0]['timer_handle']
+        match_timer_node_links = self._data.timer_node_links.query(
+            f'timer_handle == {timer_handle}'
+        )
+        if match_timer_node_links.empty:
+            return None
+
+        assert len(match_timer_node_links) == 1
+        node_handle = match_timer_node_links.iloc[0]['node_handle']
+        match_nodes = self._data.nodes.query(
+            f'node_handle == {node_handle}'
+        )
+        if match_nodes.empty:
+            return None
+
+        assert len(match_nodes) == 1
+        node_name = (match_nodes.iloc[0]['namespace']
+                     + '/' + match_nodes.iloc[0]['name'])
+        return node_name
+
+    def _get_node_name_from_cbg_sub(self, cbg_addr: int) -> Optional[str]:
+        match_cbg_sub = self._data.callback_group_subscription.query(
+            f'callback_group_addr == {cbg_addr}'
+        )
+        if match_cbg_sub.empty:
+            return None
+
+        assert len(match_cbg_sub) == 1
+        subscription_handle = match_cbg_sub.iloc[0]['subscription_handle']
+        match_subscriptions = self._data.subscriptions.query(
+            f'subscription_handle == {subscription_handle}'
+        )
+        if match_subscriptions.empty:
+            return None
+
+        assert len(match_subscriptions) == 1
+        node_handle = match_subscriptions.iloc[0]['node_handle']
+        match_nodes = self._data.nodes.query(
+            f'node_handle == {node_handle}'
+        )
+        if match_nodes.empty:
+            return None
+
+        assert len(match_nodes) == 1
+        node_name = (match_nodes.iloc[0]['namespace']
+                     + '/' + match_nodes.iloc[0]['name'])
+        return node_name
 
     def _get_node_name_from_get_parameters_srv(
         self,
         cbg_addr: int
     ) -> Optional[str]:
-        raise NotImplementedError
+        match_cbg_srv = self._data.callback_group_service.query(
+            f'callback_group_addr == {cbg_addr}'
+        )
+        if match_cbg_srv.empty:
+            return None
+
+        assert len(match_cbg_srv) == 1
+        service_handle = match_cbg_srv.iloc[0]['service_handle']
+        match_services = self._data.services.query(
+            f'service_handle == {service_handle}'
+        )
+        if match_services.empty:
+            return None
+
+        assert len(match_services) == 1
+        node_handle = match_services.iloc[0]['node_handle']
+        match_nodes = self._data.nodes.query(
+            f'node_handle == {node_handle}'
+        )
+        if match_nodes.empty:
+            return None
+
+        assert len(match_nodes) == 1
+        node_name = (match_nodes.iloc[0]['namespace']
+                     + '/' + match_nodes.iloc[0]['name'])
+        return node_name

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -68,7 +68,7 @@ class DataModelService:
             pass
 
         if node_names:
-            return sorted(list(node_names))
+            return sorted(node_names)
         else:
             raise InvalidCtfDataError(
                 'Failed to identify node name from callback group address.')

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -74,6 +74,8 @@ class DataModelService:
         self,
         cbg_addr: int
     ) -> List[str]:
+        # `.loc[[cbg_addr], :]` is intended to make the return value DataFrame
+        # instead of Series.
         match_cbg_timer = self._data.callback_group_timer.loc[[cbg_addr], :]
 
         match_timer_handles = match_cbg_timer.loc[:, 'timer_handle'].to_list()
@@ -89,6 +91,8 @@ class DataModelService:
         self,
         cbg_addr: int
     ) -> List[str]:
+        # `.loc[[cbg_addr], :]` is intended to make the return value DataFrame
+        # instead of Series.
         match_cbg_sub = \
             self._data.callback_group_subscription.loc[[cbg_addr], :]
 
@@ -106,6 +110,8 @@ class DataModelService:
         self,
         cbg_addr: int
     ) -> List[str]:
+        # `.loc[[cbg_addr], :]` is intended to make the return value DataFrame
+        # instead of Series.
         match_cbg_srv = self._data.callback_group_service.loc[[cbg_addr], :]
 
         match_srv_handles = match_cbg_srv.loc[:, 'service_handle'].to_list()

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -73,7 +73,7 @@ class DataModelService:
     def _get_node_names_from_cbg_timer(
         self,
         cbg_addr: int
-    ) -> Optional[List[str]]:
+    ) -> List[str]:
         match_cbg_timer = self._data.callback_group_timer.loc[[cbg_addr], :]
 
         match_timer_handles = match_cbg_timer.loc[:, 'timer_handle'].to_list()
@@ -88,7 +88,7 @@ class DataModelService:
     def _get_node_names_from_cbg_sub(
         self,
         cbg_addr: int
-    ) -> Optional[List[str]]:
+    ) -> List[str]:
         match_cbg_sub = \
             self._data.callback_group_subscription.loc[[cbg_addr], :]
 
@@ -105,7 +105,7 @@ class DataModelService:
     def _get_node_names_from_get_parameters_srv(
         self,
         cbg_addr: int
-    ) -> Optional[List[str]]:
+    ) -> List[str]:
         match_cbg_srv = self._data.callback_group_service.loc[[cbg_addr], :]
 
         match_srv_handles = match_cbg_srv.loc[:, 'service_handle'].to_list()

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -1,0 +1,48 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from .data_model import Ros2DataModel
+from ....exceptions import InvalidCtfDataError
+
+
+class DataModelService:
+
+    def __init__(self, data: Ros2DataModel) -> None:
+        self._data = data
+
+    def get_node_name(self, cbg_addr: int) -> str:
+        node_name = self._get_node_name_from_rcl_node_init(cbg_addr)
+        if node_name:
+            return node_name
+
+        node_name = self._get_node_name_from_get_parameters_srv(cbg_addr)
+        if node_name:
+            return node_name
+
+        raise InvalidCtfDataError(
+            'Failed to identify node name from callback group address.')
+
+    def _get_node_name_from_rcl_node_init(
+        self,
+        cbg_addr: int
+    ) -> Optional[str]:
+        raise NotImplementedError
+
+    def _get_node_name_from_get_parameters_srv(
+        self,
+        cbg_addr: int
+    ) -> Optional[str]:
+        raise NotImplementedError

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -17,7 +17,6 @@ from typing import List, Set
 import pandas as pd
 
 from .data_model import Ros2DataModel
-from ....exceptions import InvalidCtfDataError
 
 
 class DataModelService:
@@ -37,12 +36,6 @@ class DataModelService:
         Returns
         -------
         List[str]
-
-        Raises
-        ------
-        InvalidCtfDataError
-            Occurs when there is no node name associated with
-            the given callback group address.
 
         Notes
         -----
@@ -70,8 +63,8 @@ class DataModelService:
         if node_names:
             return sorted(node_names)
         else:
-            raise InvalidCtfDataError(
-                'Failed to identify node name from callback group address.')
+            # Failed to identify node name from callback group address.
+            return []
 
     def _get_node_names_from_cbg_timer(
         self,

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
+from typing import List
 
 from .data_model import Ros2DataModel
 from ....exceptions import InvalidCtfDataError

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -50,7 +50,6 @@ class DataModelService:
         return None
 
     def _get_node_name_from_cbg_timer(self, cbg_addr: int) -> Optional[str]:
-        print('a')
         match_cbg_timer = self._data.callback_group_timer.query(
             f'callback_group_addr == {cbg_addr}'
         )

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -60,11 +60,7 @@ class DataModelService:
         except KeyError:
             pass
 
-        if node_names:
-            return sorted(node_names)
-        else:
-            # Failed to identify node name from callback group address.
-            return []
+        return sorted(node_names)
 
     def _get_node_names_from_cbg_timer(
         self,

--- a/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
+++ b/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
@@ -22,7 +22,7 @@ import pytest
 
 class TestDataModelService:
 
-    def test_get_node_name_not_exist(self):
+    def test_get_node_names_not_exist(self):
         data = Ros2DataModel()
         data.callback_group_add_timer(-1, -1, -1)
         data.callback_group_add_subscription(-1, -1, -1)
@@ -31,10 +31,10 @@ class TestDataModelService:
 
         data_model_srv = DataModelService(data)
         with pytest.raises(InvalidCtfDataError) as e:
-            data_model_srv.get_node_name(0)
+            data_model_srv.get_node_names(0)
         assert 'Failed' in str(e.value)
 
-    def test_get_node_name_exist_rcl_node_init_timer(self):
+    def test_get_node_names_exist_rcl_node_init_timer(self):
         data = Ros2DataModel()
         cbg_addr = 1
         timer_handle = 2
@@ -47,10 +47,10 @@ class TestDataModelService:
         data.finalize()
 
         data_model_srv = DataModelService(data)
-        node_name = data_model_srv.get_node_name(cbg_addr)
-        assert node_name == 'ns/name'
+        node_names = data_model_srv.get_node_names(cbg_addr)
+        assert node_names == ['ns/name']
 
-    def test_get_node_name_exist_rcl_node_init_sub(self):
+    def test_get_node_names_exist_rcl_node_init_sub(self):
         data = Ros2DataModel()
         cbg_addr = 1
         sub_handle = 2
@@ -63,10 +63,10 @@ class TestDataModelService:
         data.finalize()
 
         data_model_srv = DataModelService(data)
-        node_name = data_model_srv.get_node_name(cbg_addr)
-        assert node_name == 'ns/name'
+        node_names = data_model_srv.get_node_names(cbg_addr)
+        assert node_names == ['ns/name']
 
-    def test_get_node_name_exist_get_parameters_srv(self):
+    def test_get_node_names_exist_get_parameters_srv(self):
         data = Ros2DataModel()
         cbg_addr = 1
         srv_handle = 2
@@ -79,5 +79,27 @@ class TestDataModelService:
         data.finalize()
 
         data_model_srv = DataModelService(data)
-        node_name = data_model_srv.get_node_name(cbg_addr)
-        assert node_name == 'ns/name'
+        node_names = data_model_srv.get_node_names(cbg_addr)
+        assert node_names == ['ns/name']
+
+    def test_get_node_names_multiple_exist(self):
+        data = Ros2DataModel()
+        duplicated_cbg_addr = 1
+        timer_handle1 = 2
+        timer_handle2 = 3
+        node_handle1 = 4
+        node_handle2 = 5
+        data.add_node(0, node_handle1, 0, 0, 'name1', 'ns')
+        data.add_node(0, node_handle2, 0, 0, 'name2', 'ns')
+        data.add_timer_node_link(timer_handle1, 0, node_handle1)
+        data.add_timer_node_link(timer_handle2, 0, node_handle2)
+        data.callback_group_add_timer(duplicated_cbg_addr, 0, timer_handle1)
+        data.callback_group_add_timer(duplicated_cbg_addr, 0, timer_handle2)
+        data.callback_group_add_timer(-1, -1, -1)
+        data.callback_group_add_subscription(-1, -1, -1)
+        data.callback_group_add_service(-1, -1, -1)
+        data.finalize()
+
+        data_model_srv = DataModelService(data)
+        node_names = data_model_srv.get_node_names(duplicated_cbg_addr)
+        assert node_names == ['ns/name1', 'ns/name2']

--- a/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
+++ b/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from caret_analyze.exceptions import InvalidCtfDataError
 from caret_analyze.infra.lttng.ros2_tracing.data_model import Ros2DataModel
 from caret_analyze.infra.lttng.ros2_tracing.data_model_service \
     import DataModelService
-
-import pytest
 
 
 class TestDataModelService:
@@ -27,9 +24,8 @@ class TestDataModelService:
         data.finalize()
 
         data_model_srv = DataModelService(data)
-        with pytest.raises(InvalidCtfDataError) as e:
-            data_model_srv.get_node_names(0)
-        assert 'Failed' in str(e.value)
+        node_names = data_model_srv.get_node_names(0)
+        assert node_names == []
 
     def test_get_node_names_exist_rcl_node_init_timer(self):
         data = Ros2DataModel()

--- a/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
+++ b/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
@@ -1,0 +1,76 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from caret_analyze.exceptions import InvalidCtfDataError
+from caret_analyze.infra.lttng.ros2_tracing.data_model import Ros2DataModel
+from caret_analyze.infra.lttng.ros2_tracing.data_model_service \
+    import DataModelService
+
+import pytest
+
+
+class TestDataModelService:
+
+    def test_get_node_name_not_exist(self):
+        data = Ros2DataModel()
+        data.finalize()
+
+        data_model_srv = DataModelService(data)
+        with pytest.raises(InvalidCtfDataError) as e:
+            data_model_srv.get_node_name(0)
+        assert 'Failed' in str(e.value)
+
+    def test_get_node_name_exist_rcl_node_init_timer(self):
+        data = Ros2DataModel()
+        cbg_addr = 1
+        timer_handle = 2
+        node_handle = 3
+        data.add_node(0, node_handle, 0, 0, 'name', 'ns')
+        data.add_timer_node_link(timer_handle, 0, node_handle)
+        data.callback_group_add_timer(cbg_addr, 0, timer_handle)
+        data.finalize()
+
+        data_model_srv = DataModelService(data)
+        node_name = data_model_srv.get_node_name(cbg_addr)
+        assert node_name == 'name'
+
+    def test_get_node_name_exist_rcl_node_init_sub(self):
+        data = Ros2DataModel()
+        data.callback_group_add_subscription()
+        cbg_addr = 1
+        sub_handle = 2
+        node_handle = 3
+        data.add_node(0, node_handle, 0, 0, 'name', 'ns')
+        data.add_rcl_subscription(sub_handle, 0, node_handle, 0, 'topic', 0)
+        data.callback_group_add_subscription(cbg_addr, 0, sub_handle)
+        data.finalize()
+
+        data_model_srv = DataModelService(data)
+        node_name = data_model_srv.get_node_name(cbg_addr)
+        assert node_name == 'name'
+
+    def test_get_node_name_exist_get_parameters_srv(self):
+        data = Ros2DataModel()
+        data.callback_group_add_subscription()
+        cbg_addr = 1
+        srv_handle = 2
+        node_handle = 3
+        data.add_node(0, node_handle, 0, 0, 'name', 'ns')
+        data.add_service(srv_handle, 0, node_handle, 0, 'srv')
+        data.callback_group_add_service(cbg_addr, 0, srv_handle)
+        data.finalize()
+
+        data_model_srv = DataModelService(data)
+        node_name = data_model_srv.get_node_name(cbg_addr)
+        assert node_name == 'name'

--- a/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
+++ b/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
@@ -43,7 +43,7 @@ class TestDataModelService:
 
         data_model_srv = DataModelService(data)
         node_name = data_model_srv.get_node_name(cbg_addr)
-        assert node_name == 'name'
+        assert node_name == 'ns/name'
 
     def test_get_node_name_exist_rcl_node_init_sub(self):
         data = Ros2DataModel()
@@ -58,7 +58,7 @@ class TestDataModelService:
 
         data_model_srv = DataModelService(data)
         node_name = data_model_srv.get_node_name(cbg_addr)
-        assert node_name == 'name'
+        assert node_name == 'ns/name'
 
     def test_get_node_name_exist_get_parameters_srv(self):
         data = Ros2DataModel()
@@ -73,4 +73,4 @@ class TestDataModelService:
 
         data_model_srv = DataModelService(data)
         node_name = data_model_srv.get_node_name(cbg_addr)
-        assert node_name == 'name'
+        assert node_name == 'ns/name'

--- a/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
+++ b/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
@@ -95,7 +95,6 @@ class TestDataModelService:
         data.add_timer_node_link(timer_handle2, 0, node_handle2)
         data.callback_group_add_timer(duplicated_cbg_addr, 0, timer_handle1)
         data.callback_group_add_timer(duplicated_cbg_addr, 0, timer_handle2)
-        data.callback_group_add_timer(-1, -1, -1)
         data.callback_group_add_subscription(-1, -1, -1)
         data.callback_group_add_service(-1, -1, -1)
         data.finalize()

--- a/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
+++ b/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
@@ -24,6 +24,9 @@ class TestDataModelService:
 
     def test_get_node_name_not_exist(self):
         data = Ros2DataModel()
+        data.callback_group_add_timer(-1, -1, -1)
+        data.callback_group_add_subscription(-1, -1, -1)
+        data.callback_group_add_service(-1, -1, -1)
         data.finalize()
 
         data_model_srv = DataModelService(data)
@@ -39,6 +42,8 @@ class TestDataModelService:
         data.add_node(0, node_handle, 0, 0, 'name', 'ns')
         data.add_timer_node_link(timer_handle, 0, node_handle)
         data.callback_group_add_timer(cbg_addr, 0, timer_handle)
+        data.callback_group_add_subscription(-1, -1, -1)
+        data.callback_group_add_service(-1, -1, -1)
         data.finalize()
 
         data_model_srv = DataModelService(data)
@@ -47,13 +52,14 @@ class TestDataModelService:
 
     def test_get_node_name_exist_rcl_node_init_sub(self):
         data = Ros2DataModel()
-        data.callback_group_add_subscription()
         cbg_addr = 1
         sub_handle = 2
         node_handle = 3
         data.add_node(0, node_handle, 0, 0, 'name', 'ns')
         data.add_rcl_subscription(sub_handle, 0, node_handle, 0, 'topic', 0)
         data.callback_group_add_subscription(cbg_addr, 0, sub_handle)
+        data.callback_group_add_timer(-1, -1, -1)
+        data.callback_group_add_service(-1, -1, -1)
         data.finalize()
 
         data_model_srv = DataModelService(data)
@@ -62,13 +68,14 @@ class TestDataModelService:
 
     def test_get_node_name_exist_get_parameters_srv(self):
         data = Ros2DataModel()
-        data.callback_group_add_subscription()
         cbg_addr = 1
         srv_handle = 2
         node_handle = 3
         data.add_node(0, node_handle, 0, 0, 'name', 'ns')
         data.add_service(srv_handle, 0, node_handle, 0, 'srv')
         data.callback_group_add_service(cbg_addr, 0, srv_handle)
+        data.callback_group_add_timer(-1, -1, -1)
+        data.callback_group_add_subscription(-1, -1, -1)
         data.finalize()
 
         data_model_srv = DataModelService(data)

--- a/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
+++ b/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
@@ -24,9 +24,6 @@ class TestDataModelService:
 
     def test_get_node_names_not_exist(self):
         data = Ros2DataModel()
-        data.callback_group_add_timer(-1, -1, -1)
-        data.callback_group_add_subscription(-1, -1, -1)
-        data.callback_group_add_service(-1, -1, -1)
         data.finalize()
 
         data_model_srv = DataModelService(data)
@@ -42,8 +39,6 @@ class TestDataModelService:
         data.add_node(0, node_handle, 0, 0, 'name', 'ns')
         data.add_timer_node_link(timer_handle, 0, node_handle)
         data.callback_group_add_timer(cbg_addr, 0, timer_handle)
-        data.callback_group_add_subscription(-1, -1, -1)
-        data.callback_group_add_service(-1, -1, -1)
         data.finalize()
 
         data_model_srv = DataModelService(data)
@@ -58,8 +53,6 @@ class TestDataModelService:
         data.add_node(0, node_handle, 0, 0, 'name', 'ns')
         data.add_rcl_subscription(sub_handle, 0, node_handle, 0, 'topic', 0)
         data.callback_group_add_subscription(cbg_addr, 0, sub_handle)
-        data.callback_group_add_timer(-1, -1, -1)
-        data.callback_group_add_service(-1, -1, -1)
         data.finalize()
 
         data_model_srv = DataModelService(data)
@@ -74,8 +67,6 @@ class TestDataModelService:
         data.add_node(0, node_handle, 0, 0, 'name', 'ns')
         data.add_service(srv_handle, 0, node_handle, 0, 'srv')
         data.callback_group_add_service(cbg_addr, 0, srv_handle)
-        data.callback_group_add_timer(-1, -1, -1)
-        data.callback_group_add_subscription(-1, -1, -1)
         data.finalize()
 
         data_model_srv = DataModelService(data)
@@ -95,8 +86,6 @@ class TestDataModelService:
         data.add_timer_node_link(timer_handle2, 0, node_handle2)
         data.callback_group_add_timer(duplicated_cbg_addr, 0, timer_handle1)
         data.callback_group_add_timer(duplicated_cbg_addr, 0, timer_handle2)
-        data.callback_group_add_subscription(-1, -1, -1)
-        data.callback_group_add_service(-1, -1, -1)
         data.finalize()
 
         data_model_srv = DataModelService(data)


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

This PR adds the  API to get the node name from callback group address based on Ros2DataModel.
Related thread: https://emb4hq.slack.com/archives/C03TE75R9C0/p1661140765913979?thread_ts=1661127490.661349&cid=C03TE75R9C0