### PR TITLE
feat(record): add API to get period time-series data

### DIFF
--- a/src/caret_analyze/record/__init__.py
+++ b/src/caret_analyze/record/__init__.py
@@ -14,6 +14,7 @@
 
 from .column import Column, Columns, ColumnValue
 from .data_frame_shaper import Clip, DataFrameShaper, Strip
+from .period import Period
 from .record import (merge,
                      merge_sequential,
                      merge_sequential_for_addr_track,
@@ -31,6 +32,7 @@ __all__ = [
     'Columns',
     'ColumnValue',
     'DataFrameShaper',
+    'Period',
     'Record',
     'RecordFactory',
     'RecordInterface',

--- a/src/caret_analyze/record/period.py
+++ b/src/caret_analyze/record/period.py
@@ -48,7 +48,7 @@ class Period:
     def to_records(self) -> RecordsInterface:
         """
         Calculate period records.
-~
+
         Returns
         -------
         RecordsInterface

--- a/src/caret_analyze/record/period.py
+++ b/src/caret_analyze/record/period.py
@@ -48,7 +48,7 @@ class Period:
     def to_records(self) -> RecordsInterface:
         """
         Calculate period records.
-
+~
         Returns
         -------
         RecordsInterface
@@ -62,7 +62,7 @@ class Period:
 
         for i in range(1, len(self._target_timestamps)):
             records.append(RecordFactory.create_instance(
-                {self._target_column: self._target_timestamps[i],
+                {self._target_column: self._target_timestamps[i-1],
                  'period': self._target_timestamps[i] - self._target_timestamps[i-1]}
             ))
 

--- a/src/caret_analyze/record/period.py
+++ b/src/caret_analyze/record/period.py
@@ -59,8 +59,6 @@ class Period:
 
         """
         records = self._create_empty_records()
-        if not self._target_timestamps:
-            return records
 
         for i in range(1, len(self._target_timestamps)):
             records.append(RecordFactory.create_instance(

--- a/src/caret_analyze/record/period.py
+++ b/src/caret_analyze/record/period.py
@@ -1,0 +1,78 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Optional
+
+from .column import ColumnValue
+from .interface import RecordsInterface
+from .record_factory import RecordFactory, RecordsFactory
+
+
+class Period:
+
+    def __init__(
+        self,
+        records: RecordsInterface,
+        target_column: Optional[str] = None
+    ) -> None:
+        """
+        Constructor.
+
+        Parameters
+        ----------
+        records : RecordsInterface
+            records to calculate period.
+        target_column : Optional[str], optional
+            Column name of timestamps used in the calculation, by default None
+            If None, the first column of records is selected.
+
+        """
+        self._target_column = target_column or records.columns[0]
+        self._target_timestamps: List[int] = []
+        for record in records:
+            if self._target_column in record.columns:
+                timestamp = record.get(self._target_column)
+                self._target_timestamps.append(timestamp)
+
+    def to_records(self) -> RecordsInterface:
+        """
+        Calculate period records.
+
+        Returns
+        -------
+        RecordsInterface
+            period records.
+            Columns
+            - {timestamp_column}
+            - {period_column}
+
+        """
+        records = self._create_empty_records()
+        if not self._target_timestamps:
+            return records
+
+        for i in range(1, len(self._target_timestamps)):
+            records.append(RecordFactory.create_instance(
+                {self._target_column: self._target_timestamps[i],
+                 'period': self._target_timestamps[i] - self._target_timestamps[i-1]}
+            ))
+
+        return records
+
+    def _create_empty_records(
+        self
+    ) -> RecordsInterface:
+        return RecordsFactory.create_instance(columns=[
+            ColumnValue(self._target_column), ColumnValue('period')
+        ])

--- a/src/test/record/test_period.py
+++ b/src/test/record/test_period.py
@@ -60,9 +60,9 @@ class TestPeriodRecords:
         period = Period(records)
 
         expect_raw = [
-            {'timestamp': 1, 'period': 1},
-            {'timestamp': 11, 'period': 10},
-            {'timestamp': 12, 'period': 1}
+            {'timestamp': 0, 'period': 1},
+            {'timestamp': 1, 'period': 10},
+            {'timestamp': 11, 'period': 1}
         ]
         result = to_dict(period.to_records())
         assert result == expect_raw
@@ -80,9 +80,9 @@ class TestPeriodRecords:
         period = Period(records)
 
         expect_raw = [
-            {'timestamp1': 3, 'period': 3},
-            {'timestamp1': 11, 'period': 8},
-            {'timestamp1': 13, 'period': 2}
+            {'timestamp1': 0, 'period': 3},
+            {'timestamp1': 3, 'period': 8},
+            {'timestamp1': 11, 'period': 2}
         ]
         result = to_dict(period.to_records())
         assert result == expect_raw
@@ -100,9 +100,9 @@ class TestPeriodRecords:
         period = Period(records, target_column='timestamp2')
 
         expect_raw = [
-            {'timestamp2': 4, 'period': 2},
-            {'timestamp2': 12, 'period': 8},
-            {'timestamp2': 14, 'period': 2}
+            {'timestamp2': 2, 'period': 2},
+            {'timestamp2': 4, 'period': 8},
+            {'timestamp2': 12, 'period': 2}
         ]
         result = to_dict(period.to_records())
         assert result == expect_raw
@@ -120,8 +120,8 @@ class TestPeriodRecords:
         period = Period(records)
 
         expect_raw = [
-            {'timestamp1': 11, 'period': 11},
-            {'timestamp1': 13, 'period': 2}
+            {'timestamp1': 0, 'period': 11},
+            {'timestamp1': 11, 'period': 2}
         ]
         result = to_dict(period.to_records())
         assert result == expect_raw

--- a/src/test/record/test_period.py
+++ b/src/test/record/test_period.py
@@ -1,0 +1,127 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from caret_analyze.record import ColumnValue
+from caret_analyze.record.period import Period
+from caret_analyze.record.record_factory import RecordFactory, RecordsFactory
+
+
+def create_records(records_raw, columns):
+    records = RecordsFactory.create_instance()
+    for column in columns:
+        records.append_column(column, [])
+
+    for record_raw in records_raw:
+        record = RecordFactory.create_instance(record_raw)
+        records.append(record)
+    return records
+
+
+def to_dict(records):
+    return [record.data for record in records]
+
+
+class TestPeriodRecords:
+
+    def test_empty_case(self):
+        records_raw = [
+        ]
+        columns = [ColumnValue('timestamp')]
+        records = create_records(records_raw, columns)
+
+        period = Period(records)
+
+        expect_raw = [
+        ]
+        result = to_dict(period.to_records())
+        assert result == expect_raw
+
+    def test_one_column_default_case(self):
+        records_raw = [
+            {'timestamp': 0},
+            {'timestamp': 1},
+            {'timestamp': 11},
+            {'timestamp': 12}
+        ]
+        columns = [ColumnValue('timestamp')]
+        records = create_records(records_raw, columns)
+
+        period = Period(records)
+
+        expect_raw = [
+            {'timestamp': 1, 'period': 1},
+            {'timestamp': 11, 'period': 10},
+            {'timestamp': 12, 'period': 1}
+        ]
+        result = to_dict(period.to_records())
+        assert result == expect_raw
+
+    def test_two_column_default_case(self):
+        records_raw = [
+            {'timestamp1': 0, 'timestamp2': 2},
+            {'timestamp1': 3, 'timestamp2': 4},
+            {'timestamp1': 11, 'timestamp2': 12},
+            {'timestamp1': 13, 'timestamp2': 14}
+        ]
+        columns = [ColumnValue('timestamp1'), ColumnValue('timestamp2')]
+        records = create_records(records_raw, columns)
+
+        period = Period(records)
+
+        expect_raw = [
+            {'timestamp1': 3, 'period': 3},
+            {'timestamp1': 11, 'period': 8},
+            {'timestamp1': 13, 'period': 2}
+        ]
+        result = to_dict(period.to_records())
+        assert result == expect_raw
+
+    def test_specify_target_column_case(self):
+        records_raw = [
+            {'timestamp1': 0, 'timestamp2': 2},
+            {'timestamp1': 3, 'timestamp2': 4},
+            {'timestamp1': 11, 'timestamp2': 12},
+            {'timestamp1': 13, 'timestamp2': 14}
+        ]
+        columns = [ColumnValue('timestamp1'), ColumnValue('timestamp2')]
+        records = create_records(records_raw, columns)
+
+        period = Period(records, target_column='timestamp2')
+
+        expect_raw = [
+            {'timestamp2': 4, 'period': 2},
+            {'timestamp2': 12, 'period': 8},
+            {'timestamp2': 14, 'period': 2}
+        ]
+        result = to_dict(period.to_records())
+        assert result == expect_raw
+
+    def test_drop_case(self):
+        records_raw = [
+            {'timestamp1': 0, 'timestamp2': 2},
+            {'timestamp2': 4},
+            {'timestamp1': 11, 'timestamp2': 12},
+            {'timestamp1': 13, 'timestamp2': 14}
+        ]
+        columns = [ColumnValue('timestamp1'), ColumnValue('timestamp2')]
+        records = create_records(records_raw, columns)
+
+        period = Period(records)
+
+        expect_raw = [
+            {'timestamp1': 11, 'period': 11},
+            {'timestamp1': 13, 'period': 2}
+        ]
+        result = to_dict(period.to_records())
+        assert result == expect_raw


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

This PR add API to get period time-series data in record package.
The implementation is a modification of the following parts of the plot package.
https://github.com/tier4/CARET_analyze/blob/3a1ed200e8206fe4ef7eea184325e314b597c493/src/caret_analyze/plot/bokeh/callback_info.py#L122

To reproduce: https://drive.google.com/drive/folders/1BV7G34uA7cLB6XoN9xj7NAjOboh-rxmC?usp=sharing