### PR TITLE
chore: fix bokeh version 2.x

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 setuptools
 colorcet
 pandas>=1.4.0
-bokeh
+bokeh<3
 graphviz
 types-pyyaml


### PR DESCRIPTION
# Why this change is needed
CARET doesn't run on Bokeh 3.x at the moment.

Signed-off-by: takeshi.iwanari <takeshi.iwanari@tier4.jp>
