### PR TITLE
display empty figure if there is no data

### DIFF
--- a/src/caret_analyze/plot/timeseries/frequency_timeseries.py
+++ b/src/caret_analyze/plot/timeseries/frequency_timeseries.py
@@ -122,8 +122,7 @@ class FrequencyTimeSeries(MetricsBase):
             if isinstance(last_timestamp, int):
                 last_timestamps.append(last_timestamp)
 
-        # TODO: Even if target_objects.to_records is empty, we want to display an empty graph.
-        # if len(first_timestamps) == 0 or len(last_timestamps) == 0:
-        #     return 0, 1
-        # else:
-        return min(first_timestamps), max(last_timestamps)
+        if len(first_timestamps) == 0 or len(last_timestamps) == 0:
+            return 0, 1  # Intended to show an empty figure.
+        else:
+            return min(first_timestamps), max(last_timestamps)

--- a/src/test/plot/timeseries/test_frequency_timeseries.py
+++ b/src/test/plot/timeseries/test_frequency_timeseries.py
@@ -54,11 +54,10 @@ class TestFrequencyTimeSeries:
         assert min_ts == 1
         assert max_ts == 5
 
-    # TODO: Even if target_objects.to_records is empty, we want to display an empty graph.
-    # def test_get_timestamp_range_empty_input(self):
-    #     min_ts, max_ts = FrequencyTimeSeries._get_timestamp_range([])
-    #     assert min_ts == 0
-    #     assert max_ts == 1
+    def test_get_timestamp_range_empty_input(self):
+        min_ts, max_ts = FrequencyTimeSeries._get_timestamp_range([])
+        assert min_ts == 0
+        assert max_ts == 1
 
     def test_get_timestamp_range_exist_empty_records(self, mocker):
         object_mock0 = mocker.Mock(spec=CallbackBase)
@@ -101,20 +100,19 @@ class TestFrequencyTimeSeries:
         assert min_ts == 1
         assert max_ts == 5
 
-    # TODO: Even if target_objects.to_records is empty, we want to display an empty graph.
-    # def test_get_timestamp_range_len_timestamp_is_0(self, mocker):
-    #     object_mock0 = mocker.Mock(spec=CallbackBase)
-    #     mocker.patch.object(
-    #         object_mock0, 'to_records',
-    #         return_value=create_expect_records([{}])
-    #     )
-    #     object_mock1 = mocker.Mock(spec=CallbackBase)
-    #     mocker.patch.object(
-    #         object_mock1, 'to_records',
-    #         return_value=create_expect_records([{}])
-    #     )
-    #     min_ts, max_ts = FrequencyTimeSeries._get_timestamp_range(
-    #         [object_mock0, object_mock1])
-    #
-    #     assert min_ts == 0
-    #     assert max_ts == 1
+    def test_get_timestamp_range_len_timestamp_is_0(self, mocker):
+        object_mock0 = mocker.Mock(spec=CallbackBase)
+        mocker.patch.object(
+            object_mock0, 'to_records',
+            return_value=create_expect_records([{}])
+        )
+        object_mock1 = mocker.Mock(spec=CallbackBase)
+        mocker.patch.object(
+            object_mock1, 'to_records',
+            return_value=create_expect_records([{}])
+        )
+        min_ts, max_ts = FrequencyTimeSeries._get_timestamp_range(
+            [object_mock0, object_mock1])
+
+        assert min_ts == 0
+        assert max_ts == 1


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

## Description
This PR modifies to show an empty figure when there is no time-series data.
TODO: insert image.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers
This PR causes `compare.sh` in CARET_report to fail.
[error_log](https://drive.google.com/file/d/1z37gSzlR2iFcg3ICsRyHEBPfekwQkE8N/view?usp=share_link)
Since this is not a degradation, could you please address this in the CARET_report?

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
