### PR TITLE
feat: add callback symbol name to warning message in Lttng and Architecture

### DIFF
--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -328,10 +328,11 @@ class NodeValuesLoaded():
             except ItemNotFoundError:
                 pass
 
-        msg = f'Failed to find callback group. callback_group_id: {callback_group_id}. '
-        node_names = self._reader.get_node_names(callback_group_id)
-        if node_names:
-            msg += f'node_name: {node_names}.'
+        msg = f'Failed to find callback group. callback_group_id: {callback_group_id}.\n'
+        node_names_and_cb_symbols = self._reader.get_node_names_and_cb_symbols(callback_group_id)
+        for i, node_name_and_cb_symbol in enumerate(node_names_and_cb_symbols):
+            msg += f'\t|node name {i}| {node_name_and_cb_symbol[0]}.\n'
+            msg += f'\t|callback symbol {i}| {node_name_and_cb_symbol[1]}.\n'
         raise ItemNotFoundError(msg)
 
     def find_callback(
@@ -1288,8 +1289,11 @@ class TopicIgnoredReader(ArchitectureReader):
     def get_paths(self) -> Sequence[PathValue]:
         return self._reader.get_paths()
 
-    def get_node_names(self, callback_group_id: str) -> Sequence[str]:
-        return self._reader.get_node_names(callback_group_id)
+    def get_node_names_and_cb_symbols(
+        self,
+        callback_group_id: str
+    ) -> Sequence[Tuple[Optional[str], Optional[str]]]:
+        return self._reader.get_node_names_and_cb_symbols(callback_group_id)
 
     def get_nodes(self) -> Sequence[NodeValueWithId]:
         return self._reader.get_nodes()

--- a/src/caret_analyze/architecture/reader_interface.py
+++ b/src/caret_analyze/architecture/reader_interface.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import Dict, Sequence
+from typing import Dict, Optional, Sequence, Tuple
 
 from ..value_objects import (CallbackGroupValue, ExecutorValue, NodeValue,
                              NodeValueWithId, PathValue, PublisherValue,
@@ -30,17 +30,18 @@ class ArchitectureReader(metaclass=ABCMeta):
     """Architecture reader base class."""
 
     @abstractmethod
-    def get_node_names(
+    def get_node_names_and_cb_symbols(
         self,
         callback_group_id: str
-    ) -> Sequence[str]:
+    ) -> Sequence[Tuple[Optional[str], Optional[str]]]:
         """
-        Get node names from callback group id.
+        Get node names and callback symbols from callback group id.
 
         Returns
         -------
-        Sequence[str]
-            node names.
+        Sequence[Tuple[Optional[str], Optional[str]]]
+            node names and callback symbols.
+            tuple structure: (node_name, callback_symbol)
 
         """
         pass

--- a/src/caret_analyze/infra/lttng/architecture_reader_lttng.py
+++ b/src/caret_analyze/infra/lttng/architecture_reader_lttng.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Sequence
+from typing import Dict, List, Optional, Sequence, Tuple
 
 from .lttng import LttngEventFilter
 from ...architecture.reader_interface import ArchitectureReader
@@ -41,8 +41,11 @@ class ArchitectureReaderLttng(ArchitectureReader):
             trace_dir, event_filters=[LttngEventFilter.init_pass_filter()],
             validate=False)
 
-    def get_node_names(self, callback_group_id: str) -> Sequence[str]:
-        return self._lttng.get_node_names(callback_group_id)
+    def get_node_names_and_cb_symbols(
+        self,
+        callback_group_id: str
+    ) -> Sequence[Tuple[Optional[str], Optional[str]]]:
+        return self._lttng.get_node_names_and_cb_symbols(callback_group_id)
 
     def get_nodes(self) -> Sequence[NodeValueWithId]:
         return self._lttng.get_nodes()

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -305,20 +305,24 @@ class Lttng(InfraBase):
         events_ = None if len(events) == 0 else events
         return data, events_, begin, end
 
-    def get_node_names(self, callback_group_id: str) -> Sequence[str]:
+    def get_node_names_and_cb_symbols(
+        self,
+        callback_group_id: str
+    ) -> Sequence[Tuple[Optional[str], Optional[str]]]:
         """
-        Get node names from callback group id.
+        Get node names and callback symbols from callback group id.
 
         Returns
         -------
-        Sequence[str]
-            node names.
+        Sequence[Tuple[Optional[str], Optional[str]]]
+            node names and callback symbols.
+            tuple structure: (node_name, callback_symbol)
 
         """
         data_model_srv = DataModelService(self.data)
         cbg_addr = CallbackGroupId(callback_group_id).group_addr
 
-        return data_model_srv.get_node_names(cbg_addr)
+        return data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
 
     def get_nodes(
         self

--- a/src/caret_analyze/infra/lttng/lttng_info.py
+++ b/src/caret_analyze/infra/lttng/lttng_info.py
@@ -1155,16 +1155,18 @@ class DataFrameFormatted:
         executor_duplicated_indexes = []
         for _, group in df.groupby('callback_group_addr'):
             if len(group) >= 2:
-                msg = ('Multiple executors using the same callback group were detected.'
+                msg = ('Multiple executors using the same callback group were detected. '
                        'The last executor will be used. ')
                 exec_addr = list(group['executor_addr'].values)
                 msg += f'executor address: {exec_addr}. '
                 data_model_srv = DataModelService(data)
-                cbg_addr = list(group['callback_group_addr'].values)
-                node_names = Util.flatten(data_model_srv.get_node_names(addr)
-                                          for addr in cbg_addr)
-                if node_names:
-                    msg += f'node name: {sorted(set(node_names))}.'
+                cbg_addr = set(group['callback_group_addr'].values)
+                for addr in cbg_addr:
+                    node_names_and_cb_symbols = data_model_srv.get_node_names_and_cb_symbols(addr)
+                    msg += f'callback_group_addr: {addr}.\n'
+                    for i, node_name_and_cb_symbol in enumerate(node_names_and_cb_symbols):
+                        msg += f'\t|node name {i}| {node_name_and_cb_symbol[0]}.\n'
+                        msg += f'\t|callback symbol {i}| {node_name_and_cb_symbol[1]}.\n'
                 logger.warn(msg)
                 executor_duplicated_indexes += list(group.index)[:-1]
 

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Set
+from typing import List, Optional, Set, Tuple, Union
 
 import pandas as pd
 
@@ -24,9 +24,12 @@ class DataModelService:
     def __init__(self, data: Ros2DataModel) -> None:
         self._data = data
 
-    def get_node_names(self, cbg_addr: int) -> List[str]:
+    def get_node_names_and_cb_symbols(
+        self,
+        cbg_addr: int
+    ) -> List[Tuple[Optional[str], Optional[str]]]:
         """
-        Get node names from callback group address.
+        Get node names and callback symbols from callback group address.
 
         Parameters
         ----------
@@ -35,89 +38,96 @@ class DataModelService:
 
         Returns
         -------
-        List[str]
+        List[Tuple[Optional[str], Optional[str]]]
+            node names and callback symbols.
+            tuple structure: (node_name, callback_symbol)
 
         Notes
         -----
         Since there may be duplicate addresses in the trace data,
-        this API returns a list of all possible node names.
+        this returns a list of all possible node names and callback symbols.
 
         """
-        node_names: Set[str] = set()
+        node_names_and_cb_symbols: Set[Tuple[Optional[str], Optional[str]]] = set()
         try:
-            node_names |= set(self._get_node_names_from_cbg_timer(cbg_addr))
+            node_names_and_cb_symbols |= \
+                set(self._get_node_names_and_cb_symbols_from_timer(cbg_addr))
         except KeyError:
             pass
 
         try:
-            node_names |= set(self._get_node_names_from_cbg_sub(cbg_addr))
+            node_names_and_cb_symbols |= \
+                set(self._get_node_names_and_cb_symbols_from_sub(cbg_addr))
         except KeyError:
             pass
 
         try:
-            node_names |= set(
-                self._get_node_names_from_get_parameters_srv(cbg_addr))
+            node_names_and_cb_symbols |= \
+                set(self._get_node_names_and_cb_symbols_from_srv(cbg_addr))
         except KeyError:
             pass
 
-        return sorted(node_names)
+        return sorted(
+            node_names_and_cb_symbols,
+            key=lambda x: (x[0] is None, x[1] is None, str(x[0]), str(x[1]))
+        )
 
-    def _get_node_names_from_cbg_timer(
+    def _get_node_names_and_cb_symbols_from_timer(
         self,
         cbg_addr: int
-    ) -> List[str]:
-        # `.loc[[cbg_addr], :]` is intended to make the return value DataFrame
-        # instead of Series.
-        match_cbg_timer = self._data.callback_group_timer.loc[[cbg_addr], :]
+    ) -> List[Tuple[Optional[str], Optional[str]]]:
+        match_cbg_timer = self._ensure_dataframe(
+            self._data.callback_group_timer.loc[cbg_addr, :])
+        timer_handles = match_cbg_timer.loc[:, 'timer_handle'].to_list()
 
-        match_timer_handles = match_cbg_timer.loc[:, 'timer_handle'].to_list()
-        match_timer_node_links = self._data.timer_node_links.loc[
-            match_timer_handles, :
-        ]
+        node_names_and_cb_symbols: List[Tuple[Optional[str], Optional[str]]] = []
+        for handle in timer_handles:
+            node_name = self._get_node_name_from_handle(handle, self._data.timer_node_links)
+            callback_symbol = self._get_callback_symbol_from_handle(handle)
+            if node_name or callback_symbol:
+                node_names_and_cb_symbols.append((node_name, callback_symbol))
 
-        match_node_handles = \
-            match_timer_node_links.loc[:, 'node_handle'].to_list()
-        return self._get_node_names_from_node_handles(match_node_handles)
+        return node_names_and_cb_symbols
 
-    def _get_node_names_from_cbg_sub(
+    def _get_node_names_and_cb_symbols_from_sub(
         self,
         cbg_addr: int
-    ) -> List[str]:
-        # `.loc[[cbg_addr], :]` is intended to make the return value DataFrame
-        # instead of Series.
-        match_cbg_sub = \
-            self._data.callback_group_subscription.loc[[cbg_addr], :]
+    ) -> List[Tuple[Optional[str], Optional[str]]]:
+        match_cbg_sub = self._ensure_dataframe(
+            self._data.callback_group_subscription.loc[cbg_addr, :])
+        sub_handles = match_cbg_sub.loc[:, 'subscription_handle'].to_list()
 
-        match_sub_handles = \
-            match_cbg_sub.loc[:, 'subscription_handle'].to_list()
-        match_subscriptions = self._data.subscriptions.loc[
-            match_sub_handles, :
-        ]
+        node_names_and_cb_symbols: List[Tuple[Optional[str], Optional[str]]] = []
+        for handle in sub_handles:
+            node_name = self._get_node_name_from_handle(handle, self._data.subscriptions)
+            callback_symbol = self._get_callback_symbol_from_handle(handle)
+            if node_name or callback_symbol:
+                node_names_and_cb_symbols.append((node_name, callback_symbol))
 
-        match_node_handles = \
-            match_subscriptions.loc[:, 'node_handle'].to_list()
-        return self._get_node_names_from_node_handles(match_node_handles)
+        return node_names_and_cb_symbols
 
-    def _get_node_names_from_get_parameters_srv(
+    def _get_node_names_and_cb_symbols_from_srv(
         self,
         cbg_addr: int
-    ) -> List[str]:
-        # `.loc[[cbg_addr], :]` is intended to make the return value DataFrame
-        # instead of Series.
-        match_cbg_srv = self._data.callback_group_service.loc[[cbg_addr], :]
+    ) -> List[Tuple[Optional[str], Optional[str]]]:
+        match_cbg_srv = self._ensure_dataframe(
+            self._data.callback_group_service.loc[cbg_addr, :])
+        srv_handles = match_cbg_srv.loc[:, 'service_handle'].to_list()
 
-        match_srv_handles = match_cbg_srv.loc[:, 'service_handle'].to_list()
-        match_services = self._data.services.loc[
-            match_srv_handles, :
-        ]
+        node_names_and_cb_symbols: List[Tuple[Optional[str], Optional[str]]] = []
+        for handle in srv_handles:
+            node_name = self._get_node_name_from_handle(handle, self._data.services)
+            callback_symbol = self._get_callback_symbol_from_handle(handle)
+            if node_name or callback_symbol:
+                node_names_and_cb_symbols.append((node_name, callback_symbol))
 
-        match_node_handles = match_services.loc[:, 'node_handle'].to_list()
-        return self._get_node_names_from_node_handles(match_node_handles)
+        return node_names_and_cb_symbols
 
-    def _get_node_names_from_node_handles(
+    def _get_node_name_from_handle(
         self,
-        node_handles: List[int]
-    ) -> List[str]:
+        handle: int,
+        middle_df: pd.DataFrame
+    ) -> Optional[str]:
         def ns_and_node_name(row: pd.Series) -> str:
             ns: str = row['namespace']
             name: str = row['name']
@@ -127,8 +137,47 @@ class DataModelService:
             else:
                 return ns + '/' + name
 
-        match_nodes = self._data.nodes.loc[node_handles, :]
+        try:
+            match_middle = self._ensure_dataframe(middle_df.loc[handle, :])
+            node_handles = match_middle.loc[:, 'node_handle'].to_list()
+            match_nodes = self._data.nodes.loc[node_handles, :]
+            assert len(match_nodes) == 1
+            return ns_and_node_name(match_nodes.iloc[0])
+        except KeyError:
+            return None
 
-        node_names = [ns_and_node_name(row)
-                      for _, row in match_nodes.iterrows()]
-        return node_names
+    def _get_callback_symbol_from_handle(
+        self,
+        handle: int
+    ) -> Optional[str]:
+        try:
+            match_callback_objects = self._ensure_dataframe(
+                self._data.callback_objects.loc[handle, :])
+            callback_objects = match_callback_objects.loc[:, 'callback_object'].to_list()
+            match_callback_symbols = self._data.callback_symbols.loc[callback_objects, :]
+            assert len(match_callback_symbols) == 1
+            return match_callback_symbols.iloc[0]['symbol']
+        except KeyError:
+            return None
+
+    @staticmethod
+    def _ensure_dataframe(
+        dataframe_or_series: Union[pd.DataFrame, pd.Series]
+    ) -> pd.DataFrame:
+        """
+        If input is Series, convert to DataFrame.
+
+        Note
+        ----
+        In the pandas specification,
+        when a conditional extraction is performed on DataFrame,
+        if there is only one matching row, it is converted to Series.
+        To address the above case, this converts Series to a one-row DataFrame.
+
+        """
+        if isinstance(dataframe_or_series, pd.Series):
+            df = pd.DataFrame([dataframe_or_series])
+        else:
+            df = dataframe_or_series
+
+        return df

--- a/src/caret_analyze/infra/yaml/architecture_reader_yaml.py
+++ b/src/caret_analyze/infra/yaml/architecture_reader_yaml.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from logging import getLogger
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import yaml
 
@@ -39,8 +39,12 @@ class ArchitectureReaderYaml(ArchitectureReader):
         if self._arch is None:
             raise InvalidYamlFormatError('Failed to parse yaml.')
 
-    def get_node_names(self, callback_group_id: str) -> Sequence[str]:
-        logger.warning('get_node_names method is not implemented in ArchitectureReaderYaml class.')
+    def get_node_names_and_cb_symbols(
+        self,
+        callback_group_id: str
+    ) -> Sequence[Tuple[Optional[str], Optional[str]]]:
+        logger.warning('get_node_names_and_cb_symbols method is not implemented '
+                       'in ArchitectureReaderYaml class.')
         return []
 
     def get_nodes(self) -> Sequence[NodeValueWithId]:

--- a/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
+++ b/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
@@ -19,15 +19,105 @@ from caret_analyze.infra.lttng.ros2_tracing.data_model_service \
 
 class TestDataModelService:
 
-    def test_get_node_names_not_exist(self):
+    def test_get_node_names_and_cb_symbols_not_exist(self):
         data = Ros2DataModel()
         data.finalize()
 
         data_model_srv = DataModelService(data)
-        node_names = data_model_srv.get_node_names(0)
-        assert node_names == []
+        node_names_and_cb_symbols = data_model_srv.get_node_names_and_cb_symbols(0)
+        assert node_names_and_cb_symbols == []
 
-    def test_get_node_names_exist_rcl_node_init_timer(self):
+    def test_get_node_names_and_cb_symbols_exist_rcl_node_init_timer(self):
+        data = Ros2DataModel()
+        cbg_addr = 1
+        timer_handle = 2
+        node_handle = 3
+        cb_object = 4
+        data.add_node(0, node_handle, 0, 0, 'name', 'ns')
+        data.add_timer_node_link(timer_handle, 0, node_handle)
+        data.callback_group_add_timer(cbg_addr, 0, timer_handle)
+        data.add_callback_object(timer_handle, 0, cb_object)
+        data.add_callback_symbol(cb_object, 0, 'cb')
+        data.finalize()
+
+        data_model_srv = DataModelService(data)
+        node_names_and_cb_symbols = data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
+        assert node_names_and_cb_symbols == [('ns/name', 'cb')]
+
+    def test_get_node_names_and_cb_symbols_exist_rcl_node_init_sub(self):
+        data = Ros2DataModel()
+        cbg_addr = 1
+        sub_handle = 2
+        node_handle = 3
+        cb_object = 4
+        data.add_node(0, node_handle, 0, 0, 'name', 'ns')
+        data.add_rcl_subscription(sub_handle, 0, node_handle, 0, 'topic', 0)
+        data.callback_group_add_subscription(cbg_addr, 0, sub_handle)
+        data.add_callback_object(sub_handle, 0, cb_object)
+        data.add_callback_symbol(cb_object, 0, 'cb')
+        data.finalize()
+
+        data_model_srv = DataModelService(data)
+        node_names_and_cb_symbols = data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
+        assert node_names_and_cb_symbols == [('ns/name', 'cb')]
+
+    def test_get_node_names_and_cb_symbols_exist_get_parameters_srv(self):
+        data = Ros2DataModel()
+        cbg_addr = 1
+        srv_handle = 2
+        node_handle = 3
+        cb_object = 4
+        data.add_node(0, node_handle, 0, 0, 'name', 'ns')
+        data.add_service(srv_handle, 0, node_handle, 0, 'srv')
+        data.callback_group_add_service(cbg_addr, 0, srv_handle)
+        data.add_callback_object(srv_handle, 0, cb_object)
+        data.add_callback_symbol(cb_object, 0, 'cb')
+        data.finalize()
+
+        data_model_srv = DataModelService(data)
+        node_names_and_cb_symbols = data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
+        assert node_names_and_cb_symbols == [('ns/name', 'cb')]
+
+    def test_get_node_names_and_cb_symbols_multiple_exist(self):
+        data = Ros2DataModel()
+        duplicated_cbg_addr = 1
+        timer_handle1 = 2
+        timer_handle2 = 3
+        node_handle1 = 4
+        node_handle2 = 5
+        cb_object1 = 6
+        cb_object2 = 7
+        data.add_node(0, node_handle1, 0, 0, 'name1', 'ns')
+        data.add_node(0, node_handle2, 0, 0, 'name2', 'ns')
+        data.add_timer_node_link(timer_handle1, 0, node_handle1)
+        data.add_timer_node_link(timer_handle2, 0, node_handle2)
+        data.callback_group_add_timer(duplicated_cbg_addr, 0, timer_handle1)
+        data.callback_group_add_timer(duplicated_cbg_addr, 0, timer_handle2)
+        data.add_callback_object(timer_handle1, 0, cb_object1)
+        data.add_callback_object(timer_handle2, 0, cb_object2)
+        data.add_callback_symbol(cb_object1, 0, 'cb1')
+        data.add_callback_symbol(cb_object2, 0, 'cb2')
+        data.finalize()
+
+        data_model_srv = DataModelService(data)
+        node_names_and_cb_symbols = data_model_srv.get_node_names_and_cb_symbols(duplicated_cbg_addr)
+        assert node_names_and_cb_symbols == [('ns/name1', 'cb1'), ('ns/name2', 'cb2')]
+
+    def test_get_node_names_and_cb_symbols_drop_node_name(self):
+        data = Ros2DataModel()
+        cbg_addr = 1
+        timer_handle = 2
+        cb_object = 3
+        data.callback_group_add_timer(cbg_addr, 0, timer_handle)
+        data.add_callback_object(timer_handle, 0, cb_object)
+        data.add_callback_symbol(cb_object, 0, 'cb')
+        data.finalize()
+
+        data_model_srv = DataModelService(data)
+        node_names_and_cb_symbols = data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
+        assert node_names_and_cb_symbols == [(None, 'cb')]
+
+    def test_get_node_names_and_cb_symbols_drop_callback_symbol(self):
         data = Ros2DataModel()
         cbg_addr = 1
         timer_handle = 2
@@ -38,52 +128,5 @@ class TestDataModelService:
         data.finalize()
 
         data_model_srv = DataModelService(data)
-        node_names = data_model_srv.get_node_names(cbg_addr)
-        assert node_names == ['ns/name']
-
-    def test_get_node_names_exist_rcl_node_init_sub(self):
-        data = Ros2DataModel()
-        cbg_addr = 1
-        sub_handle = 2
-        node_handle = 3
-        data.add_node(0, node_handle, 0, 0, 'name', 'ns')
-        data.add_rcl_subscription(sub_handle, 0, node_handle, 0, 'topic', 0)
-        data.callback_group_add_subscription(cbg_addr, 0, sub_handle)
-        data.finalize()
-
-        data_model_srv = DataModelService(data)
-        node_names = data_model_srv.get_node_names(cbg_addr)
-        assert node_names == ['ns/name']
-
-    def test_get_node_names_exist_get_parameters_srv(self):
-        data = Ros2DataModel()
-        cbg_addr = 1
-        srv_handle = 2
-        node_handle = 3
-        data.add_node(0, node_handle, 0, 0, 'name', 'ns')
-        data.add_service(srv_handle, 0, node_handle, 0, 'srv')
-        data.callback_group_add_service(cbg_addr, 0, srv_handle)
-        data.finalize()
-
-        data_model_srv = DataModelService(data)
-        node_names = data_model_srv.get_node_names(cbg_addr)
-        assert node_names == ['ns/name']
-
-    def test_get_node_names_multiple_exist(self):
-        data = Ros2DataModel()
-        duplicated_cbg_addr = 1
-        timer_handle1 = 2
-        timer_handle2 = 3
-        node_handle1 = 4
-        node_handle2 = 5
-        data.add_node(0, node_handle1, 0, 0, 'name1', 'ns')
-        data.add_node(0, node_handle2, 0, 0, 'name2', 'ns')
-        data.add_timer_node_link(timer_handle1, 0, node_handle1)
-        data.add_timer_node_link(timer_handle2, 0, node_handle2)
-        data.callback_group_add_timer(duplicated_cbg_addr, 0, timer_handle1)
-        data.callback_group_add_timer(duplicated_cbg_addr, 0, timer_handle2)
-        data.finalize()
-
-        data_model_srv = DataModelService(data)
-        node_names = data_model_srv.get_node_names(duplicated_cbg_addr)
-        assert node_names == ['ns/name1', 'ns/name2']
+        node_names_and_cb_symbols = data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
+        assert node_names_and_cb_symbols == [('ns/name', None)]

--- a/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
+++ b/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
@@ -24,7 +24,8 @@ class TestDataModelService:
         data.finalize()
 
         data_model_srv = DataModelService(data)
-        node_names_and_cb_symbols = data_model_srv.get_node_names_and_cb_symbols(0)
+        node_names_and_cb_symbols = \
+            data_model_srv.get_node_names_and_cb_symbols(0)
         assert node_names_and_cb_symbols == []
 
     def test_get_node_names_and_cb_symbols_exist_rcl_node_init_timer(self):
@@ -41,7 +42,8 @@ class TestDataModelService:
         data.finalize()
 
         data_model_srv = DataModelService(data)
-        node_names_and_cb_symbols = data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
+        node_names_and_cb_symbols = \
+            data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
         assert node_names_and_cb_symbols == [('ns/name', 'cb')]
 
     def test_get_node_names_and_cb_symbols_exist_rcl_node_init_sub(self):
@@ -58,7 +60,8 @@ class TestDataModelService:
         data.finalize()
 
         data_model_srv = DataModelService(data)
-        node_names_and_cb_symbols = data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
+        node_names_and_cb_symbols = \
+            data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
         assert node_names_and_cb_symbols == [('ns/name', 'cb')]
 
     def test_get_node_names_and_cb_symbols_exist_get_parameters_srv(self):
@@ -75,7 +78,8 @@ class TestDataModelService:
         data.finalize()
 
         data_model_srv = DataModelService(data)
-        node_names_and_cb_symbols = data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
+        node_names_and_cb_symbols = \
+            data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
         assert node_names_and_cb_symbols == [('ns/name', 'cb')]
 
     def test_get_node_names_and_cb_symbols_multiple_exist(self):
@@ -100,7 +104,8 @@ class TestDataModelService:
         data.finalize()
 
         data_model_srv = DataModelService(data)
-        node_names_and_cb_symbols = data_model_srv.get_node_names_and_cb_symbols(duplicated_cbg_addr)
+        node_names_and_cb_symbols = \
+            data_model_srv.get_node_names_and_cb_symbols(duplicated_cbg_addr)
         assert node_names_and_cb_symbols == [('ns/name1', 'cb1'), ('ns/name2', 'cb2')]
 
     def test_get_node_names_and_cb_symbols_drop_node_name(self):
@@ -114,7 +119,8 @@ class TestDataModelService:
         data.finalize()
 
         data_model_srv = DataModelService(data)
-        node_names_and_cb_symbols = data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
+        node_names_and_cb_symbols = \
+            data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
         assert node_names_and_cb_symbols == [(None, 'cb')]
 
     def test_get_node_names_and_cb_symbols_drop_callback_symbol(self):
@@ -128,5 +134,6 @@ class TestDataModelService:
         data.finalize()
 
         data_model_srv = DataModelService(data)
-        node_names_and_cb_symbols = data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
+        node_names_and_cb_symbols = \
+            data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
         assert node_names_and_cb_symbols == [('ns/name', None)]

--- a/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
+++ b/src/test/infra/lttng/ros2_tracing/test_data_model_service.py
@@ -108,6 +108,27 @@ class TestDataModelService:
             data_model_srv.get_node_names_and_cb_symbols(duplicated_cbg_addr)
         assert node_names_and_cb_symbols == [('ns/name1', 'cb1'), ('ns/name2', 'cb2')]
 
+    def test_get_node_names_and_cb_symbols_multiple_symbols_for_one_handle(self):
+        data = Ros2DataModel()
+        cbg_addr = 1
+        duplicated_timer_handle = 2
+        node_handle = 3
+        cb_object1 = 4
+        cb_object2 = 5
+        data.add_node(0, node_handle, 0, 0, 'name', 'ns')
+        data.add_timer_node_link(duplicated_timer_handle, 0, node_handle)
+        data.callback_group_add_timer(cbg_addr, 0, duplicated_timer_handle)
+        data.add_callback_object(duplicated_timer_handle, 0, cb_object1)
+        data.add_callback_object(duplicated_timer_handle, 0, cb_object2)
+        data.add_callback_symbol(cb_object1, 0, 'cb1')
+        data.add_callback_symbol(cb_object2, 0, 'cb2')
+        data.finalize()
+
+        data_model_srv = DataModelService(data)
+        node_names_and_cb_symbols = \
+            data_model_srv.get_node_names_and_cb_symbols(cbg_addr)
+        assert node_names_and_cb_symbols == [('ns/name', 'cb1'), ('ns/name', 'cb2')]
+
     def test_get_node_names_and_cb_symbols_drop_node_name(self):
         data = Ros2DataModel()
         cbg_addr = 1


### PR DESCRIPTION
This PR add callback symbol name to warning message in Lttng and Architecture.
This PR contains modifications to API in DataModelService.
To reproduce: https://drive.google.com/drive/folders/1dWd2o6rtVhe56VXRnEdPM9G4H6RvnN1c?usp=share_link

### Note: 
The current implementation does not support **the case where multiple node names or multiple callback symbols are associated with a handle** (such as `timer_handle`, `subscription_handle`, and `service_handle`).
This is because the data structure of the return value is complicated in the above case.
The above case did not occur with Autoware trace data, but please let me know if this implementation is undesirable.
```
assert len(match_nodes) == 1
~~~
assert len(match_callback_symbols) == 1
```



