### PR TITLE
chore: add publishers and subscriptions properties

### DIFF
--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -27,7 +27,8 @@ from ..common import Summarizable, Summary, Util
 from ..exceptions import InvalidArgumentError, ItemNotFoundError
 from ..value_objects import (CallbackGroupStructValue, CallbackStructValue,
                              CommunicationStructValue, ExecutorStructValue,
-                             NodeStructValue, PathStructValue)
+                             NodeStructValue, PathStructValue, PublisherStructValue,
+                             SubscriptionStructValue)
 
 
 class Architecture(Summarizable):
@@ -138,6 +139,16 @@ class Architecture(Summarizable):
     @property
     def communications(self) -> Tuple[CommunicationStructValue, ...]:
         return tuple([v.to_value() for v in self._communications])
+
+    @property
+    def publishers(self) -> Tuple[PublisherStructValue, ...]:
+        publishers = Util.flatten(_.publishers for _ in self.nodes)
+        return tuple(sorted(publishers, key=lambda x: x.topic_name))
+
+    @property
+    def subscriptions(self) -> Tuple[SubscriptionStructValue, ...]:
+        subscriptions = Util.flatten(_.subscriptions for _ in self.nodes)
+        return tuple(sorted(subscriptions, key=lambda x: x.topic_name))
 
     @property
     def summary(self) -> Summary:

--- a/src/caret_analyze/runtime/application.py
+++ b/src/caret_analyze/runtime/application.py
@@ -120,6 +120,34 @@ class Application(Summarizable):
         return sorted(self._communications, key=lambda x: x.topic_name)
 
     @property
+    def publishers(self) -> List[Publisher]:
+        """
+        Get publishers.
+
+        Returns
+        -------
+        List[Publisher]
+            All publishers defined in the architecture.
+
+        """
+        publishers = Util.flatten(_.publishers for _ in self.nodes)
+        return sorted(publishers, key=lambda x: x.topic_name)
+
+    @property
+    def subscriptions(self) -> List[Subscription]:
+        """
+        Get subscriptions.
+
+        Returns
+        -------
+        List[Subscription]
+            All subscriptions defined in the architecture.
+
+        """
+        subscriptions = Util.flatten(_.subscriptions for _ in self.nodes)
+        return sorted(subscriptions, key=lambda x: x.topic_name)
+
+    @property
     def paths(self) -> List[Path]:
         """
         Get paths.


### PR DESCRIPTION
This PR adds `publishers` and `subscriptions` properties.

- app.publishers / app.subscriptions
- arch.publishers / arch.subscriptions

After this PR is merged, #180 can be merged.