### PR TITLE
fix(plot): fix corrupted x-axis by using AdaptiveTicker, and display …

### DIFF
--- a/src/caret_analyze/plot/util.py
+++ b/src/caret_analyze/plot/util.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 from logging import getLogger
 from typing import Sequence, Tuple, Union
 
-import datetime
-
-from bokeh.models import LinearAxis, Range1d, AdaptiveTicker
+from bokeh.models import AdaptiveTicker, LinearAxis, Range1d
 from bokeh.plotting import Figure
 
 import numpy as np

--- a/src/caret_analyze/plot/util.py
+++ b/src/caret_analyze/plot/util.py
@@ -15,7 +15,9 @@
 from logging import getLogger
 from typing import Sequence, Tuple, Union
 
-from bokeh.models import LinearAxis, Range1d, SingleIntervalTicker
+import datetime
+
+from bokeh.models import LinearAxis, Range1d, AdaptiveTicker
 from bokeh.plotting import Figure
 
 import numpy as np
@@ -72,7 +74,7 @@ def apply_x_axis_offset(
     xaxis = LinearAxis(x_range_name=x_range_name)
     xaxis.visible = False  # type: ignore
 
-    ticker = SingleIntervalTicker(interval=1, num_minor_ticks=10)
+    ticker = AdaptiveTicker(min_interval=0.1, mantissas=[1, 2, 5])
     fig.xaxis.ticker = ticker
     fig.add_layout(xaxis, 'below')
 
@@ -81,7 +83,8 @@ def apply_x_axis_offset(
     fig.xgrid.minor_grid_line_color = 'black'
     fig.xgrid.minor_grid_line_alpha = 0.1
 
-    fig.xaxis.major_label_overrides = {0: f'0+{offset_s}'}
+    datetime_s = datetime.datetime.fromtimestamp(offset_s).strftime('%Y-%m-%d %H:%M:%S')
+    fig.xaxis.major_label_overrides = {0: datetime_s}
 
 
 # TODO: Duplication of source code. Use visualize_lib

--- a/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 from logging import getLogger
 from typing import List, Sequence, Tuple, Union
 
-from bokeh.models import Arrow, LinearAxis, NormalHead, Range1d, SingleIntervalTicker
+import datetime
+
+from bokeh.models import Arrow, LinearAxis, NormalHead, Range1d, AdaptiveTicker
 from bokeh.plotting import Figure, figure
 import numpy as np
 import pandas as pd
@@ -343,7 +345,7 @@ class Bokeh(VisualizeLibInterface):
         xaxis = LinearAxis(x_range_name=x_range_name)
         xaxis.visible = False  # type: ignore
 
-        ticker = SingleIntervalTicker(interval=1, num_minor_ticks=10)
+        ticker = AdaptiveTicker(min_interval=0.1, mantissas=[1, 2, 5])
         fig.xaxis.ticker = ticker
         fig.add_layout(xaxis, 'below')
 
@@ -352,4 +354,5 @@ class Bokeh(VisualizeLibInterface):
         fig.xgrid.minor_grid_line_color = 'black'
         fig.xgrid.minor_grid_line_alpha = 0.1
 
-        fig.xaxis.major_label_overrides = {0: f'0+{offset_s}'}
+        datetime_s = datetime.datetime.fromtimestamp(offset_s).strftime('%Y-%m-%d %H:%M:%S')
+        fig.xaxis.major_label_overrides = {0: datetime_s}

--- a/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
@@ -14,12 +14,11 @@
 
 from __future__ import annotations
 
+import datetime
 from logging import getLogger
 from typing import List, Sequence, Tuple, Union
 
-import datetime
-
-from bokeh.models import Arrow, LinearAxis, NormalHead, Range1d, AdaptiveTicker
+from bokeh.models import AdaptiveTicker, Arrow, LinearAxis, NormalHead, Range1d
 from bokeh.plotting import Figure, figure
 import numpy as np
 import pandas as pd

--- a/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
@@ -355,3 +355,16 @@ class Bokeh(VisualizeLibInterface):
 
         datetime_s = datetime.datetime.fromtimestamp(offset_s).strftime('%Y-%m-%d %H:%M:%S')
         fig.xaxis.major_label_overrides = {0: datetime_s}
+
+        # # Code to display hhmmss for x-axis
+        # from bokeh.models import FuncTickFormatter
+        # fig.xaxis.formatter = FuncTickFormatter(
+        #     code = '''
+        #     let time_ms = (tick + offset_s) * 1e3;
+        #     let date_time = new Date(time_ms);
+        #     let hh = date_time.getHours();
+        #     let mm = date_time.getMinutes();
+        #     let ss = date_time.getSeconds();
+        #     return hh + ":" + mm + ":" + ss;
+        #     ''',
+        #     args={"offset_s": offset_s})


### PR DESCRIPTION
fix corrupted x-axis by using AdaptiveTicker, and display datetime instead of UNIX time for zero point

Signed-off-by: takeshi.iwanari <takeshi.iwanari@tier4.jp>

## Description

### Current issue

- X-axis ticks becomes unreadable when the length of graph is long (about more than 2 minutes)
- Unix time is displayed as offset (zero point), but it's inconvenient

![image](https://user-images.githubusercontent.com/105265012/218006138-2d15920d-7547-4a3c-b813-252a197eb416.png)

### What's changed

- Use AdaptiveTicker instead of SingleTicker, so that the interval of x-axis is adjusted as scale changes
- Display datetime instead of UNIX time

![image](https://user-images.githubusercontent.com/105265012/218006171-1134f7d0-39bd-4c80-912e-d5c1f88cac98.png)
![image](https://user-images.githubusercontent.com/105265012/218006194-6ec8c740-06fd-4da4-a5d8-0c63aa7f200d.png)


## Related links

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/T4PB-24221)

## Notes for reviewers

- None

## Memo

- So far, a user needs to add offset(zero-point) and the value of x-axis to get absolute datetime
- We can use hhmmss format for x-axis as well, but x-axis with hhmmss format makes it hard to see duration in a graph especially when scale is less than 1 second. (Although, it's useful to find datetime when a problem occurs like an increase of latency)
- So, I don't use hhmmss format for each x-axis value at the moment, but just leave a note how to modify it

```diff
diff --git a/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py b/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
index 17d188b..63fcfae 100644
--- a/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
@@ -355,3 +355,15 @@ class Bokeh(VisualizeLibInterface):
 
         datetime_s = datetime.datetime.fromtimestamp(offset_s).strftime('%Y-%m-%d %H:%M:%S')
         fig.xaxis.major_label_overrides = {0: datetime_s}
+
+        from bokeh.models import FuncTickFormatter
+        fig.xaxis.formatter = FuncTickFormatter(
+            code = '''
+            let time_ms = (tick + offset_s) * 1e3;
+            let date_time = new Date(time_ms);
+            let hh = date_time.getHours();
+            let mm = date_time.getMinutes();
+            let ss = date_time.getSeconds();
+            return hh + ":" + mm + ":" + ss;
+            ''',
+            args={"offset_s": offset_s})
```

![image](https://user-images.githubusercontent.com/105265012/218020220-46c2bd58-8053-4548-b165-b4eee87aba4e.png)


## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
