### PR TITLE
chore(plot): remove deprecated jitter plot

### DIFF
--- a/src/caret_analyze/plot/plot_facade.py
+++ b/src/caret_analyze/plot/plot_facade.py
@@ -237,23 +237,6 @@ class Plot:
         return Plot.create_period_timeseries_plot(callbacks)
 
     @singledispatchmethod
-    def create_callback_jitter_plot(
-        callbacks: Collection[CallbackBase]
-    ) -> PlotBase:
-        logger.warning('create_callback_jitter_plot is deprecated.'
-                       'Use create_callback_period_plot')
-        return Plot.create_callback_period_plot(callbacks)
-
-    @staticmethod
-    @create_callback_jitter_plot.register
-    def _create_callback_jitter_plot_tuple(
-        *callbacks: CallbackBase
-    ) -> PlotBase:
-        logger.warning('create_callback_jitter_plot is deprecated.'
-                       'Use create_callback_period_plot')
-        return Plot.create_callback_period_plot(callbacks)
-
-    @singledispatchmethod
     def create_callback_latency_plot(
         callbacks: Collection[CallbackBase]
     ) -> PlotBase:


### PR DESCRIPTION
Signed-off-by: atsushi421 <a.yano.578@ms.saitama-u.ac.jp>

## Description
This PR removes deprecated `Plot.create_callback_jitter_plot()` method.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
