### PR TITLE
fix(plot): add unit into time-series figure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,8 @@ dmypy.json
 # Visual Studio Code
 .vscode/
 log/
+
+# add
+*.ipynb
+*.png
+*.yaml

--- a/src/caret_analyze/plot/visualize_lib/bokeh.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh.py
@@ -75,10 +75,14 @@ class Bokeh(VisualizeLibInterface):
         timeseries_records_list = metrics.to_timeseries_records_list(xaxis_type)
 
         # Initialize figure
+        fig_args: Dict[str, Any] = {'frame_height': 270,
+                                    'frame_width': 800}
+
         y_axis_label = timeseries_records_list[0].columns[1]
-        fig_args = {'frame_height': 270,
-                    'frame_width': 800,
-                    'y_axis_label': y_axis_label}
+        if y_axis_label == 'frequency':
+            fig_args['y_axis_label'] = y_axis_label + ' [Hz]'
+        elif y_axis_label in ['period', 'latency']:
+            fig_args['y_axis_label'] = y_axis_label + ' [ms]'
 
         if xaxis_type == 'system_time':
             fig_args['x_axis_label'] = 'system time [s]'


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

## Description
This PR adds units to the y-label of the time series data figure.
This is the degradation that occurred during the refactoring process.

## Related links
- To reproduce: https://drive.google.com/drive/folders/1uw77LtqUBbjTbU06I7e0GE6MYItteHFj?usp=share_link
- Refactring PR: https://github.com/tier4/CARET_analyze/pull/170

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
