### PR TITLE
chore(runtime): rename from Path.callbacks to Path.callback_chain

### DIFF
--- a/src/caret_analyze/plot/bokeh/message_flow.py
+++ b/src/caret_analyze/plot/bokeh/message_flow.py
@@ -76,8 +76,8 @@ def message_flow(
 
     converter: Optional[ClockConverter] = None
     if use_sim_time:
-        assert path.callbacks is not None and len(path.callbacks) > 0
-        cb = path.callbacks[0]
+        assert path.callback_chain is not None and len(path.callback_chain) > 0
+        cb = path.callback_chain[0]
         converter = cb._provider.get_sim_time_converter()  # TODO(hsgwa): refactor
 
     strip = Strip(lstrip_s, rstrip_s)
@@ -184,7 +184,7 @@ def get_callback_rect_list(
         'height': []
     })
 
-    if path.callbacks is None:
+    if path.callback_chain is None:
         return rect_source
 
     x = []
@@ -197,7 +197,7 @@ def get_callback_rect_list(
     latency = []
     height = []
 
-    for callback in path.callbacks:
+    for callback in path.callback_chain:
         if granularity == 'raw':
             search_name = callback.callback_name
         elif granularity == 'node':

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -300,9 +300,9 @@ class Path(PathBase, Summarizable):
         return self._value.summary
 
     @property
-    def callbacks(self) -> Optional[List[CallbackBase]]:
+    def callback_chain(self) -> Optional[List[CallbackBase]]:
         """
-        Get callbacks.
+        Get callback chain.
 
         Returns
         -------


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

This PR renames from `Path.callbacks` to `Path.callback_chain`

The current `Path.callbacks` property returns the callbacks that comprise the path when `callback_chain` is specified in the definition of the path.
The reason for this PR is that `callback_chain` is rarely specified in the definition of a path, and I plan to add a new property that will return all callbacks for the nodes that composes the path.