### PR TITLE
feat(record): add API to get latency time-series data

### DIFF
--- a/src/caret_analyze/record/__init__.py
+++ b/src/caret_analyze/record/__init__.py
@@ -14,6 +14,7 @@
 
 from .column import Column, Columns, ColumnValue
 from .data_frame_shaper import Clip, DataFrameShaper, Strip
+from .latency import Latency
 from .record import (merge,
                      merge_sequential,
                      merge_sequential_for_addr_track,
@@ -31,6 +32,7 @@ __all__ = [
     'Columns',
     'ColumnValue',
     'DataFrameShaper',
+    'Latency',
     'Record',
     'RecordFactory',
     'RecordInterface',

--- a/src/caret_analyze/record/latency.py
+++ b/src/caret_analyze/record/latency.py
@@ -70,8 +70,6 @@ class Latency:
 
         """
         records = self._create_empty_records()
-        if not self._start_timestamps or not self._end_timestamps:
-            return records
 
         for start_ts, end_ts in zip(self._start_timestamps, self._end_timestamps):
             records.append(RecordFactory.create_instance(

--- a/src/caret_analyze/record/latency.py
+++ b/src/caret_analyze/record/latency.py
@@ -1,0 +1,89 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Optional
+
+from .column import ColumnValue
+from .interface import RecordsInterface
+from .record_factory import RecordFactory, RecordsFactory
+
+
+class Latency:
+
+    def __init__(
+        self,
+        records: RecordsInterface,
+        start_column: Optional[str] = None,
+        end_column: Optional[str] = None
+    ) -> None:
+        """
+        Constructor.
+
+        Parameters
+        ----------
+        records : RecordsInterface
+            records to calculate latency.
+        start_column : Optional[str], optional
+            Column name of start timestamps used in the calculation, by default None
+            If None, the first column of records is selected.
+        end_column : Optional[str], optional
+            Column name of end timestamps used in the calculation, by default None
+            If None, the last column of records is selected.
+
+        """
+        self._start_column = start_column or records.columns[0]
+        self._end_column = end_column or records.columns[-1]
+
+        self._start_timestamps: List[int] = []
+        self._end_timestamps: List[int] = []
+        for record in records:
+            if (self._start_column not in record.columns or
+                    self._end_column not in record.columns):
+                continue
+            start_ts = record.get(self._start_column)
+            self._start_timestamps.append(start_ts)
+            end_ts = record.get(self._end_column)
+            self._end_timestamps.append(end_ts)
+
+    def to_records(self) -> RecordsInterface:
+        """
+        Calculate latency records.
+
+        Returns
+        -------
+        RecordsInterface
+            latency records.
+            Columns
+            - {start_timestamp_column}
+            - {latency_column}
+
+        """
+        records = self._create_empty_records()
+        if not self._start_timestamps or not self._end_timestamps:
+            return records
+
+        for start_ts, end_ts in zip(self._start_timestamps, self._end_timestamps):
+            records.append(RecordFactory.create_instance(
+                {self._start_column: start_ts,
+                 'latency': end_ts - start_ts}
+            ))
+
+        return records
+
+    def _create_empty_records(
+        self
+    ) -> RecordsInterface:
+        return RecordsFactory.create_instance(columns=[
+            ColumnValue(self._start_column), ColumnValue('latency')
+        ])

--- a/src/test/record/test_latency_records.py
+++ b/src/test/record/test_latency_records.py
@@ -1,0 +1,123 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from caret_analyze.record import ColumnValue
+from caret_analyze.record.latency import Latency
+from caret_analyze.record.record_factory import RecordFactory, RecordsFactory
+
+
+def create_records(records_raw, columns):
+    records = RecordsFactory.create_instance()
+    for column in columns:
+        records.append_column(column, [])
+
+    for record_raw in records_raw:
+        record = RecordFactory.create_instance(record_raw)
+        records.append(record)
+    return records
+
+
+def to_dict(records):
+    return [record.data for record in records]
+
+
+class TestLatencyRecords:
+
+    def test_empty_case(self):
+        records_raw = [
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        latency = Latency(records)
+
+        expect_raw = [
+        ]
+        result = to_dict(latency.to_records())
+        assert result == expect_raw
+
+    def test_two_column_default_case(self):
+        records_raw = [
+            {'start': 0, 'end': 2},
+            {'start': 3, 'end': 4},
+            {'start': 11, 'end': 12}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        latency = Latency(records)
+
+        expect_raw = [
+            {'start': 0, 'latency': 2},
+            {'start': 3, 'latency': 1},
+            {'start': 11, 'latency': 1}
+        ]
+        result = to_dict(latency.to_records())
+        assert result == expect_raw
+
+    def test_three_column_default_case(self):
+        records_raw = [
+            {'start': 0, 'ts': 1, 'end': 2},
+            {'start': 3, 'ts': 4, 'end': 5},
+            {'start': 11, 'ts': 12, 'end': 13}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('ts'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        latency = Latency(records)
+
+        expect_raw = [
+            {'start': 0, 'latency': 2},
+            {'start': 3, 'latency': 2},
+            {'start': 11, 'latency': 2}
+        ]
+        result = to_dict(latency.to_records())
+        assert result == expect_raw
+
+    def test_specify_target_column_case(self):
+        records_raw = [
+            {'start': 0, 'end': 1, 'ts': 2},
+            {'start': 3, 'end': 4, 'ts': 5},
+            {'start': 11, 'end': 12, 'ts': 13}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end'), ColumnValue('ts')]
+        records = create_records(records_raw, columns)
+
+        latency = Latency(records, start_column='start', end_column='end')
+
+        expect_raw = [
+            {'start': 0, 'latency': 1},
+            {'start': 3, 'latency': 1},
+            {'start': 11, 'latency': 1}
+        ]
+        result = to_dict(latency.to_records())
+        assert result == expect_raw
+
+    def test_drop_case(self):
+        records_raw = [
+            {'start': 0, 'end': 2},
+            {'start': 3},
+            {'start': 11, 'end': 12}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        latency = Latency(records)
+
+        expect_raw = [
+            {'start': 0, 'latency': 2},
+            {'start': 11, 'latency': 1}
+        ]
+        result = to_dict(latency.to_records())
+        assert result == expect_raw


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

This PR add API to get latency time-series data in record package.
The implementation is a modification of the following parts of the plot package.
https://github.com/tier4/CARET_analyze/blob/3a1ed200e8206fe4ef7eea184325e314b597c493/src/caret_analyze/plot/bokeh/callback_info.py#L68

To reproduce: https://drive.google.com/drive/folders/1xabhXzw6DmuRrVSc-VWKRH_TrPVETjeR?usp=sharing