### PR TITLE
feat: add dynamic type check decorator & use it to check Path input

### DIFF
--- a/src/caret_analyze/common/__init__.py
+++ b/src/caret_analyze/common/__init__.py
@@ -16,6 +16,7 @@ from .clock_converter import ClockConverter
 from .progress import Progress
 from .singleton import Singleton
 from .summary import Summarizable, Summary
+from .type_check_decorator import type_check_decorator
 from .unique_list import UniqueList
 from .util import Util
 
@@ -25,6 +26,7 @@ __all__ = [
     'Singleton',
     'Summarizable',
     'Summary',
+    'type_check_decorator',
     'Util',
     'UniqueList'
 ]

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 try:
     from pydantic import validate_arguments
     type_check_decorator = validate_arguments(config={'arbitrary_types_allowed': True})

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -12,9 +12,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List
+
+from ..exceptions import InvalidArgumentError
+
+
 try:
-    from pydantic import validate_arguments
-    type_check_decorator = validate_arguments(config={'arbitrary_types_allowed': True})
+    from pydantic import validate_arguments, ValidationError
+
+    def decorator(func):
+        validate_arguments_wrapper = \
+            validate_arguments(config={'arbitrary_types_allowed': True})(func)
+
+        def _custom_wrapper(*args, **kargs):
+            try:
+                validate_arguments_wrapper(*args, **kargs)
+            except ValidationError as e:
+                expected_types: List[str] = []
+                for error in e.errors():
+                    if error['type'] == 'type_error.arbitrary_type':
+                        expected_types.append(error['ctx']['expected_arbitrary_type'])
+                    else:
+                        expected_types.append(error['type'].replace('type_error.', ''))
+                if len(expected_types) == 1:
+                    expected_types_str = f"'{expected_types[0]}'"
+                else:
+                    expected_types_str = str(expected_types)
+
+                if len(error['loc']) == 2:  # (argument_name, index)
+                    loc_str = f'`{error["loc"][0]}`[{error["loc"][1]}]'
+                else:
+                    loc_str = f'`{error["loc"][0]}`'
+
+                msg = f'Type of argument {loc_str} must be {expected_types_str}\n'
+                raise InvalidArgumentError(msg) from None
+        return _custom_wrapper
+    type_check_decorator = decorator
+
 except ImportError:
     def empty_decorator(func):
         def _wrapper(*args, **kargs):

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -36,6 +36,7 @@ try:
             (ii) Custom class type case:
                 {'type': 'type_error.arbitrary_type',
                 'ctx': {'expected_arbitrary_type': '[EXPECT_TYPE]'}, ...}
+
         """
         expected_types: List[str] = []
         for error in e.errors():
@@ -84,6 +85,12 @@ try:
 
         Parameters
         ----------
+        signature: Signature
+            Signature of target function.
+        args: Tuple[Any, ...]
+            Arguments of target function.
+        kwargs: Dict[str, Any]
+            Keyword arguments of target function.
         given_arg_loc: tuple
             (i) Not iterable type case
                 ('[ARGUMENT_NAME],')

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -24,9 +24,9 @@ try:
         validate_arguments_wrapper = \
             validate_arguments(config={'arbitrary_types_allowed': True})(func)
 
-        def _custom_wrapper(*args, **kargs):
+        def _custom_wrapper(*args, **kwargs):
             try:
-                return validate_arguments_wrapper(*args, **kargs)
+                return validate_arguments_wrapper(*args, **kwargs)
             except ValidationError as e:
                 expected_types: List[str] = []
                 for error in e.errors():

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -14,7 +14,7 @@
 
 from typing import List
 
-from ..exceptions import InvalidArgumentError
+from ..exceptions import UnsupportedTypeError
 
 
 try:
@@ -66,7 +66,7 @@ try:
                     loc_str = f'\'{error["loc"][0]}\''
 
                 msg = f'Type of argument {loc_str} must be {expected_types_str}\n'
-                raise InvalidArgumentError(msg) from None
+                raise UnsupportedTypeError(msg) from None
         return _custom_wrapper
 
     type_check_decorator = decorator

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -73,7 +73,7 @@ try:
 
 except ImportError:
     def empty_decorator(func):
-        def _wrapper(*args, **kargs):
-            return func(*args, **kargs)
+        def _wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
         return _wrapper
     type_check_decorator = empty_decorator

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -1,7 +1,7 @@
 try:
     from pydantic import validate_arguments
     type_check_decorator = validate_arguments(config={'arbitrary_types_allowed': True})
-except ModuleNotFoundError:
+except ImportError:
     def empty_decorator(func):
         def _wrapper(*args, **kargs):
             return func(*args, **kargs)

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -26,7 +26,7 @@ try:
 
         def _custom_wrapper(*args, **kargs):
             try:
-                validate_arguments_wrapper(*args, **kargs)
+                return validate_arguments_wrapper(*args, **kargs)
             except ValidationError as e:
                 expected_types: List[str] = []
                 for error in e.errors():

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -25,12 +25,17 @@ try:
     def _get_expected_types(e: ValidationError) -> str:
         """Get expected types.
 
-        (i) Build-in type case:
-            {'type': 'type_error.[EXPECT_TYPE]', ...}
+        Parameters
+        ----------
+        e: ValidationError
+            ValidationError instance has one or more ErrorDict instances.
+            Example of ErrorDict structure is as follows.
+            (i) Build-in type case:
+                {'type': 'type_error.[EXPECT_TYPE]', ...}
 
-        (ii) Custom class type case:
-            {'type': 'type_error.arbitrary_type',
-             'ctx': {'expected_arbitrary_type': '[EXPECT_TYPE]'}, ...}
+            (ii) Custom class type case:
+                {'type': 'type_error.arbitrary_type',
+                'ctx': {'expected_arbitrary_type': '[EXPECT_TYPE]'}, ...}
         """
         expected_types: List[str] = []
         for error in e.errors():
@@ -49,14 +54,17 @@ try:
     def _get_given_arg_loc(given_arg_loc: tuple) -> str:
         """Get given argument location.
 
-        (i) Not iterable type case
-            ('[ARGUMENT_NAME],')
+        Parameters
+        ----------
+        given_arg_loc: tuple
+            (i) Not iterable type case
+                ('[ARGUMENT_NAME],')
 
-        (ii) Iterable type except for dict case
-            ('[ARGUMENT_NAME]', '[INDEX]')
+            (ii) Iterable type except for dict case
+                ('[ARGUMENT_NAME]', '[INDEX]')
 
-        (ii) Dict case
-            ('[ARGUMENT_NAME]', '[KEY]')
+            (ii) Dict case
+                ('[ARGUMENT_NAME]', '[KEY]')
 
         """
         if len(given_arg_loc) == 2:  # Iterable type case
@@ -70,21 +78,24 @@ try:
         signature: Signature,
         args: Tuple[Any, ...],
         kwargs: Dict[str, Any],
-        loc: tuple
+        given_arg_loc: tuple
     ) -> str:
         """Get given argument type.
 
-        (i) Not iterable type case
-            ('[ARGUMENT_NAME],')
+        Parameters
+        ----------
+        given_arg_loc: tuple
+            (i) Not iterable type case
+                ('[ARGUMENT_NAME],')
 
-        (ii) Iterable type except for dict case
-            ('[ARGUMENT_NAME]', '[INDEX]')
+            (ii) Iterable type except for dict case
+                ('[ARGUMENT_NAME]', '[INDEX]')
 
-        (ii) Dict case
-            ('[ARGUMENT_NAME]', '[KEY]')
+            (ii) Dict case
+                ('[ARGUMENT_NAME]', '[KEY]')
 
         """
-        arg_name = loc[0]
+        arg_name = given_arg_loc[0]
         given_arg: Any = None
 
         # Check kwargs
@@ -98,11 +109,11 @@ try:
             given_arg_idx = list(signature.parameters.keys()).index(arg_name)
             given_arg = args[given_arg_idx]
 
-        if len(loc) == 2:  # Iterable type case
+        if len(given_arg_loc) == 2:  # Iterable type case
             if isinstance(given_arg, dict):
-                given_arg_type_str = f"'{given_arg[loc[1]].__class__.__name__}'"
+                given_arg_type_str = f"'{given_arg[given_arg_loc[1]].__class__.__name__}'"
             else:
-                given_arg_type_str = f"'{given_arg[int(loc[1])].__class__.__name__}'"
+                given_arg_type_str = f"'{given_arg[int(given_arg_loc[1])].__class__.__name__}'"
         else:
             given_arg_type_str = f"'{given_arg.__class__.__name__}'"
 

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -1,9 +1,9 @@
 try:
-    from pytypes import typechecked
-    type_check_decorator = typechecked
+    from pydantic import validate_arguments
+    type_check_decorator = validate_arguments(config=dict(arbitrary_types_allowed=True))
 except ModuleNotFoundError:
-    def empty_decorator(f):
+    def empty_decorator(func):
         def _wrapper(*args, **kargs):
-            return f(*args, **kargs)
+            return func(*args, **kargs)
         return _wrapper
     type_check_decorator = empty_decorator

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -62,9 +62,9 @@ try:
 
         return expected_types_str
 
-    def _get_given_arg_loc(given_arg_loc: tuple) -> str:
+    def _get_given_arg_loc_str(given_arg_loc: tuple) -> str:
         """
-        Get given argument location.
+        Get given argument location string.
 
         Parameters
         ----------
@@ -173,10 +173,10 @@ try:
             except ValidationError as e:
                 expected_types = _get_expected_types(e)
                 loc_tuple = e.errors()[0]['loc']
-                given_arg_loc = _get_given_arg_loc(loc_tuple)
+                given_arg_loc_str = _get_given_arg_loc_str(loc_tuple)
                 given_arg_type = _get_given_arg_type(signature(func), args, kwargs, loc_tuple)
 
-                msg = f'Type of argument {given_arg_loc} must be {expected_types}. '
+                msg = f'Type of argument {given_arg_loc_str} must be {expected_types}. '
                 msg += f'The given argument type is {given_arg_type}.'
                 raise UnsupportedTypeError(msg) from None
         return _custom_wrapper

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -1,0 +1,9 @@
+try:
+    from pytypes import typechecked
+    type_check_decorator = typechecked
+except ModuleNotFoundError:
+    def empty_decorator(f):
+        def _wrapper(*args, **kargs):
+            return f(*args, **kargs)
+        return _wrapper
+    type_check_decorator = empty_decorator

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import wraps
 from typing import List
 
 from ..exceptions import UnsupportedTypeError
@@ -24,6 +25,7 @@ try:
         validate_arguments_wrapper = \
             validate_arguments(config={'arbitrary_types_allowed': True})(func)
 
+        @wraps(func)
         def _custom_wrapper(*args, **kwargs):
             try:
                 return validate_arguments_wrapper(*args, **kwargs)
@@ -73,6 +75,7 @@ try:
 
 except ImportError:
     def empty_decorator(func):
+        @wraps(func)
         def _wrapper(*args, **kwargs):
             return func(*args, **kwargs)
         return _wrapper

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -23,7 +23,8 @@ try:
     from pydantic import validate_arguments, ValidationError
 
     def _get_expected_types(e: ValidationError) -> str:
-        """Get expected types.
+        """
+        Get expected types.
 
         Parameters
         ----------
@@ -53,7 +54,8 @@ try:
         return expected_types_str
 
     def _get_given_arg_loc(given_arg_loc: tuple) -> str:
-        """Get given argument location.
+        """
+        Get given argument location.
 
         Parameters
         ----------
@@ -81,7 +83,8 @@ try:
         kwargs: Dict[str, Any],
         given_arg_loc: tuple
     ) -> str:
-        """Get given argument type.
+        """
+        Get given argument type.
 
         Parameters
         ----------

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -32,11 +32,20 @@ try:
             ValidationError instance has one or more ErrorDict instances.
             Example of ErrorDict structure is as follows.
             (i) Build-in type case:
-                {'type': 'type_error.[EXPECT_TYPE]', ...}
+                {'type': 'type_error.<EXPECT_TYPE>', ...}
 
             (ii) Custom class type case:
                 {'type': 'type_error.arbitrary_type',
-                'ctx': {'expected_arbitrary_type': '[EXPECT_TYPE]'}, ...}
+                'ctx': {'expected_arbitrary_type': '<EXPECT_TYPE>'}, ...}
+
+        Returns
+        -------
+        str
+            (i) Union case:
+                ['<EXPECT_TYPE1>', '<EXPECT_TYPE2>', ...]
+
+            (ii) otherwise:
+                '<EXPECT_TYPE>'
 
         """
         expected_types: List[str] = []
@@ -61,13 +70,25 @@ try:
         ----------
         given_arg_loc: tuple
             (i) Not iterable type case
-                ('[ARGUMENT_NAME],')
+                ('<ARGUMENT_NAME>,')
 
             (ii) Iterable type except for dict case
-                ('[ARGUMENT_NAME]', '[INDEX]')
+                ('<ARGUMENT_NAME>', '<INDEX>')
 
             (ii) Dict case
-                ('[ARGUMENT_NAME]', '[KEY]')
+                ('<ARGUMENT_NAME>', '<KEY>')
+
+        Returns
+        -------
+        str
+            (i) Not iterable type case
+                '<ARGUMENT_NAME>'
+
+            (ii) Iterable type except for dict case
+                '<ARGUMENT_NAME>'[INDEX]
+
+            (ii) Dict case
+                '<ARGUMENT_NAME>'[KEY]
 
         """
         if len(given_arg_loc) == 2:  # Iterable type case
@@ -96,13 +117,25 @@ try:
             Keyword arguments of target function.
         given_arg_loc: tuple
             (i) Not iterable type case
-                ('[ARGUMENT_NAME],')
+                ('<ARGUMENT_NAME>,')
 
             (ii) Iterable type except for dict case
-                ('[ARGUMENT_NAME]', '[INDEX]')
+                ('<ARGUMENT_NAME>', '<INDEX>')
 
             (ii) Dict case
-                ('[ARGUMENT_NAME]', '[KEY]')
+                ('<ARGUMENT_NAME>', '<KEY>')
+
+        Returns
+        -------
+        str
+            (i) Not iterable type case
+                Class name input for argument <ARGUMENT_NAME>
+
+            (ii) Iterable type except for dict case
+                Class name input for argument <ARGUMENT_NAME>[<INDEX>]
+
+            (ii) Dict case
+                Class name input for argument <ARGUMENT_NAME>[<KEY>]
 
         """
         arg_name = given_arg_loc[0]

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -1,6 +1,6 @@
 try:
     from pydantic import validate_arguments
-    type_check_decorator = validate_arguments(config=dict(arbitrary_types_allowed=True))
+    type_check_decorator = validate_arguments(config={'arbitrary_types_allowed': True})
 except ModuleNotFoundError:
     def empty_decorator(func):
         def _wrapper(*args, **kargs):

--- a/src/caret_analyze/plot/bokeh/callback_sched.py
+++ b/src/caret_analyze/plot/bokeh/callback_sched.py
@@ -37,6 +37,7 @@ from ...exceptions import InvalidArgumentError
 from ...record import Clip
 from ...runtime import (Application, CallbackBase, CallbackGroup,
                         Executor, Node, Path)
+from ...value_objects import PathStructValue
 
 logger = getLogger(__name__)
 
@@ -85,6 +86,9 @@ def callback_sched(
 
     """
     assert coloring_rule in ['callback', 'callback_group', 'node']
+    if isinstance(target, PathStructValue):
+        raise InvalidArgumentError(
+            'The input path must be that of the application, not the architecture.')
 
     callback_groups, target_name = get_cbg_and_name(target)
     callbacks = Util.flatten([cbg.callbacks for cbg in callback_groups])

--- a/src/caret_analyze/plot/bokeh/callback_sched.py
+++ b/src/caret_analyze/plot/bokeh/callback_sched.py
@@ -32,7 +32,7 @@ import pandas as pd
 
 from .util import (apply_x_axis_offset,
                    get_callback_param_desc, get_range, RectValues)
-from ...common import ClockConverter, UniqueList, Util
+from ...common import ClockConverter, type_check_decorator, UniqueList, Util
 from ...exceptions import InvalidArgumentError
 from ...record import Clip
 from ...runtime import (Application, CallbackBase, CallbackGroup,
@@ -45,6 +45,7 @@ CallbackGroupTypes = Union[Application, Executor, Path, Node,
                            CallbackGroup, List[CallbackGroup]]
 
 
+@type_check_decorator
 def callback_sched(
     target: CallbackGroupTypes,
     lstrip_s: float = 0,

--- a/src/caret_analyze/plot/bokeh/callback_sched.py
+++ b/src/caret_analyze/plot/bokeh/callback_sched.py
@@ -37,7 +37,6 @@ from ...exceptions import InvalidArgumentError
 from ...record import Clip
 from ...runtime import (Application, CallbackBase, CallbackGroup,
                         Executor, Node, Path)
-from ...value_objects import PathStructValue
 
 logger = getLogger(__name__)
 
@@ -87,9 +86,6 @@ def callback_sched(
 
     """
     assert coloring_rule in ['callback', 'callback_group', 'node']
-    if isinstance(target, PathStructValue):
-        raise InvalidArgumentError(
-            'The input path must be that of the application, not the architecture.')
 
     callback_groups, target_name = get_cbg_and_name(target)
     callbacks = Util.flatten([cbg.callbacks for cbg in callback_groups])

--- a/src/caret_analyze/plot/bokeh/histogram.py
+++ b/src/caret_analyze/plot/bokeh/histogram.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Collection
+from typing import Sequence
 
 from bokeh.plotting import figure, show
 
@@ -31,7 +31,7 @@ class ResponseTimePlot(HistPlot):
 
     def __init__(
         self,
-        target: Collection[Path],
+        target: Sequence[Path],
         case: str = 'best-to-worst',
         binsize_ns: int = 10000000
     ):

--- a/src/caret_analyze/plot/bokeh/histogram_interface.py
+++ b/src/caret_analyze/plot/bokeh/histogram_interface.py
@@ -15,7 +15,9 @@
 from abc import ABCMeta, abstractmethod
 from typing import Collection
 
+from ...exceptions import InvalidArgumentError
 from ...runtime import Path
+from ...value_objects import PathStructValue
 
 
 class HistPlot(metaclass=ABCMeta):
@@ -23,6 +25,11 @@ class HistPlot(metaclass=ABCMeta):
         self,
         target: Collection[Path]
     ) -> None:
+        for path in target:
+            if isinstance(path, PathStructValue):
+                raise InvalidArgumentError(
+                    'The input path must be that of the application, not the architecture.')
+
         self._target = list(target)
 
     def show(

--- a/src/caret_analyze/plot/bokeh/histogram_interface.py
+++ b/src/caret_analyze/plot/bokeh/histogram_interface.py
@@ -15,10 +15,8 @@
 from abc import ABCMeta, abstractmethod
 from typing import Collection
 
-from ...exceptions import InvalidArgumentError
 from ...common import type_check_decorator
 from ...runtime import Path
-from ...value_objects import PathStructValue
 
 
 class HistPlot(metaclass=ABCMeta):
@@ -28,11 +26,6 @@ class HistPlot(metaclass=ABCMeta):
         self,
         target: Collection[Path]
     ) -> None:
-        for path in target:
-            if isinstance(path, PathStructValue):
-                raise InvalidArgumentError(
-                    'The input path must be that of the application, not the architecture.')
-
         self._target = list(target)
 
     def show(

--- a/src/caret_analyze/plot/bokeh/histogram_interface.py
+++ b/src/caret_analyze/plot/bokeh/histogram_interface.py
@@ -16,11 +16,14 @@ from abc import ABCMeta, abstractmethod
 from typing import Collection
 
 from ...exceptions import InvalidArgumentError
+from ...common import type_check_decorator
 from ...runtime import Path
 from ...value_objects import PathStructValue
 
 
 class HistPlot(metaclass=ABCMeta):
+
+    @type_check_decorator
     def __init__(
         self,
         target: Collection[Path]

--- a/src/caret_analyze/plot/bokeh/histogram_interface.py
+++ b/src/caret_analyze/plot/bokeh/histogram_interface.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import ABCMeta, abstractmethod
-from typing import Collection
+from typing import Sequence
 
 from ...common import type_check_decorator
 from ...runtime import Path
@@ -24,7 +24,7 @@ class HistPlot(metaclass=ABCMeta):
     @type_check_decorator
     def __init__(
         self,
-        target: Collection[Path]
+        target: Sequence[Path]
     ) -> None:
         self._target = list(target)
 

--- a/src/caret_analyze/plot/bokeh/message_flow.py
+++ b/src/caret_analyze/plot/bokeh/message_flow.py
@@ -32,7 +32,6 @@ from ...common import ClockConverter, type_check_decorator
 from ...exceptions import InvalidArgumentError
 from ...record.data_frame_shaper import Clip, Strip
 from ...runtime.path import Path
-from ...value_objects import PathStructValue
 
 
 @type_check_decorator
@@ -45,9 +44,6 @@ def message_flow(
     rstrip_s: float = 0,
     use_sim_time: bool = False
 ) -> Figure:
-    if isinstance(path, PathStructValue):
-        raise InvalidArgumentError(
-            'The input path must be that of the application, not the architecture.')
     granularity = granularity or 'raw'
     if granularity not in ['raw', 'node']:
         raise InvalidArgumentError('granularity must be [ raw / node ]')

--- a/src/caret_analyze/plot/bokeh/message_flow.py
+++ b/src/caret_analyze/plot/bokeh/message_flow.py
@@ -32,6 +32,7 @@ from ...common import ClockConverter
 from ...exceptions import InvalidArgumentError
 from ...record.data_frame_shaper import Clip, Strip
 from ...runtime.path import Path
+from ...value_objects import PathStructValue
 
 
 def message_flow(
@@ -43,6 +44,9 @@ def message_flow(
     rstrip_s: float = 0,
     use_sim_time: bool = False
 ) -> Figure:
+    if isinstance(path, PathStructValue):
+        raise InvalidArgumentError(
+            'The input path must be that of the application, not the architecture.')
     granularity = granularity or 'raw'
     if granularity not in ['raw', 'node']:
         raise InvalidArgumentError('granularity must be [ raw / node ]')

--- a/src/caret_analyze/plot/bokeh/message_flow.py
+++ b/src/caret_analyze/plot/bokeh/message_flow.py
@@ -28,13 +28,14 @@ import numpy as np
 import pandas as pd
 
 from .util import apply_x_axis_offset, get_callback_param_desc, RectValues
-from ...common import ClockConverter
+from ...common import ClockConverter, type_check_decorator
 from ...exceptions import InvalidArgumentError
 from ...record.data_frame_shaper import Clip, Strip
 from ...runtime.path import Path
 from ...value_objects import PathStructValue
 
 
+@type_check_decorator
 def message_flow(
     path: Path,
     export_path: Optional[str] = None,

--- a/src/caret_analyze/plot/bokeh/plot_factory.py
+++ b/src/caret_analyze/plot/bokeh/plot_factory.py
@@ -269,7 +269,7 @@ class Plot:
         case: str = 'best-to-worst',
         binsize_ns: int = 10000000
     ) -> ResponseTimePlot:
-        return ResponseTimePlot(paths, case, int(binsize_ns))
+        return ResponseTimePlot(list(paths), case, int(binsize_ns))
 
     @staticmethod
     @create_response_time_histogram_plot.register
@@ -278,4 +278,4 @@ class Plot:
         case: str = 'best-to-worst',
         binsize_ns: int = 10000000
     ) -> ResponseTimePlot:
-        return ResponseTimePlot(paths, case, int(binsize_ns))
+        return ResponseTimePlot(list(paths), case, int(binsize_ns))

--- a/src/caret_analyze/plot/graphviz/chain_latency.py
+++ b/src/caret_analyze/plot/graphviz/chain_latency.py
@@ -20,6 +20,7 @@ import pandas as pd
 
 from ...exceptions import InvalidArgumentError
 from ...runtime.path import Path
+from ...value_objects import PathStructValue
 
 
 def chain_latency(
@@ -30,6 +31,9 @@ def chain_latency(
     lstrip_s=0,
     rstrip_s=0,
 ) -> Optional[Source]:
+    if isinstance(path, PathStructValue):
+        raise InvalidArgumentError(
+            'The input path must be that of the application, not the architecture.')
     granularity = granularity or 'node'
     if granularity not in ['node', 'end-to-end']:
         raise InvalidArgumentError('granularity must be [ node / end-to-end ]')

--- a/src/caret_analyze/plot/graphviz/chain_latency.py
+++ b/src/caret_analyze/plot/graphviz/chain_latency.py
@@ -21,7 +21,6 @@ import pandas as pd
 from ...common import type_check_decorator
 from ...exceptions import InvalidArgumentError
 from ...runtime.path import Path
-from ...value_objects import PathStructValue
 
 
 @type_check_decorator
@@ -33,9 +32,6 @@ def chain_latency(
     lstrip_s=0,
     rstrip_s=0,
 ) -> Optional[Source]:
-    if isinstance(path, PathStructValue):
-        raise InvalidArgumentError(
-            'The input path must be that of the application, not the architecture.')
     granularity = granularity or 'node'
     if granularity not in ['node', 'end-to-end']:
         raise InvalidArgumentError('granularity must be [ node / end-to-end ]')

--- a/src/caret_analyze/plot/graphviz/chain_latency.py
+++ b/src/caret_analyze/plot/graphviz/chain_latency.py
@@ -31,7 +31,7 @@ def chain_latency(
     treat_drop_as_delay=False,
     lstrip_s=0,
     rstrip_s=0,
-) -> Optional[Source]:
+) -> Optional[Digraph]:
     granularity = granularity or 'node'
     if granularity not in ['node', 'end-to-end']:
         raise InvalidArgumentError('granularity must be [ node / end-to-end ]')

--- a/src/caret_analyze/plot/graphviz/chain_latency.py
+++ b/src/caret_analyze/plot/graphviz/chain_latency.py
@@ -18,11 +18,13 @@ from graphviz import Digraph, Source
 import numpy as np
 import pandas as pd
 
+from ...common import type_check_decorator
 from ...exceptions import InvalidArgumentError
 from ...runtime.path import Path
 from ...value_objects import PathStructValue
 
 
+@type_check_decorator
 def chain_latency(
     path: Path,
     export_path: Optional[str] = None,

--- a/src/package.xml
+++ b/src/package.xml
@@ -11,6 +11,7 @@
   <exec_depend>tracetools_analysis</exec_depend>
   <exec_depend>python3-tqdm</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
+  <exec_depend>python3-pydantic</exec_depend>
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/src/test/common/test_type_check_decorator.py
+++ b/src/test/common/test_type_check_decorator.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from typing import Dict, List, Union
 
 from caret_analyze.common.type_check_decorator import type_check_decorator
@@ -22,7 +20,6 @@ from caret_analyze.exceptions import UnsupportedTypeError
 import pytest
 
 
-@pytest.mark.skipif('GITHUB_ACTION' in os.environ, reason='requires pydantic>=1.5')
 class TestTypeCheckDecorator:
 
     def test_type_check_decorator_built_in_type(self):

--- a/src/test/common/test_type_check_decorator.py
+++ b/src/test/common/test_type_check_decorator.py
@@ -15,7 +15,7 @@
 from typing import Dict, List, Union
 
 from caret_analyze.common.type_check_decorator import type_check_decorator
-from caret_analyze.exceptions import InvalidArgumentError
+from caret_analyze.exceptions import UnsupportedTypeError
 
 import pytest
 
@@ -27,7 +27,7 @@ class TestTypeCheckDecorator:
         def bool_arg(b: bool):
             pass
 
-        with pytest.raises(InvalidArgumentError) as e:
+        with pytest.raises(UnsupportedTypeError) as e:
             bool_arg(10)
         assert "'b' must be 'bool'" in str(e.value)
 
@@ -41,7 +41,7 @@ class TestTypeCheckDecorator:
         def custom_arg(c: Custom):
             pass
 
-        with pytest.raises(InvalidArgumentError) as e:
+        with pytest.raises(UnsupportedTypeError) as e:
             custom_arg(10)
         assert "'c' must be 'Custom'" in str(e.value)
 
@@ -50,7 +50,7 @@ class TestTypeCheckDecorator:
         def union_arg(u: Union[bool, set]):
             pass
 
-        with pytest.raises(InvalidArgumentError) as e:
+        with pytest.raises(UnsupportedTypeError) as e:
             union_arg(10)
         assert "'u' must be ['bool', 'set']" in str(e.value)
 
@@ -59,7 +59,7 @@ class TestTypeCheckDecorator:
         def iterable_arg(i: List[bool]):
             pass
 
-        with pytest.raises(InvalidArgumentError) as e:
+        with pytest.raises(UnsupportedTypeError) as e:
             iterable_arg([True, 10])
         assert "'i'[1] must be 'bool'" in str(e.value)
 
@@ -68,7 +68,7 @@ class TestTypeCheckDecorator:
         def key_arg(d: Dict[str, bool]):
             pass
 
-        with pytest.raises(InvalidArgumentError) as e:
+        with pytest.raises(UnsupportedTypeError) as e:
             key_arg({'key1': True,
                      'key2': 10})
         assert "'d'[key2] must be 'bool'" in str(e.value)

--- a/src/test/common/test_type_check_decorator.py
+++ b/src/test/common/test_type_check_decorator.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from typing import Dict, List, Union
 
 from caret_analyze.common.type_check_decorator import type_check_decorator
 from caret_analyze.exceptions import UnsupportedTypeError
 
-import os
 import pytest
 
 

--- a/src/test/common/test_type_check_decorator.py
+++ b/src/test/common/test_type_check_decorator.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
-from typing import List, Union, Dict
+from typing import Dict, List, Union
 
 from caret_analyze.common.type_check_decorator import type_check_decorator
 from caret_analyze.exceptions import InvalidArgumentError
+
+import pytest
 
 
 class TestTypeCheckDecorator:
@@ -33,6 +33,7 @@ class TestTypeCheckDecorator:
 
     def test_type_check_decorator_custom_type(self):
         class Custom:
+
             def __init__(self) -> None:
                 pass
 

--- a/src/test/common/test_type_check_decorator.py
+++ b/src/test/common/test_type_check_decorator.py
@@ -32,7 +32,7 @@ class TestTypeCheckDecorator:
 
         with pytest.raises(UnsupportedTypeError) as e:
             bool_arg(10)
-        assert "'b' must be 'bool'" in str(e.value)
+        assert "'b' must be 'bool'. The given argument type is 'int'" in str(e.value)
 
     def test_type_check_decorator_custom_type(self):
         class Custom:
@@ -46,7 +46,7 @@ class TestTypeCheckDecorator:
 
         with pytest.raises(UnsupportedTypeError) as e:
             custom_arg(10)
-        assert "'c' must be 'Custom'" in str(e.value)
+        assert "'c' must be 'Custom'. The given argument type is 'int'" in str(e.value)
 
     def test_type_check_decorator_union(self):
         @type_check_decorator
@@ -55,7 +55,7 @@ class TestTypeCheckDecorator:
 
         with pytest.raises(UnsupportedTypeError) as e:
             union_arg(10)
-        assert "'u' must be ['bool', 'set']" in str(e.value)
+        assert "'u' must be ['bool', 'set']. The given argument type is 'int'" in str(e.value)
 
     def test_type_check_decorator_iterable(self):
         @type_check_decorator
@@ -64,7 +64,7 @@ class TestTypeCheckDecorator:
 
         with pytest.raises(UnsupportedTypeError) as e:
             iterable_arg([True, 10])
-        assert "'i'[1] must be 'bool'" in str(e.value)
+        assert "'i'[1] must be 'bool'. The given argument type is 'int'" in str(e.value)
 
     def test_type_check_decorator_dict(self):
         @type_check_decorator
@@ -74,4 +74,13 @@ class TestTypeCheckDecorator:
         with pytest.raises(UnsupportedTypeError) as e:
             dict_arg({'key1': True,
                       'key2': 10})
-        assert "'d'[key2] must be 'bool'" in str(e.value)
+        assert "'d'[key2] must be 'bool'. The given argument type is 'int'" in str(e.value)
+
+    def test_type_check_decorator_kwargs(self):
+        @type_check_decorator
+        def kwarg(k: bool):
+            pass
+
+        with pytest.raises(UnsupportedTypeError) as e:
+            kwarg(k=10)
+        assert "'k' must be 'bool'. The given argument type is 'int'" in str(e.value)

--- a/src/test/common/test_type_check_decorator.py
+++ b/src/test/common/test_type_check_decorator.py
@@ -17,9 +17,11 @@ from typing import Dict, List, Union
 from caret_analyze.common.type_check_decorator import type_check_decorator
 from caret_analyze.exceptions import UnsupportedTypeError
 
+import os
 import pytest
 
 
+@pytest.mark.skipif('GITHUB_ACTION' in os.environ, reason='requires pydantic>=1.5')
 class TestTypeCheckDecorator:
 
     def test_type_check_decorator_built_in_type(self):

--- a/src/test/common/test_type_check_decorator.py
+++ b/src/test/common/test_type_check_decorator.py
@@ -65,10 +65,10 @@ class TestTypeCheckDecorator:
 
     def test_type_check_decorator_dict(self):
         @type_check_decorator
-        def key_arg(d: Dict[str, bool]):
+        def dict_arg(d: Dict[str, bool]):
             pass
 
         with pytest.raises(UnsupportedTypeError) as e:
-            key_arg({'key1': True,
-                     'key2': 10})
+            dict_arg({'key1': True,
+                      'key2': 10})
         assert "'d'[key2] must be 'bool'" in str(e.value)

--- a/src/test/common/test_type_check_decorator.py
+++ b/src/test/common/test_type_check_decorator.py
@@ -1,0 +1,73 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from typing import List, Union, Dict
+
+from caret_analyze.common.type_check_decorator import type_check_decorator
+from caret_analyze.exceptions import InvalidArgumentError
+
+
+class TestTypeCheckDecorator:
+
+    def test_type_check_decorator_built_in_type(self):
+        @type_check_decorator
+        def bool_arg(b: bool):
+            pass
+
+        with pytest.raises(InvalidArgumentError) as e:
+            bool_arg(10)
+        assert "'b' must be 'bool'" in str(e.value)
+
+    def test_type_check_decorator_custom_type(self):
+        class Custom:
+            def __init__(self) -> None:
+                pass
+
+        @type_check_decorator
+        def custom_arg(c: Custom):
+            pass
+
+        with pytest.raises(InvalidArgumentError) as e:
+            custom_arg(10)
+        assert "'c' must be 'Custom'" in str(e.value)
+
+    def test_type_check_decorator_union(self):
+        @type_check_decorator
+        def union_arg(u: Union[bool, set]):
+            pass
+
+        with pytest.raises(InvalidArgumentError) as e:
+            union_arg(10)
+        assert "'u' must be ['bool', 'set']" in str(e.value)
+
+    def test_type_check_decorator_iterable(self):
+        @type_check_decorator
+        def iterable_arg(i: List[bool]):
+            pass
+
+        with pytest.raises(InvalidArgumentError) as e:
+            iterable_arg([True, 10])
+        assert "'i'[1] must be 'bool'" in str(e.value)
+
+    def test_type_check_decorator_dict(self):
+        @type_check_decorator
+        def key_arg(d: Dict[str, bool]):
+            pass
+
+        with pytest.raises(InvalidArgumentError) as e:
+            key_arg({'key1': True,
+                     'key2': 10})
+        assert "'d'[key2] must be 'bool'" in str(e.value)


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

This PR adds a dynamic type check decorator and applies it to APIs that accept `Path` as input.
The dynamic type checking use [pydintic](https://pydantic-docs.helpmanual.io/usage/validation_decorator/). (See [this page](https://tier4.atlassian.net/browse/T4PB-20204?focusedCommentId=104443) for comparison of pydintic with other libraries.)
If pydantic cannot import, the process is performed without type checking.

- JIRA ticket: https://tier4.atlassian.net/browse/T4PB-20204
- To reproduce: https://drive.google.com/drive/folders/1PeBu4seVX4Z7Md6EHD4-ce3TiioPlGIh?usp=share_link