### PR TITLE
chore: support publisher-only / subscription-only topic names

### DIFF
--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -27,7 +27,8 @@ from ..common import Summarizable, Summary, Util
 from ..exceptions import InvalidArgumentError, ItemNotFoundError
 from ..value_objects import (CallbackGroupStructValue, CallbackStructValue,
                              CommunicationStructValue, ExecutorStructValue,
-                             NodeStructValue, PathStructValue)
+                             NodeStructValue, PathStructValue, PublisherStructValue,
+                             SubscriptionStructValue)
 
 
 class Architecture(Summarizable):
@@ -138,6 +139,16 @@ class Architecture(Summarizable):
     @property
     def communications(self) -> Tuple[CommunicationStructValue, ...]:
         return tuple([v.to_value() for v in self._communications])
+
+    @property
+    def publishers(self) -> Tuple[PublisherStructValue, ...]:
+        publishers = Util.flatten(_.publishers for _ in self.nodes)
+        return tuple(sorted(publishers, key=lambda x: x.topic_name))
+
+    @property
+    def subscriptions(self) -> Tuple[SubscriptionStructValue, ...]:
+        subscriptions = Util.flatten(_.subscriptions for _ in self.nodes)
+        return tuple(sorted(subscriptions, key=lambda x: x.topic_name))
 
     @property
     def summary(self) -> Summary:

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -78,7 +78,10 @@ class Architecture(Summarizable):
 
     @property
     def topic_names(self) -> Tuple[str, ...]:
-        return tuple(sorted({_.topic_name for _ in self.communications}))
+        topic_names: Set[str]
+        topic_names |= {_.topic_name for _ in self.publishers}
+        topic_names |= {_.topic_name for _ in self.subscriptions}
+        return tuple(sorted(topic_names))
 
     def get_callback(self, callback_name: str) -> CallbackStructValue:
         return Util.find_one(lambda x: x.callback_name == callback_name, self.callbacks)

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -78,8 +78,7 @@ class Architecture(Summarizable):
 
     @property
     def topic_names(self) -> Tuple[str, ...]:
-        topic_names: Set[str]
-        topic_names |= {_.topic_name for _ in self.publishers}
+        topic_names = {_.topic_name for _ in self.publishers}
         topic_names |= {_.topic_name for _ in self.subscriptions}
         return tuple(sorted(topic_names))
 

--- a/src/caret_analyze/runtime/application.py
+++ b/src/caret_analyze/runtime/application.py
@@ -120,6 +120,34 @@ class Application(Summarizable):
         return sorted(self._communications, key=lambda x: x.topic_name)
 
     @property
+    def publishers(self) -> List[Publisher]:
+        """
+        Get publishers.
+
+        Returns
+        -------
+        List[Publisher]
+            All publishers defined in the architecture.
+
+        """
+        publishers = Util.flatten(_.publishers for _ in self.nodes)
+        return sorted(publishers, key=lambda x: x.topic_name)
+
+    @property
+    def subscriptions(self) -> List[Subscription]:
+        """
+        Get subscriptions.
+
+        Returns
+        -------
+        List[Subscription]
+            All subscriptions defined in the architecture.
+
+        """
+        subscriptions = Util.flatten(_.subscriptions for _ in self.nodes)
+        return sorted(subscriptions, key=lambda x: x.topic_name)
+
+    @property
     def paths(self) -> List[Path]:
         """
         Get paths.

--- a/src/caret_analyze/runtime/application.py
+++ b/src/caret_analyze/runtime/application.py
@@ -18,7 +18,7 @@ import fnmatch
 
 from logging import getLogger
 
-from typing import List, Optional, Set, Union
+from typing import List, Optional, Union
 
 from .callback import CallbackBase
 from .callback_group import CallbackGroup
@@ -369,8 +369,7 @@ class Application(Summarizable):
             All topic names defined in architecture.
 
         """
-        topic_names: Set[str]
-        topic_names |= {_.topic_name for _ in self.publishers}
+        topic_names = {_.topic_name for _ in self.publishers}
         topic_names |= {_.topic_name for _ in self.subscriptions}
         return sorted(topic_names)
 

--- a/src/caret_analyze/runtime/application.py
+++ b/src/caret_analyze/runtime/application.py
@@ -18,7 +18,7 @@ import fnmatch
 
 from logging import getLogger
 
-from typing import List, Optional, Union
+from typing import List, Optional, Set, Union
 
 from .callback import CallbackBase
 from .callback_group import CallbackGroup
@@ -369,7 +369,10 @@ class Application(Summarizable):
             All topic names defined in architecture.
 
         """
-        return sorted({_.topic_name for _ in self.communications})
+        topic_names: Set[str]
+        topic_names |= {_.topic_name for _ in self.publishers}
+        topic_names |= {_.topic_name for _ in self.subscriptions}
+        return sorted(topic_names)
 
     @property
     def executor_names(self) -> List[str]:


### PR DESCRIPTION
This PR modify topic name property to support publisher-only / subscription-only case.

https://github.com/tier4/CARET_analyze/pull/179 is applied beforehand.