### PR TITLE
chore(plot): add legend label to tooltips

### DIFF
--- a/src/caret_analyze/plot/bokeh/pub_sub_info_interface.py
+++ b/src/caret_analyze/plot/bokeh/pub_sub_info_interface.py
@@ -81,6 +81,7 @@ class PubSubTimeSeriesPlot(metaclass=ABCMeta):
                     tooltips="""
                     <div style="width:400px; word-wrap: break-word;">
                     <br>
+                    legend_label = @legend_label<br>
                     node_name = @node_name <br>
                     topic_name = @topic_name <br>
                     </div>
@@ -112,6 +113,14 @@ class PubSubTimeSeriesPlot(metaclass=ABCMeta):
                              if pub_sub.topic_name == topic_name]
         for i, pub_sub in enumerate(drawn_pub_sub):
             color = color_selector.get_color(str(i))
+
+            if isinstance(pub_sub, Publisher):
+                legend_label = f'publisher{pub_count}'
+                pub_count += 1
+            else:
+                legend_label = f'subscription{sub_count}'
+                sub_count += 1
+
             # TODO:
             # remove source_df_by_topic argument from _get_pub_sub_lines.
             # source_df_by_topic is a redundant argument since pub_sub has its data
@@ -119,14 +128,9 @@ class PubSubTimeSeriesPlot(metaclass=ABCMeta):
                 pub_sub,
                 source_df_by_topic,
                 frame_min,
-                xaxis_type
+                xaxis_type,
+                legend_label
             )
-            if isinstance(pub_sub, Publisher):
-                legend_label = f'publisher{pub_count}'
-                pub_count += 1
-            else:
-                legend_label = f'subscription{sub_count}'
-                sub_count += 1
             renderer = p.line('x', 'y',
                               source=line_source,
                               color=color)
@@ -160,7 +164,8 @@ class PubSubTimeSeriesPlot(metaclass=ABCMeta):
         pub_sub: Union[Publisher, Subscription],
         source_df_by_topic: Dict[str, pd.DataFrame],
         frame_min: int,
-        xaxis_type: str
+        xaxis_type: str,
+        legend_label: str
     ) -> ColumnDataSource:
         source_df = source_df_by_topic[pub_sub.topic_name].dropna()
         ts_column_idx = source_df.columns.to_list().index(
@@ -184,6 +189,7 @@ class PubSubTimeSeriesPlot(metaclass=ABCMeta):
                 'y': [],
                 'node_name': [],
                 'topic_name': [],
+                'legend_label': [],
             }
         )
         for x, y in zip(x_item, y_item):
@@ -192,6 +198,7 @@ class PubSubTimeSeriesPlot(metaclass=ABCMeta):
                 'y': [y],
                 'node_name': [pub_sub.node_name],
                 'topic_name': [pub_sub.topic_name],
+                'legend_label': [legend_label],
             }
             line_source.stream(new_data)
 


### PR DESCRIPTION
Signed-off-by: Takayuki AKAMINE <takayuki.akamine@tier4.jp>

I'd like to make this PR to add legend label to tooltips as the following picture shows.

![Selection_081](https://user-images.githubusercontent.com/38586589/206402668-016134ab-d000-40b5-9aa1-625b3e1e6975.png)

I cannot distinguish which line is corresponding to legend label so far. After merging this PR, this inconvenience will be resolved.

Sample code for testing is uploaded also in the PR. This test uses sample data which is stored in [CARET_demos](https://github.com/tier4/CARET_demos/tree/main/samples/end_to_end_sample).
[test_pub_sub_ plot.zip](https://github.com/tier4/CARET_analyze/files/10183770/test_pub_sub_.plot.zip)
