### PR TITLE
fix(infra): disable multimethod in add_column function to avoid exceeding recursive depth

### DIFF
--- a/src/caret_analyze/infra/lttng/lttng_info.py
+++ b/src/caret_analyze/infra/lttng/lttng_info.py
@@ -1087,7 +1087,7 @@ class DataFrameFormatted:
         columns = ['timestamp', 'timer_handle', 'type', 'params']
         timers = data.timers.clone()
         timers.reset_index()
-        timers.add_column('type', 'init')
+        timers.add_column('type', lambda _: 'init')
 
         def to_params(row: pd.Series):
             return {'period': row['period']}

--- a/src/caret_analyze/infra/trace_point_data.py
+++ b/src/caret_analyze/infra/trace_point_data.py
@@ -217,9 +217,31 @@ class TracePointData:
         """
         return self._df.at[row, column]
 
-    @singledispatchmethod
-    def add_column(self, arg) -> None:
-        raise NotImplementedError('')
+    def add_column(
+        self,
+        column: str,
+        f: Callable[[pd.Series], Any]
+    ) -> None:
+        """
+        Add column.
+
+        Parameters
+        ----------
+        column : str
+            column name to be added.
+        f : Callable[[pd.Series], Any]
+            column value for each row.
+
+        """
+        df = deepcopy(self._df)
+
+        data = []
+        for i in range(len(df)):
+            row = df.iloc[i, :]
+            data.append(f(row))
+        df[column] = data
+
+        self._df = df
 
     def filter_rows(self, column: str, value: Any) -> None:
         """
@@ -329,52 +351,6 @@ class TracePointData:
             right_on=on,
             how=how  # type: ignore
         )
-
-    @add_column.register
-    def _add_column_func(
-        self,
-        column: str,
-        f: Callable[[pd.Series], Any]
-    ) -> None:
-        """
-        Add column.
-
-        Parameters
-        ----------
-        column : str
-            column name to be added.
-        f : Callable[[pd.Series], Any]
-            column value for each row.
-
-        """
-        df = deepcopy(self._df)
-
-        data = []
-        for i in range(len(df)):
-            row = df.iloc[i, :]
-            data.append(f(row))
-        df[column] = data
-
-        self._df = df
-
-    @add_column.register
-    def _add_column_value(
-        self,
-        column: str,
-        value: Any
-    ) -> None:
-        """
-        Add column.
-
-        Parameters
-        ----------
-        column : str
-            column name to be added.
-        value : Any
-            value.
-
-        """
-        self._df[column] = value
 
     def set_columns(
         self,


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

Applying https://github.com/tier4/CARET_analyze/pull/193 with multimethod-1.8, a recursion error occurs.
This patch fixes the issue.

To reproduce:
```
pip install -U 'multimethod<1.9' # latest version is 1.9
python -c 'import caret_analyze'
```
```
RecursionError: maximum recursion depth exceeded in __subclasscheck__
```