### PR TITLE
feat(lttng): automatic cache updating

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,7 +10,7 @@ addopts = -p no:launch -p no:launch_ros -p no:launch_testing
 #
 # 3. execute "up" to call importlib-related function
 #
-# 4. check arguments for impotlib.import_module()
+# 4. check arguments for importlib.import_module()
 #    'launch_testing.XXX.YYY' can be found.
 #
 # 5. add -p no:launch_testing to adopts argument

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,18 @@
 [pytest]
-addopts = -p no:launch -p no:launch_ros
+addopts = -p no:launch -p no:launch_ros -p no:launch_testing
+# How to add adopts arguments
+#
+# 1. add breakpoint to self.propagate = False
+#    ref. /opt/ros/humble/lib/python3.10/site-packages/launch/logging/__init__.py
+#         https://github.com/ros2/launch/blob/humble/launch/launch/logging/__init__.py#L482
+#
+# 2. run pytest, then stop at break point.
+#
+# 3. execute "up" to call importlib-related function
+#
+# 4. check arguments for impotlib.import_module()
+#    'launch_testing.XXX.YYY' can be found.
+#
+# 5. add -p no:launch_testing to adopts argument
+#
+# ref. https://stackoverflow.com/a/65261267

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -90,10 +90,46 @@ class EventCollection(Iterable, Sized):
 
     @staticmethod
     def _trace_dir_exists(path: str) -> bool:
+        """
+        Check whether trace dir exists.
+
+        Parameters
+        ----------
+        path : str
+            path to trace dir.
+
+        Returns
+        -------
+        bool
+            True if trace dir exists, false otherwise.
+
+        Note
+        ----
+        This function is written in isolation to simplify testing.
+
+        """
         return os.path.exists(path)
 
     @staticmethod
     def _cache_exists(path: str) -> bool:
+        """
+        Check whether cache exists.
+
+        Parameters
+        ----------
+        path : str
+            Path to cache.
+
+        Returns
+        -------
+        bool
+            True if cache exists, false otherwise.
+
+        Note
+        ----
+        This function is written in isolation to simplify testing.
+
+        """
         return os.path.exists(path)
 
 

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 from datetime import datetime
+from functools import cached_property
 from logging import getLogger
 import os
 import pickle
@@ -48,19 +49,26 @@ logger = getLogger(__name__)
 
 class EventCollection(Iterable, Sized):
 
-    def __init__(self, trace_dir: str, force_conversion: bool) -> None:
-        if not os.path.exists(trace_dir):
+    def __init__(self, trace_dir: str, force_conversion: bool, *, store_cache=True) -> None:
+        if not self._trace_dir_exists(trace_dir):
             raise FileNotFoundError(f'Failed to found {trace_dir}')
 
         self._iterable_events: IterableEvents
         cache_path = self._cache_path(trace_dir)
+        use_cache = False
 
-        if os.path.exists(cache_path) and not force_conversion:
+        if self._cache_exists(cache_path) and not force_conversion:
+            cache_start_time, _ = PickleEventCollection(cache_path).time_range()
+            ctf_start_time, _ = CtfEventCollection(trace_dir).time_range()
+            use_cache = cache_start_time == ctf_start_time
+
+        if use_cache:
             logger.info('Found converted file.')
             self._iterable_events = PickleEventCollection(cache_path)
         else:
             self._iterable_events = CtfEventCollection(trace_dir)
-            self._store_cache(self._iterable_events, cache_path)
+            if store_cache:
+                self._store_cache(self._iterable_events, cache_path)
             logger.info(f'Converted to {cache_path}')
 
     @staticmethod
@@ -79,6 +87,14 @@ class EventCollection(Iterable, Sized):
 
     def _cache_path(self, events_path: str) -> str:
         return os.path.join(events_path, 'caret_converted')
+
+    @staticmethod
+    def _trace_dir_exists(path: str) -> bool:
+        return os.path.exists(path)
+
+    @staticmethod
+    def _cache_exists(path: str) -> bool:
+        return os.path.exists(path)
 
 
 class IterableEvents(Iterable, Sized, metaclass=ABCMeta):
@@ -153,10 +169,10 @@ class CtfEventCollection(IterableEvents):
         self._begin_time: int = begin_msg.default_clock_snapshot.ns_from_origin
         self._end_time: int = end_msg.default_clock_snapshot.ns_from_origin
         self._size = event_count
-        self._events = self._to_dicts(events_path, event_count)
+        self._events_path = events_path
 
     def __iter__(self) -> Iterator[Dict]:
-        return iter(self._events)
+        return iter(self.events)
 
     def __len__(self) -> int:
         return self._size
@@ -170,9 +186,9 @@ class CtfEventCollection(IterableEvents):
         event.update(msg.event.common_context_field)
         return event
 
-    @property
+    @cached_property
     def events(self) -> List[Dict]:
-        return self._events
+        return self._to_dicts(self._events_path, self._size)
 
     def time_range(self) -> Tuple[int, int]:
         return self._begin_time, self._end_time

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -96,7 +96,7 @@ class EventCollection(Iterable, Sized):
         Parameters
         ----------
         path : str
-            path to trace dir.
+            Path to trace dir.
 
         Returns
         -------


### PR DESCRIPTION
This PR adds the ability to automatically update the cache.
It solves the problem of the old cache being loaded after remeasurement.

It implements the following:

- If there is a cache, compare the measurement time of the cache with the measurement time of the ctf file.
- If the measurement times are different, the cache is generated again.