### PR TITLE
chore: ignore weird flake8 errors

### DIFF
--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# flake8: noqa: F811
+# This line is a workaround for the following warning that seems to be a problem with flake8.
+# F811 redefinition of unused 'publishers'
+# F811 redefinition of unused 'subscriptions'
+
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
This PR ignores following flake8 errors which occours recently.

```
./src/caret_analyze/architecture/architecture.py:156:5: F811 redefinition of unused 'publishers' from line 146
    def publishers(self) -> Tuple[PublisherStructValue, ...]:
    ^

./src/caret_analyze/architecture/architecture.py:161:5: F811 redefinition of unused 'subscriptions' from line 151
    def subscriptions(self) -> Tuple[SubscriptionStructValue, ...]:
    ^

2     F811 redefinition of unused 'publishers' from line 146
```