### PR TITLE
fix(lttng): bug with different range of duration_filter when there is no cache

### DIFF
--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -252,7 +252,7 @@ class CtfEventCollection(IterableEvents):
 
         assert begin_msg is not None
         assert end_msg is not None
-        # NOTE: Begin_time and end_time should be the same time as the PicleEventCollection.
+        # NOTE: Begin_time and end_time should be the same time as the PickleEventCollection.
         self._begin_time: int = begin_msg.default_clock_snapshot.ns_from_origin
         self._end_time: int = end_msg.default_clock_snapshot.ns_from_origin
         self._size = event_count

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -247,8 +247,8 @@ class CtfEventCollection(IterableEvents):
 
             if type(msg) is bt2._EventMessageConst:
                 if not begin_msg:
-                    begin_msg = msg
-                end_msg = msg
+                    begin_msg = msg  # store first one
+                end_msg = msg  # store last one
 
         assert begin_msg is not None
         assert end_msg is not None

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -229,28 +229,32 @@ class CtfEventCollection(IterableEvents):
 
     def __init__(self, events_path: str) -> None:
         event_count = 0
-        begin_time: Optional[int] = None
-        end_time: int
+        begin_msg: Any = None
+        end_msg: Any = None
 
         for msg in bt2.TraceCollectionMessageIterator(events_path):
             if type(msg) is bt2._EventMessageConst:
                 event_count += 1
 
-            if not begin_time and type(msg) is bt2._PacketBeginningMessageConst:
-                begin_time = msg.default_clock_snapshot.ns_from_origin
-            elif type(msg) is bt2._PacketEndMessageConst:
-                end_time = msg.default_clock_snapshot.ns_from_origin
             # Check for traces lost
-            elif(type(msg) is bt2._DiscardedEventsMessageConst):
+            if(type(msg) is bt2._DiscardedEventsMessageConst):
                 msg = ('Tracer discarded '
                        f'{msg.count} events between '
                        f'{msg.beginning_default_clock_snapshot.ns_from_origin} and '
                        f'{msg.end_default_clock_snapshot.ns_from_origin}.')
                 logger.warning(msg)
+                continue
 
-        assert begin_time is not None
-        self._begin_time: int = begin_time
-        self._end_time: int = end_time
+            if type(msg) is bt2._EventMessageConst:
+                if not begin_msg:
+                    begin_msg = msg
+                end_msg = msg
+
+        assert begin_msg is not None
+        assert end_msg is not None
+        # NOTE: Begin_time and end_time should be the same time as the PicleEventCollection.
+        self._begin_time: int = begin_msg.default_clock_snapshot.ns_from_origin
+        self._end_time: int = end_msg.default_clock_snapshot.ns_from_origin
         self._size = event_count
         self._events = self._to_dicts(events_path, event_count)
 


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

This PR fixes a bug where duration_filter results differed depending on whether the cache exists.
See attached figure for the cause of the bug.

![image](https://user-images.githubusercontent.com/19860128/192192143-1b2ca1b1-9bc5-41cd-9cb5-0a994caa5b86.png)

