### PR TITLE
feat(lttng): add node name to warning message

### DIFF
--- a/src/caret_analyze/infra/lttng/lttng_info.py
+++ b/src/caret_analyze/infra/lttng/lttng_info.py
@@ -25,6 +25,7 @@ import numpy as np
 import pandas as pd
 
 from .ros2_tracing.data_model import Ros2DataModel
+from .ros2_tracing.data_model_service import DataModelService
 from .value_objects import (CallbackGroupValueLttng, NodeValueLttng,
                             PublisherValueLttng,
                             SubscriptionCallbackValueLttng,
@@ -1155,7 +1156,13 @@ class DataFrameFormatted:
                 msg = ('Multiple executors using the same callback group were detected.'
                        'The last executor will be used. ')
                 exec_addr = list(group['executor_addr'].values)
-                msg += f'executor address: {exec_addr}'
+                msg += f'executor address: {exec_addr}. '
+                data_model_srv = DataModelService(data)
+                cbg_addr = list(group['callback_group_addr'].values)
+                node_names = Util.flatten(data_model_srv.get_node_names(addr)
+                                          for addr in cbg_addr)
+                if node_names:
+                    msg += f'node name: {sorted(set(node_names))}.'
                 logger.warn(msg)
                 executor_duplicated_indexes += list(group.index)[:-1]
 


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

This PR adds the target node name to the following warning message.
`Multiple executors using the same callback group were detected`

To reproduce: https://drive.google.com/drive/folders/1AomDMGYDyyg2wdUgaLijN9Nq_smIbvCV?usp=sharing

