### PR TITLE
fix(intra): add sorting to communication.to_records and publisher.to_records

### DIFF
--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1547,6 +1547,8 @@ class FilteredRecordsSource:
                 inter_pub_records = grouped_records[publisher_handle].clone()
                 pub_records.concat(inter_pub_records)
 
+        pub_records.sort(COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP)
+
         return pub_records
 
     def tilde_publish_records(

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1435,6 +1435,8 @@ class FilteredRecordsSource:
         merged.drop_columns(drop)
         merged.reindex(columns)
 
+        # NOTE: After merge, the dropped data are aligned at the end
+        # regardless of the time of publish.
         merged.sort(COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP)
 
         return merged

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1435,6 +1435,8 @@ class FilteredRecordsSource:
         merged.drop_columns(drop)
         merged.reindex(columns)
 
+        merged.sort(COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP)
+
         return merged
 
     def intra_comm_records(

--- a/src/test/infra/lttng/test_latency_definitions.py
+++ b/src/test/infra/lttng/test_latency_definitions.py
@@ -1180,6 +1180,98 @@ class TestCommunicationRecords:
 
         assert df.equals(df_expect)
 
+    def test_inter_proc_with_message_drop(
+        self,
+        mocker,
+        create_lttng,
+        create_publisher_lttng,
+        setup_bridge_get_publisher,
+        create_publisher_struct,
+        bridge_setup_get_callback,
+        create_subscription_lttng,
+        create_subscription_struct,
+        create_comm_struct
+    ):
+        pub_handle = 7
+        callback_obj = 12
+        sub_handle = 28
+        tid = 16
+
+        data = Ros2DataModel()
+        # 1st message
+        send_message = 5
+        recv_message = 8
+        message_stamp = 6
+        source_stamp = 9
+        data.add_rclcpp_publish_instance(tid, 1, pub_handle, send_message, message_stamp)
+        data.add_dds_bind_addr_to_stamp(tid, 4, send_message, source_stamp)
+        data.add_dispatch_subscription_callback_instance(
+            5, callback_obj, recv_message, source_stamp, message_stamp)
+        data.add_callback_start_instance(16, callback_obj, False)
+        data.add_callback_end_instance(17, callback_obj)
+
+        # 2nd message
+        send_message = 105
+        recv_message = 108
+        message_stamp = 106
+        source_stamp = 109
+        data.add_rclcpp_publish_instance(tid, 17, pub_handle, send_message, message_stamp)
+        data.add_dds_bind_addr_to_stamp(tid, 18, send_message, source_stamp)
+
+        # 3rd message
+        send_message = 205
+        recv_message = 208
+        message_stamp = 206
+        source_stamp = 209
+        data.add_rclcpp_publish_instance(tid, 19, pub_handle, send_message, message_stamp)
+        data.add_dds_bind_addr_to_stamp(tid, 20, send_message, source_stamp)
+        data.add_dispatch_subscription_callback_instance(
+            21, callback_obj, recv_message, source_stamp, message_stamp)
+        data.add_callback_start_instance(22, callback_obj, False)
+        data.add_callback_end_instance(23, callback_obj)
+        data.finalize()
+
+        pub_lttng = create_publisher_lttng(pub_handle)
+        publisher = create_publisher_struct('topic_name')
+        setup_bridge_get_publisher(publisher, [pub_lttng])
+
+        subscription = create_subscription_struct()
+        callback = subscription.callback
+        callback_lttng = create_subscription_lttng(callback_obj, sub_handle)
+        bridge_setup_get_callback(callback, callback_lttng)
+
+        communication = create_comm_struct(publisher, subscription)
+
+        lttng = create_lttng(data)
+        provider = RecordsProviderLttng(lttng)
+        mocker.patch.object(provider, 'is_intra_process_communication', return_value=False)
+
+        records = provider.communication_records(communication)
+        df = records.to_dataframe()
+
+        df_expect = pd.DataFrame(
+            [
+                {
+                    f'{communication.topic_name}/rclcpp_publish_timestamp': 1,
+                    f'{callback.callback_name}/callback_start_timestamp': 16,
+                },
+                {
+                    f'{communication.topic_name}/rclcpp_publish_timestamp': 17,
+                },
+                {
+                    f'{communication.topic_name}/rclcpp_publish_timestamp': 19,
+                    f'{callback.callback_name}/callback_start_timestamp': 22,
+                }
+            ],
+            columns=[
+                f'{communication.topic_name}/rclcpp_publish_timestamp',
+                f'{callback.callback_name}/callback_start_timestamp',
+            ],
+            dtype='Int64'
+        )
+
+        assert df.equals(df_expect)
+
     def test_intra_proc(
         self,
         mocker,


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

If there are drops, the data for the communication.to_records would be as follows:

| publish | callback_start|
|-------------|--------------------|
|0 | 1
| 4 | 5|
|2 | None|

This PR adds sort by timestamp of rclcpp_publish

| publish | callback_start|
|-------------|--------------------|
|0 | 1
|2 | None|
| 4 | 5|
