### PR TITLE
fix(architecture): annotation for list to avoid runtime error

### DIFF
--- a/src/caret_analyze/architecture/struct/node.py
+++ b/src/caret_analyze/architecture/struct/node.py
@@ -191,7 +191,7 @@ class NodeStruct():
             None if self.variable_passings is None
             else tuple(v.to_value() for v in self.variable_passings))
 
-    def update_node_path(self, paths: list[NodePathStruct]):
+    def update_node_path(self, paths: List[NodePathStruct]):
         self._node_paths = paths
 
     # def assign_message_context(self, node_name: str, context_type: str,


### PR DESCRIPTION
Signed-off-by: takeshi.iwanari <takeshi.iwanari@tier4.jp>

## Description

- Due to `list` annotation, `'type' object is not subscriptable` error occurs when running cli commands like `ros2 caret check_ctf` in Galactic
- Only one part uses `list` while all the other parts use `List` for annotation
- This PR changes `list` annotation to `List` annotation

## Related links

None

## Notes for reviewers

None

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
