### PR TITLE
fix: to_dataframe type error "cannot cast from dtype('float64') to dtype('int64')"

### DIFF
--- a/src/caret_analyze/record/record.py
+++ b/src/caret_analyze/record/record.py
@@ -309,10 +309,19 @@ class Records(RecordsInterface):
         # so here uses a dictionary type.
         df_dict: Dict[str, List[Optional[int]]]
         df_dict = {c: [None]*len(df_list) for c in columns}
+
+        int64_max = 2**63-1
+
         for i, df_row in enumerate(df_list):
             for c in columns:
                 if c in df_row:
-                    df_dict[c][i] = df_row[c]
+                    # uint64 to int64 conversion.
+                    # This is workaround to fix some uint64 trace points.
+                    if df_row[c] <= int64_max:
+                        df_dict[c][i] = df_row[c]
+                    else:
+                        # convert uint64 to int64
+                        df_dict[c][i] = ~(df_row[c] & int64_max)
 
         df = pd.DataFrame(df_dict, dtype='Int64')
 


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

This PR fixes following error as workaround

```
Lttng('/path/to/ctf')


---
TypeError: Cannot cast array data from dtype('float64') to dtype('int64') according to the rule 'safe'

The above exception was the direct cause of the following exception:

TypeError                                 Traceback (most recent call last)
Input In [2], in <cell line: 1>()
----> 1 lttng = Lttng('autoware_without_tilde')

File ~/ros2_caret_ws/build/caret_analyze/caret_analyze/infra/lttng/lttng.py:231, in Lttng.__init__(self, trace_dir_or_events, force_conversion, event_filters, store_events, validate)
    229 self._info = LttngInfo(data)
    230 self._source: RecordsSource = RecordsSource(data, self._info)
--> 231 self._counter = EventCounter(data, validate=validate)
    232 self.events = events
    233 self._begin = begin
```

## To reproduce 

Data can be download [here](https://drive.google.com/drive/folders/1a-bQ5Q_3-6rgGZ2dFteYVHGwVLMCfggn?usp=sharing).

## Cause

The cause of this error is type miss match.
Following code is minimum sample.

```
import pandas as pd
pd.DataFrame({'a': [2**63, 0]}, dtype='Int64')

---
TypeError: Cannot cast array data from dtype('float64') to dtype('int64') according to the rule 'safe'
```
Note that numbers over 2**63 cannot convert to int64.

There are options to solve; unify Int64 or UInt64.
I'm planning to unify trace points into Int64 because official packages are using int64 and some arguments of trace points may have negative value.
(message time stamp possibly have negative value.)

Though modifying trace points argument into int64 is right solution, it may break trace data compatibility.
So I'm thinking to fix as a workaround.


