### PR TITLE
feat: add node names in warning message when callback group not found

### DIFF
--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -215,6 +215,7 @@ class NodeValuesLoaded():
         self,
         reader: ArchitectureReader,
     ) -> None:
+        self._reader = reader
         nodes_struct: List[NodeStruct] = []
         self._cb_loaded: List[CallbacksLoaded] = []
         self._cbg_loaded: List[CallbackGroupsLoaded] = []
@@ -327,7 +328,10 @@ class NodeValuesLoaded():
             except ItemNotFoundError:
                 pass
 
-        msg = f'Failed to find callback group. callback_group_id={callback_group_id}'
+        msg = f'Failed to find callback group. callback_group_id: {callback_group_id}. '
+        node_names = self._reader.get_node_names(callback_group_id)
+        if node_names:
+            msg += f'node_name: {node_names}.'
         raise ItemNotFoundError(msg)
 
     def find_callback(
@@ -1283,6 +1287,9 @@ class TopicIgnoredReader(ArchitectureReader):
 
     def get_paths(self) -> Sequence[PathValue]:
         return self._reader.get_paths()
+
+    def get_node_names(self, callback_group_id: str) -> Sequence[str]:
+        return self._reader.get_node_names(callback_group_id)
 
     def get_nodes(self) -> Sequence[NodeValueWithId]:
         return self._reader.get_nodes()

--- a/src/caret_analyze/architecture/reader_interface.py
+++ b/src/caret_analyze/architecture/reader_interface.py
@@ -35,7 +35,7 @@ class ArchitectureReader(metaclass=ABCMeta):
         callback_group_id: str
     ) -> Sequence[str]:
         """
-        Get node names from callback group address.
+        Get node names from callback group id.
 
         Returns
         -------

--- a/src/caret_analyze/architecture/reader_interface.py
+++ b/src/caret_analyze/architecture/reader_interface.py
@@ -30,6 +30,22 @@ class ArchitectureReader(metaclass=ABCMeta):
     """Architecture reader base class."""
 
     @abstractmethod
+    def get_node_names(
+        self,
+        callback_group_id: str
+    ) -> Sequence[str]:
+        """
+        Get node names from callback group address.
+
+        Returns
+        -------
+        Sequence[str]
+            node names.
+
+        """
+        pass
+
+    @abstractmethod
     def get_nodes(
         self
     ) -> Sequence[NodeValueWithId]:

--- a/src/caret_analyze/infra/lttng/architecture_reader_lttng.py
+++ b/src/caret_analyze/infra/lttng/architecture_reader_lttng.py
@@ -41,6 +41,9 @@ class ArchitectureReaderLttng(ArchitectureReader):
             trace_dir, event_filters=[LttngEventFilter.init_pass_filter()],
             validate=False)
 
+    def get_node_names(self, callback_group_id: str) -> Sequence[str]:
+        return self._lttng.get_node_names(callback_group_id)
+
     def get_nodes(self) -> Sequence[NodeValueWithId]:
         return self._lttng.get_nodes()
 

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -30,7 +30,8 @@ from .lttng_event_filter import LttngEventFilter
 from .ros2_tracing.data_model import Ros2DataModel
 from .ros2_tracing.data_model_service import DataModelService
 from .ros2_tracing.processor import get_field, Ros2Handler
-from .value_objects import (PublisherValueLttng,
+from .value_objects import (CallbackGroupId,
+                            PublisherValueLttng,
                             SubscriptionCallbackValueLttng,
                             TimerCallbackValueLttng)
 from ..infra_base import InfraBase
@@ -315,7 +316,7 @@ class Lttng(InfraBase):
 
         """
         data_model_srv = DataModelService(self.data)
-        cbg_addr = int(callback_group_id.replace('callback_group_', ''))
+        cbg_addr = CallbackGroupId(callback_group_id).group_addr
 
         return data_model_srv.get_node_names(cbg_addr)
 

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -28,6 +28,7 @@ from tqdm import tqdm
 from .events_factory import EventsFactory
 from .lttng_event_filter import LttngEventFilter
 from .ros2_tracing.data_model import Ros2DataModel
+from .ros2_tracing.data_model_service import DataModelService
 from .ros2_tracing.processor import get_field, Ros2Handler
 from .value_objects import (PublisherValueLttng,
                             SubscriptionCallbackValueLttng,
@@ -302,6 +303,21 @@ class Lttng(InfraBase):
 
         events_ = None if len(events) == 0 else events
         return data, events_, begin, end
+
+    def get_node_names(self, callback_group_id: str) -> Sequence[str]:
+        """
+        Get node names from callback group address.
+
+        Returns
+        -------
+        Sequence[str]
+            node names.
+
+        """
+        data_model_srv = DataModelService(self.data)
+        cbg_addr = int(callback_group_id.replace('callback_group_', ''))
+
+        return data_model_srv.get_node_names(cbg_addr)
 
     def get_nodes(
         self

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -307,7 +307,7 @@ class Lttng(InfraBase):
 
     def get_node_names(self, callback_group_id: str) -> Sequence[str]:
         """
-        Get node names from callback group address.
+        Get node names from callback group id.
 
         Returns
         -------

--- a/src/caret_analyze/infra/lttng/lttng_info.py
+++ b/src/caret_analyze/infra/lttng/lttng_info.py
@@ -26,7 +26,9 @@ import pandas as pd
 
 from .ros2_tracing.data_model import Ros2DataModel
 from .ros2_tracing.data_model_service import DataModelService
-from .value_objects import (CallbackGroupValueLttng, NodeValueLttng,
+from .value_objects import (CallbackGroupAddr,
+                            CallbackGroupValueLttng,
+                            NodeValueLttng,
                             PublisherValueLttng,
                             SubscriptionCallbackValueLttng,
                             TimerCallbackValueLttng,
@@ -1140,7 +1142,7 @@ class DataFrameFormatted:
 
         def to_callback_group_id(row: pd.Series) -> str:
             addr = row['callback_group_addr']
-            return f'callback_group_{addr}'
+            return CallbackGroupAddr(addr).group_id
 
         df = DataFrameFormatted._add_column(df, 'callback_group_id', to_callback_group_id)
         df = DataFrameFormatted._ensure_columns(df, columns)

--- a/src/caret_analyze/infra/lttng/value_objects/__init__.py
+++ b/src/caret_analyze/infra/lttng/value_objects/__init__.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 from .callback import SubscriptionCallbackValueLttng, TimerCallbackValueLttng
-from .callback_group import CallbackGroupValueLttng
+from .callback_group import CallbackGroupAddr, CallbackGroupId, CallbackGroupValueLttng
 from .node import NodeValueLttng
 from .publisher import PublisherValueLttng
 from .timer_control import TimerControl, TimerInit
 
 __all__ = [
+    'CallbackGroupAddr',
+    'CallbackGroupId',
     'CallbackGroupValueLttng',
     'NodeValueLttng',
     'PublisherValueLttng',

--- a/src/caret_analyze/infra/lttng/value_objects/callback_group.py
+++ b/src/caret_analyze/infra/lttng/value_objects/callback_group.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Tuple
 
-from ....value_objects import CallbackGroupValue
+from ....value_objects import CallbackGroupValue, ValueObject
 
 
 class CallbackGroupValueLttng(CallbackGroupValue):
@@ -46,3 +46,37 @@ class CallbackGroupValueLttng(CallbackGroupValue):
     @property
     def executor_addr(self) -> int:
         return self._executor_addr
+
+
+class CallbackGroupAddr(ValueObject):
+
+    def __init__(self, callback_group_addr: int) -> None:
+        self._callback_group_addr = callback_group_addr
+
+    def __str__(self) -> str:
+        return str(self._callback_group_addr)
+
+    @property
+    def group_id(self) -> str:
+        return self.to_id(self._callback_group_addr)
+
+    @staticmethod
+    def to_id(callback_group_addr: int) -> str:
+        return f'callback_group_{callback_group_addr}'
+
+
+class CallbackGroupId(ValueObject):
+
+    def __init__(self, callback_group_id: str) -> None:
+        self._callback_group_id = callback_group_id
+
+    def __str__(self) -> str:
+        return self._callback_group_id
+
+    @property
+    def group_addr(self) -> int:
+        return self.to_addr(self._callback_group_id)
+
+    @staticmethod
+    def to_addr(callback_group_id: str) -> int:
+        return int(callback_group_id.replace('callback_group_', ''))

--- a/src/caret_analyze/infra/yaml/architecture_reader_yaml.py
+++ b/src/caret_analyze/infra/yaml/architecture_reader_yaml.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from logging import getLogger
 from typing import Any, Dict, List, Sequence
 
 import yaml
@@ -25,6 +26,8 @@ from ...value_objects import (CallbackGroupValue, CallbackType, ExecutorValue,
                               SubscriptionCallbackValue, SubscriptionValue,
                               TimerCallbackValue, TimerValue, VariablePassingValue)
 
+logger = getLogger(__name__)
+
 
 class ArchitectureReaderYaml(ArchitectureReader):
 
@@ -35,6 +38,10 @@ class ArchitectureReaderYaml(ArchitectureReader):
 
         if self._arch is None:
             raise InvalidYamlFormatError('Failed to parse yaml.')
+
+    def get_node_names(self, callback_group_id: str) -> Sequence[str]:
+        logger.warning('get_node_names method is not implemented in ArchitectureReaderYaml class.')
+        return []
 
     def get_nodes(self) -> Sequence[NodeValueWithId]:
         nodes_dict = self._get_value(self._arch, 'nodes')


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

This PR adds the target node name to the following warning message.
`Failed to find callback group`

To reproduce: https://drive.google.com/drive/folders/1AomDMGYDyyg2wdUgaLijN9Nq_smIbvCV?usp=sharing