### PR TITLE
feat: add api showing histogram of response time

### DIFF
--- a/src/caret_analyze/plot/bokeh/histogram.py
+++ b/src/caret_analyze/plot/bokeh/histogram.py
@@ -6,6 +6,8 @@ from caret_analyze.record import ResponseTime
 
 from .histogram_interface import HistPlot
 
+from .plot_util import PlotColorSelector
+
 
 class ResponseTimePlot(HistPlot):
 
@@ -23,12 +25,15 @@ class ResponseTimePlot(HistPlot):
         self._case = case
 
     def _show_core(self):
-        for i, path in enumerate(self._target, 1):
-            try:
-                records = path.to_records()
-                response = ResponseTime(records)
-            except IndexError:
-                pass
+        p = figure(plot_width=600,
+                   plot_height=400,
+                   active_scroll='wheel_zoom',
+                   x_axis_label='Response Time [ms]',
+                   y_axis_label='Probability')
+        color_selector = PlotColorSelector()
+        for _, path in enumerate(self._target):
+            records = path.to_records()
+            response = ResponseTime(records)
 
             if self._case == 'default':
                 hist, bins = response.to_histogram(binsize_ns=10000000)
@@ -37,15 +42,10 @@ class ResponseTimePlot(HistPlot):
             elif self._case == 'worst':
                 hist, bins = response.to_worst_case_histogram(binsize_ns=10000000)
 
-            p = figure(plot_width=600,
-                       plot_height=400,
-                       title=f'{path.path_name}',
-                       active_scroll='wheel_zoom',
-                       x_axis_label='Response Time [ms] (period: 10ms)',
-                       y_axis_label='Probability')
             hist = hist / sum(hist)
 
             bins = bins*10**-6
+            color = color_selector.get_color(path.path_name)
             p.quad(top=hist, bottom=0, left=bins[:-1], right=bins[1:],
-                   line_color='white', alpha=0.5)
-            show(p)
+                   color=color, alpha=0.5, legend_label=f'{path.path_name}')
+        show(p)

--- a/src/caret_analyze/plot/bokeh/histogram.py
+++ b/src/caret_analyze/plot/bokeh/histogram.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Collection
+
 from bokeh.plotting import figure, show
 
 from caret_analyze.exceptions import UnsupportedTypeError
@@ -22,14 +24,16 @@ from .histogram_interface import HistPlot
 
 from .plot_util import PlotColorSelector
 
+from ...runtime import Path
+
 
 class ResponseTimePlot(HistPlot):
 
     def __init__(
         self,
-        target,
-        case='best-to-worst',
-        binsize_ns=10000000
+        target: Collection[Path],
+        case: str = 'best-to-worst',
+        binsize_ns: int = 10000000
     ):
         if case not in ['best-to-worst', 'best', 'worst']:
             raise UnsupportedTypeError(

--- a/src/caret_analyze/plot/bokeh/histogram.py
+++ b/src/caret_analyze/plot/bokeh/histogram.py
@@ -28,15 +28,17 @@ class ResponseTimePlot(HistPlot):
     def __init__(
         self,
         target,
-        case='default'
+        case='best-to-worst',
+        binsize_ns=10000000
     ):
-        if case not in ['default', 'best', 'worst']:
+        if case not in ['best-to-worst', 'best', 'worst']:
             raise UnsupportedTypeError(
                 f'Unsupported "case". case = {case}.'
-                'supported "case": [default/best/worst]'
+                'supported "case": [best-to-worst/best/worst]'
             )
         super().__init__(target)
         self._case = case
+        self._binsize_ns = binsize_ns
 
     def _show_core(self):
         p = figure(plot_width=600,
@@ -49,12 +51,12 @@ class ResponseTimePlot(HistPlot):
             records = path.to_records()
             response = ResponseTime(records)
 
-            if self._case == 'default':
-                hist, bins = response.to_histogram(binsize_ns=10000000)
+            if self._case == 'best-to-worst':
+                hist, bins = response.to_histogram(self._binsize_ns)
             elif self._case == 'best':
-                hist, bins = response.to_best_case_histogram(binsize_ns=10000000)
+                hist, bins = response.to_best_case_histogram(self._binsize_ns)
             elif self._case == 'worst':
-                hist, bins = response.to_worst_case_histogram(binsize_ns=10000000)
+                hist, bins = response.to_worst_case_histogram(self._binsize_ns)
 
             hist = hist / sum(hist)
 

--- a/src/caret_analyze/plot/bokeh/histogram.py
+++ b/src/caret_analyze/plot/bokeh/histogram.py
@@ -1,0 +1,51 @@
+from bokeh.plotting import figure, show
+
+from caret_analyze.exceptions import UnsupportedTypeError
+
+from caret_analyze.record import ResponseTime
+
+from .histogram_interface import HistPlot
+
+
+class ResponseTimePlot(HistPlot):
+
+    def __init__(
+        self,
+        target,
+        case='default'
+    ):
+        if case not in ['default', 'best', 'worst']:
+            raise UnsupportedTypeError(
+                f'Unsupported "case". case = {case}.'
+                'supported "case": [default/best/worst]'
+            )
+        super().__init__(target)
+        self._case = case
+
+    def _show_core(self):
+        for i, path in enumerate(self._target, 1):
+            try:
+                records = path.to_records()
+                response = ResponseTime(records)
+            except IndexError:
+                pass
+
+            if self._case == 'default':
+                hist, bins = response.to_histogram(binsize_ns=10000000)
+            elif self._case == 'best':
+                hist, bins = response.to_best_case_histogram(binsize_ns=10000000)
+            elif self._case == 'worst':
+                hist, bins = response.to_worst_case_histogram(binsize_ns=10000000)
+
+            p = figure(plot_width=600,
+                       plot_height=400,
+                       title=f'{path.path_name}',
+                       active_scroll='wheel_zoom',
+                       x_axis_label='Response Time [ms] (period: 10ms)',
+                       y_axis_label='Probability')
+            hist = hist / sum(hist)
+
+            bins = bins*10**-6
+            p.quad(top=hist, bottom=0, left=bins[:-1], right=bins[1:],
+                   line_color='white', alpha=0.5)
+            show(p)

--- a/src/caret_analyze/plot/bokeh/histogram.py
+++ b/src/caret_analyze/plot/bokeh/histogram.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from bokeh.plotting import figure, show
 
 from caret_analyze.exceptions import UnsupportedTypeError
@@ -49,3 +63,4 @@ class ResponseTimePlot(HistPlot):
             p.quad(top=hist, bottom=0, left=bins[:-1], right=bins[1:],
                    color=color, alpha=0.5, legend_label=f'{path.path_name}')
         show(p)
+        return p

--- a/src/caret_analyze/plot/bokeh/histogram_interface.py
+++ b/src/caret_analyze/plot/bokeh/histogram_interface.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from abc import ABCMeta, abstractmethod
 from typing import Collection
 

--- a/src/caret_analyze/plot/bokeh/histogram_interface.py
+++ b/src/caret_analyze/plot/bokeh/histogram_interface.py
@@ -1,0 +1,21 @@
+from abc import ABCMeta, abstractmethod
+from typing import Collection
+
+from ...runtime import Path
+
+
+class HistPlot(metaclass=ABCMeta):
+    def __init__(
+        self,
+        target: Collection[Path]
+    ) -> None:
+        self._target = list(target)
+
+    def show(
+        self
+    ):
+        return self._show_core()
+
+    @abstractmethod
+    def _show_core(self):
+        pass

--- a/src/caret_analyze/plot/bokeh/plot_factory.py
+++ b/src/caret_analyze/plot/bokeh/plot_factory.py
@@ -269,7 +269,7 @@ class Plot:
         case: str = 'best-to-worst',
         binsize_ns: int = 10000000
     ) -> ResponseTimePlot:
-        return ResponseTimePlot(paths, case, binsize_ns)
+        return ResponseTimePlot(paths, case, int(binsize_ns))
 
     @staticmethod
     @create_response_time_histogram_plot.register
@@ -278,4 +278,4 @@ class Plot:
         case: str = 'best-to-worst',
         binsize_ns: int = 10000000
     ) -> ResponseTimePlot:
-        return ResponseTimePlot(paths, case, binsize_ns)
+        return ResponseTimePlot(paths, case, int(binsize_ns))

--- a/src/caret_analyze/plot/bokeh/plot_factory.py
+++ b/src/caret_analyze/plot/bokeh/plot_factory.py
@@ -15,6 +15,8 @@
 from logging import getLogger
 from typing import Collection, Union
 
+from matplotlib.path import Path
+
 from multimethod import multimethod as singledispatchmethod
 
 from .callback_info import (CallbackFrequencyPlot,
@@ -25,6 +27,7 @@ from .communication_info import (CommunicationFrequencyPlot,
                                  CommunicationLatencyPlot,
                                  CommunicationPeriodPlot)
 from .communication_info_interface import CommunicationTimeSeriesPlot
+from .histogram import ResponseTimePlot
 from .pub_sub_info import PubSubFrequencyPlot, PubSubPeriodPlot
 from .pub_sub_info_interface import PubSubTimeSeriesPlot
 from ...exceptions import InvalidArgumentError
@@ -242,3 +245,35 @@ class Plot:
         *communications: Communication
     ) -> CommunicationTimeSeriesPlot:
         return CommunicationPeriodPlot(communications)
+
+    @singledispatchmethod
+    def create_response_time_histogram_plot(arg) -> TimeSeriesPlot:
+        """
+        Get ResponseTimePlot instance.
+
+        Parameters
+        ----------
+        path : Collection[Path]
+            Target path.
+            This also accepts multiple path inputs by unpacking.
+
+        Returns
+        -------
+        ResponseTimePlot
+
+        """
+        raise InvalidArgumentError(f'Unknown argument type: {arg}')
+
+    @staticmethod
+    @create_response_time_histogram_plot.register
+    def _create_response_time_histogram_plot(
+        paths: Collection[Path]
+    ) -> ResponseTimePlot:
+        return ResponseTimePlot(paths)
+
+    @staticmethod
+    @create_response_time_histogram_plot.register
+    def _create_response_time_histogram_plot_tuple(
+        *paths: Path
+    ) -> ResponseTimePlot:
+        return ResponseTimePlot(paths)

--- a/src/caret_analyze/plot/bokeh/plot_factory.py
+++ b/src/caret_analyze/plot/bokeh/plot_factory.py
@@ -15,8 +15,6 @@
 from logging import getLogger
 from typing import Collection, Union
 
-from matplotlib.path import Path
-
 from multimethod import multimethod as singledispatchmethod
 
 from .callback_info import (CallbackFrequencyPlot,
@@ -31,7 +29,7 @@ from .histogram import ResponseTimePlot
 from .pub_sub_info import PubSubFrequencyPlot, PubSubPeriodPlot
 from .pub_sub_info_interface import PubSubTimeSeriesPlot
 from ...exceptions import InvalidArgumentError
-from ...runtime import (CallbackBase, Communication, Publisher, Subscription)
+from ...runtime import (CallbackBase, Communication, Path, Publisher, Subscription)
 
 logger = getLogger(__name__)
 
@@ -267,13 +265,17 @@ class Plot:
     @staticmethod
     @create_response_time_histogram_plot.register
     def _create_response_time_histogram_plot(
-        paths: Collection[Path]
+        paths: Collection[Path],
+        case: str,
+        binsize_ns: int
     ) -> ResponseTimePlot:
-        return ResponseTimePlot(paths)
+        return ResponseTimePlot(paths, case, binsize_ns)
 
     @staticmethod
     @create_response_time_histogram_plot.register
     def _create_response_time_histogram_plot_tuple(
-        *paths: Path
+        *paths: Path,
+        case: str,
+        binsize_ns: int
     ) -> ResponseTimePlot:
-        return ResponseTimePlot(paths)
+        return ResponseTimePlot(paths, case, binsize_ns)

--- a/src/caret_analyze/plot/bokeh/plot_factory.py
+++ b/src/caret_analyze/plot/bokeh/plot_factory.py
@@ -266,8 +266,8 @@ class Plot:
     @create_response_time_histogram_plot.register
     def _create_response_time_histogram_plot(
         paths: Collection[Path],
-        case: str,
-        binsize_ns: int
+        case: str = 'best-to-worst',
+        binsize_ns: int = 10000000
     ) -> ResponseTimePlot:
         return ResponseTimePlot(paths, case, binsize_ns)
 
@@ -275,7 +275,7 @@ class Plot:
     @create_response_time_histogram_plot.register
     def _create_response_time_histogram_plot_tuple(
         *paths: Path,
-        case: str,
-        binsize_ns: int
+        case: str = 'best-to-worst',
+        binsize_ns: int = 10000000
     ) -> ResponseTimePlot:
         return ResponseTimePlot(paths, case, binsize_ns)


### PR DESCRIPTION
Signed-off-by: bopeng-saitama <peng.b.203@ms.saitama-u.ac.jp>

Add histogram API.
Use method.
```
arch = Architecture('yaml', arch_file)
lttng = Lttng(trace_data)
app = Application(arch, lttng)
path = app.get_path(target_path)
path1 =  app.get_path('target_path')
path2 =  app.get_path('Sensing')
plot = Plot.create_response_time_histogram_plot(path1,path2)
plot.show()
```