### PR TITLE
feat: add api showing histogram of response time

### DIFF
--- a/src/caret_analyze/plot/bokeh/histogram.py
+++ b/src/caret_analyze/plot/bokeh/histogram.py
@@ -1,0 +1,38 @@
+from .histogram_interface import HistPlot
+from bokeh.plotting import ColumnDataSource, Figure, figure, save, show
+
+class ResponseTimePlot(HistPlot):
+	def __init__(
+		self,
+		target,
+		case = 'default'
+	):
+		if case not in ['default', 'best', 'worst']:
+			raise UnsupportedTypeError(
+				f'Unsupported "case". case = {case}.'
+				'supported "case": [default/best/worst]'
+			)
+		super().__init__(target)
+		self._case = case
+		self._target = target
+
+	def _show_core(self):
+		if self._case == 'default':
+			hist, bins = self._target.to_histogram(binsize_ns=10000000)
+		elif self._case == 'best':
+			hist, bins = self._target.to_best_case_histogram(binsize_ns=10000000)
+		elif self._case == 'worst':
+			hist, bins = self._target.to_worst_case_histogram(binsize_ns=10000000)
+		
+		p = figure(plot_width=600, 
+				   plot_height=400,
+				   active_scroll='wheel_zoom',
+				   x_axis_label='Response Time [ms] (period: 10ms)', 
+				   y_axis_label='Probability')
+		hist = hist / sum(hist)
+
+		bins = bins*10**-6
+		p.quad(top=hist, bottom=0, left=bins[:-1], right=bins[1:],
+		       line_color="white", alpha=0.5)
+		show(p)
+		return p

--- a/src/caret_analyze/plot/bokeh/histogram.py
+++ b/src/caret_analyze/plot/bokeh/histogram.py
@@ -23,11 +23,11 @@ class ResponseTimePlot(HistPlot):
 			hist, bins = self._target.to_best_case_histogram(binsize_ns=10000000)
 		elif self._case == 'worst':
 			hist, bins = self._target.to_worst_case_histogram(binsize_ns=10000000)
-		
-		p = figure(plot_width=600, 
+
+		p = figure(plot_width=600,
 				   plot_height=400,
 				   active_scroll='wheel_zoom',
-				   x_axis_label='Response Time [ms] (period: 10ms)', 
+				   x_axis_label='Response Time [ms] (period: 10ms)',
 				   y_axis_label='Probability')
 		hist = hist / sum(hist)
 

--- a/src/caret_analyze/plot/bokeh/histogram_interface.py
+++ b/src/caret_analyze/plot/bokeh/histogram_interface.py
@@ -1,0 +1,21 @@
+from abc import ABCMeta, abstractmethod
+
+from bokeh.plotting import ColumnDataSource, Figure, figure, save, show
+
+
+class HistPlot(metaclass=ABCMeta):
+	def __init__(
+		self,
+		target
+	):
+		super().__init__()
+
+	def show(
+		self
+	):
+
+		return self._show_core()
+
+	@abstractmethod
+	def _show_core(self):
+		pass

--- a/src/caret_analyze/plot/bokeh/plot_factory.py
+++ b/src/caret_analyze/plot/bokeh/plot_factory.py
@@ -23,6 +23,7 @@ from .communication_info import (CommunicationFrequencyPlot,
                                  CommunicationLatencyPlot,
                                  CommunicationPeriodPlot)
 from .communication_info_interface import CommunicationTimeSeriesPlot
+from .histogram import ResponseTimePlot
 from .pub_sub_info import PubSubFrequencyPlot, PubSubPeriodPlot
 from .pub_sub_info_interface import PubSubTimeSeriesPlot
 from ...runtime import (Application, CallbackBase, CallbackGroup,
@@ -153,3 +154,8 @@ class Plot:
         *communications: Communication
     ) -> CommunicationTimeSeriesPlot:
         return CommunicationPeriodPlot(*communications)
+
+    @staticmethod
+    def create_response_time_histogram_plot(
+        *response_time):
+        return ResponseTimePlot(*response_time)


### PR DESCRIPTION
Add histogram API.
API written on ROSCon slide.

Use method.
```
arch = Architecture('yaml', arch_file)
lttng = Lttng(trace_data)
app = Application(arch, lttng)
path = app.get_path(target_path)
records = path.to_records()
response = ResponseTime(records)

plot = Plot.create_response_time_histogram_plot(response)
plot.show()
```

@hsgwa 
This is draft PR.
Please check whether this construct is OK.
If it is OK,  I will ask @bopeng-saitama to implement detail.