### PR TITLE
fix: fix warnings for pandas.groupby

### DIFF
--- a/src/caret_analyze/infra/lttng/lttng_info.py
+++ b/src/caret_analyze/infra/lttng/lttng_info.py
@@ -436,7 +436,7 @@ class LttngInfo:
                 concat_df, self._formatted.callback_groups_df, 'callback_group_addr')
 
             callback_groups = []
-            for _, group_df in concat_df.groupby(['callback_group_addr']):
+            for _, group_df in concat_df.groupby('callback_group_addr'):
                 row = group_df.iloc[0, :]
                 node_id_ = row['node_id']
                 if node_id != node_id_:


### PR DESCRIPTION
# Why this change is needed

The following warning appears when loading lttng trace log data.

```
/home/aaai/ros2_caret_ws/build/caret_analyze/caret_analyze/infra/lttng/lttng_info.py:439: FutureWarning: In a future version of pandas, a length 1 tuple will be returned when iterating over a groupby with a grouper equal to a list of length 1. Don't supply a list with a single grouper to avoid this warning.
  for _, group_df in concat_df.groupby(['callback_group_addr']):
```

Environment:
- Ubuntu 22.04
- Python 3.10.6
- pandas 1.5.0

How to reproduce:
- Run `ros2 caret check-ctf` for the following trace log
- https://github.com/tier4/CARET_report/releases/download/20220831/autoware_launch_trace_20220826-105249_universe_rosbag.zip


Signed-off-by: takeshi.iwanari <takeshi.iwanari@tier4.jp>