### PR TITLE
fix: validation for unknown columns

### DIFF
--- a/src/caret_analyze/record/record.py
+++ b/src/caret_analyze/record/record.py
@@ -133,10 +133,10 @@ class Records(RecordsInterface):
 
     @staticmethod
     def __validate_unknown_columns(
-        columns: Set[str],
-        selected_columns: Set[str]
+        selected_columns: Set[str],
+        columns: Set[str]
     ) -> None:
-        unknown_column = columns - set(selected_columns)
+        unknown_column = selected_columns - columns
         if len(unknown_column) > 0:
             msg = 'Contains an unknown columns. '
             msg += f'{unknown_column}'
@@ -150,8 +150,12 @@ class Records(RecordsInterface):
         columns = columns or []
 
         columns_set = set(columns)
+        columns_set_ = set()
         for records in records_args:
-            Records.__validate_unknown_columns(set(records.columns), columns_set)
+            for column in records.columns:
+                columns_set_.add(column)
+
+        Records.__validate_unknown_columns(columns_set, columns_set_)
 
         Records.__validate_duplicated_columns(columns)
 
@@ -384,7 +388,6 @@ class Records(RecordsInterface):
         progress_label: Optional[str] = None  # unused
     ) -> Records:
         maxsize = 2**64 - 1
-        self._validate_merge_records(columns, self, right_records)
 
         left_records = self.clone()
         merge_left = how in ['left', 'outer']

--- a/src/caret_analyze/record/record.py
+++ b/src/caret_analyze/record/record.py
@@ -113,11 +113,7 @@ class Records(RecordsInterface):
 
         columns_set = set(columns)
         for record in init:
-            unknown_column = set(record.columns) - columns_set
-            if len(unknown_column) > 0:
-                msg = 'Contains an unknown columns. '
-                msg += f'{unknown_column}'
-                raise InvalidArgumentError(msg)
+            Records._validate_unknown_columns(set(record.columns), columns_set)
 
         Records._validate_duplicated_columns(columns)
 
@@ -136,6 +132,17 @@ class Records(RecordsInterface):
             raise InvalidArgumentError(msg)
 
     @staticmethod
+    def _validate_unknown_columns(
+        columns: Set[str],
+        selected_columns: Set[str]
+    ) -> None:
+        unknown_column = columns - set(selected_columns)
+        if len(unknown_column) > 0:
+            msg = 'Contains an unknown columns. '
+            msg += f'{unknown_column}'
+            raise InvalidArgumentError(msg)
+
+    @staticmethod
     def _validate_merge_records(
         left: RecordsInterface,
         right: RecordsInterface,
@@ -145,11 +152,7 @@ class Records(RecordsInterface):
 
         columns_set = set(columns)
         for records in [left, right]:
-            unknown_column = set(records.columns) - columns_set
-            if len(unknown_column) > 0:
-                msg = 'Contains an unknown columns. '
-                msg += f'{unknown_column}'
-                raise InvalidArgumentError(msg)
+            Records._validate_unknown_columns(set(records.columns), columns_set)
 
         Records._validate_duplicated_columns(columns)
 

--- a/src/caret_analyze/record/record.py
+++ b/src/caret_analyze/record/record.py
@@ -17,8 +17,7 @@ from __future__ import annotations
 from copy import deepcopy
 from enum import IntEnum
 from itertools import groupby
-from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple
-from multimethod import multimethod as singledispatchmethod
+from typing import Callable, Dict, List, Optional, Sequence, Set , Tuple
 import pandas as pd
 
 from .column import Column, Columns, ColumnValue
@@ -120,6 +119,11 @@ class Records(RecordsInterface):
                 msg += f'{unknown_column}'
                 raise InvalidArgumentError(msg)
 
+        Records._validate_duplicated_columns(columns)
+
+
+    @staticmethod
+    def _validate_duplicated_columns(columns: Sequence[str]):
         if len(set(columns)) != len(columns):
             from itertools import groupby
             msg = 'columns must be unique. '
@@ -147,16 +151,7 @@ class Records(RecordsInterface):
                 msg += f'{unknown_column}'
                 raise InvalidArgumentError(msg)
 
-        if len(set(columns)) != len(columns):
-            from itertools import groupby
-            msg = 'columns must be unique. '
-            columns = sorted(columns)
-            msg += 'duplicated columns: '
-            for key, group in groupby(columns):
-                if len(list(group)) >= 2:
-                    msg += f'{key}, '
-
-            raise InvalidArgumentError(msg)
+        Records._validate_duplicated_columns(columns)
 
     def __len__(self) -> int:
         return len(self.data)

--- a/src/caret_analyze/record/record.py
+++ b/src/caret_analyze/record/record.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 from copy import deepcopy
 from enum import IntEnum
 from itertools import groupby
-from typing import Callable, Dict, List, Optional, Sequence, Set , Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple
+
 import pandas as pd
 
 from .column import Column, Columns, ColumnValue
@@ -116,7 +117,6 @@ class Records(RecordsInterface):
             Records._validate_unknown_columns(set(record.columns), columns_set)
 
         Records._validate_duplicated_columns(columns)
-
 
     @staticmethod
     def _validate_duplicated_columns(columns: Sequence[str]):

--- a/src/caret_analyze/record/record.py
+++ b/src/caret_analyze/record/record.py
@@ -144,14 +144,13 @@ class Records(RecordsInterface):
 
     @staticmethod
     def _validate_merge_records(
-        left: RecordsInterface,
-        right: RecordsInterface,
-        columns: Optional[List[str]]
+        columns: Optional[List[str]],
+        *records_args: RecordsInterface,
     ) -> None:
         columns = columns or []
 
         columns_set = set(columns)
-        for records in [left, right]:
+        for records in records_args:
             Records._validate_unknown_columns(set(records.columns), columns_set)
 
         Records._validate_duplicated_columns(columns)
@@ -385,7 +384,7 @@ class Records(RecordsInterface):
         progress_label: Optional[str] = None  # unused
     ) -> Records:
         maxsize = 2**64 - 1
-        self._validate_merge_records(self, right_records, columns)
+        self._validate_merge_records(columns, self, right_records)
 
         left_records = self.clone()
         merge_left = how in ['left', 'outer']

--- a/src/caret_analyze/record/record.py
+++ b/src/caret_analyze/record/record.py
@@ -152,8 +152,7 @@ class Records(RecordsInterface):
         columns_set = set(columns)
         columns_set_ = set()
         for records in records_args:
-            for column in records.columns:
-                columns_set_.add(column)
+            columns_set_ |= set(records.columns)
 
         Records.__validate_unknown_columns(columns_set, columns_set_)
 

--- a/src/caret_analyze/record/record.py
+++ b/src/caret_analyze/record/record.py
@@ -114,12 +114,12 @@ class Records(RecordsInterface):
 
         columns_set = set(columns)
         for record in init:
-            Records._validate_unknown_columns(set(record.columns), columns_set)
+            Records.__validate_unknown_columns(set(record.columns), columns_set)
 
-        Records._validate_duplicated_columns(columns)
+        Records.__validate_duplicated_columns(columns)
 
     @staticmethod
-    def _validate_duplicated_columns(columns: Sequence[str]):
+    def __validate_duplicated_columns(columns: Sequence[str]):
         if len(set(columns)) != len(columns):
             from itertools import groupby
             msg = 'columns must be unique. '
@@ -132,7 +132,7 @@ class Records(RecordsInterface):
             raise InvalidArgumentError(msg)
 
     @staticmethod
-    def _validate_unknown_columns(
+    def __validate_unknown_columns(
         columns: Set[str],
         selected_columns: Set[str]
     ) -> None:
@@ -151,9 +151,9 @@ class Records(RecordsInterface):
 
         columns_set = set(columns)
         for records in records_args:
-            Records._validate_unknown_columns(set(records.columns), columns_set)
+            Records.__validate_unknown_columns(set(records.columns), columns_set)
 
-        Records._validate_duplicated_columns(columns)
+        Records.__validate_duplicated_columns(columns)
 
     def __len__(self) -> int:
         return len(self.data)

--- a/src/caret_analyze/record/record_cpp_impl.py
+++ b/src/caret_analyze/record/record_cpp_impl.py
@@ -246,6 +246,8 @@ class RecordsCppImpl(RecordsInterface):
         progress_label: Optional[str] = None,
     ) -> RecordsInterface:
         progress_label = progress_label or ''
+        Records._validate_merge_records(self, right_records, columns)
+
         assert isinstance(right_records, RecordsCppImpl)
         merged_cpp_base = self._records.merge_sequential(
             right_records._records,

--- a/src/caret_analyze/record/record_cpp_impl.py
+++ b/src/caret_analyze/record/record_cpp_impl.py
@@ -127,6 +127,8 @@ class RecordsCppImpl(RecordsInterface):
         assert how in ['inner', 'left', 'right', 'outer']
         assert isinstance(right_records, RecordsCppImpl)
 
+        Records._validate_merge_records(columns, self, right_records)
+
         merged_cpp_base = self._records.merge(
             right_records._records, join_left_key, join_right_key,
             columns, how,
@@ -282,6 +284,8 @@ class RecordsCppImpl(RecordsInterface):
     ) -> RecordsInterface:
         assert isinstance(copy_records, RecordsCppImpl)
         assert isinstance(sink_records, RecordsCppImpl)
+
+        Records._validate_merge_records(columns, self, copy_records, sink_records)
 
         progress_label = progress_label or ''
         merged_cpp_base = self._records.merge_sequential_for_addr_track(

--- a/src/caret_analyze/record/record_cpp_impl.py
+++ b/src/caret_analyze/record/record_cpp_impl.py
@@ -246,7 +246,7 @@ class RecordsCppImpl(RecordsInterface):
         progress_label: Optional[str] = None,
     ) -> RecordsInterface:
         progress_label = progress_label or ''
-        Records._validate_merge_records(self, right_records, columns)
+        Records._validate_merge_records(columns, self, right_records)
 
         assert isinstance(right_records, RecordsCppImpl)
         merged_cpp_base = self._records.merge_sequential(

--- a/src/test/record/test_record.py
+++ b/src/test/record/test_record.py
@@ -1755,6 +1755,38 @@ class TestRecords:
 
             assert merged.equals(expect_records)
 
+    def test_merge_sequential_validate(self):
+        left_records_py: Records = Records(
+            [
+                Record({'stamp': 0}),
+            ],
+            [ColumnValue('stamp')]
+        )
+
+        right_records_py: Records = Records(
+            [
+                Record({'sub_stamp': 1}),
+            ],
+            [ColumnValue('sub_stamp')]
+        )
+
+        for left_records, right_records in zip(
+            [left_records_py, to_cpp_records(left_records_py)],
+            [right_records_py, to_cpp_records(right_records_py)],
+        ):
+            if left_records is None and not CppImplEnabled:
+                continue
+            with pytest.raises(InvalidArgumentError):
+                left_records.merge_sequential(
+                    right_records=right_records,
+                    left_stamp_key='stamp',
+                    right_stamp_key='sub_stamp',
+                    join_left_key=None,
+                    join_right_key=None,
+                    columns=['not_exist'],
+                    how='left',
+                )
+
     @pytest.mark.parametrize(
         'how, expect_records_py',
         [


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR adds InvalidArgumentError for following case.


```python
left_records.merge_sequential(
    **args,
    columns=['not_exist_column_name'],
    how='left'
)
```

These validation are applied for `merge` and `merge_sequential_for_addr_track` as well.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
