### PR TITLE
feat(runtime): add callbacks property in Plot object

### DIFF
--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -300,6 +300,23 @@ class Path(PathBase, Summarizable):
         return self._value.summary
 
     @property
+    def callbacks(self) -> List[CallbackBase]:
+        """
+        Get callbacks.
+
+        Returns
+        -------
+        List[CallbackBase]
+            callbacks in all nodes that comprise the node path.
+
+        """
+        callbacks = [comm.publish_node.callbacks
+                     for comm in self.communications]
+        callbacks.extend(self.communications[-1].subscribe_node.callbacks)
+
+        return callbacks
+
+    @property
     def callback_chain(self) -> Optional[List[CallbackBase]]:
         """
         Get callback chain.

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -310,9 +310,12 @@ class Path(PathBase, Summarizable):
             callbacks in all nodes that comprise the node path.
 
         """
-        callbacks = [comm.publish_node.callbacks
-                     for comm in self.communications]
-        callbacks.extend(self.communications[-1].subscribe_node.callbacks)
+        callbacks = Util.flatten(
+            comm.publish_node.callbacks for comm in self.communications
+            if comm.publish_node.callbacks
+        )
+        if self.communications[-1].subscribe_node.callbacks is not None:
+            callbacks.extend(self.communications[-1].subscribe_node.callbacks)
 
         return callbacks
 


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

This PR adds the `Path.callbacks` property that returns callbacks in all nodes that comprise the node path.
The implementation is the same as follows: https://github.com/tier4/CARET_analyze/blob/2202e1b133fe89a5fe56b9081ff9482128d8a4f2/src/caret_analyze/plot/bokeh/callback_info_interface.py#L50.
