### PR TITLE
Feat: record for stacked bar

### DIFF
--- a/src/caret_analyze/record/__init__.py
+++ b/src/caret_analyze/record/__init__.py
@@ -22,7 +22,7 @@ from .record import (merge,
                      Records,
                      RecordsInterface)
 from .record_factory import RecordFactory, RecordsFactory
-from .records_service import Frequency, Latency, Period, Range, ResponseTime
+from .records_service import Frequency, Latency, Period, Range, ResponseTime, StackedBar
 
 __all__ = [
     'Clip',
@@ -41,6 +41,7 @@ __all__ = [
     'RecordsFactory',
     'RecordsInterface',
     'ResponseTime',
+    'StackedBar',
     'Strip',
     'merge',
     'merge_sequential',

--- a/src/caret_analyze/record/records_service/__init__.py
+++ b/src/caret_analyze/record/records_service/__init__.py
@@ -17,6 +17,7 @@ from .latency import Latency
 from .period import Period
 from .range import Range
 from .response_time import ResponseTime
+from .stacked_bar import StackedBar
 
 __all__ = [
     'Frequency',
@@ -24,4 +25,5 @@ __all__ = [
     'Period',
     'Range',
     'ResponseTime',
+    'StackedBar',
 ]

--- a/src/caret_analyze/record/records_service/stacked_bar.py
+++ b/src/caret_analyze/record/records_service/stacked_bar.py
@@ -1,0 +1,264 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..interface import RecordsInterface
+from ..record_factory import RecordsFactory
+from ..record import ColumnValue
+from .latency import Latency
+
+
+from typing import Dict, List
+
+class StackedBar:
+    def __init__(
+        self,
+        records: RecordsInterface,
+    ) -> None:
+        """
+        Generate records for stacked bar.
+
+        Parameters
+        ----------
+        records : RecordsInterface
+            Records of response time.
+
+        Raises
+        ------
+        ValueError
+            Error occurs if the records are empty.
+        """
+
+        # rename columns to nodes and topics granularity
+        self._records = records
+        self._diff_response_time_name = '[worst - best] response time'
+        rename_map: Dict[str, str] = \
+            self._get_rename_column_map(self._records.columns)
+        renamed_records: RecordsInterface = \
+            self._rename_columns(self._records, rename_map)
+        columns = list(rename_map.values())
+        if len(columns) < 2:
+            raise ValueError(f'Column size is {len(columns)} and must be more 2.')
+
+        # add stacked bar data
+        xlabel: str = 'start time'
+        x_axis_values: RecordsInterface = self._get_x_axis_values(renamed_records, self._diff_response_time_name, xlabel)
+        stacked_bar_records = self._to_stacked_bar_records(renamed_records, columns)
+        stacked_bar_records = \
+            self._append_column_series(
+                stacked_bar_records,
+                x_axis_values.get_column_series(xlabel),
+                xlabel,
+            )
+        self._stacked_bar_records = stacked_bar_records
+        self._columns = columns[:-1]
+
+    @staticmethod
+    def _rename_columns(
+        records: RecordsInterface,
+        rename_map: Dict[str, str],
+    ) -> RecordsInterface:
+        """
+        Rename columns of records.
+
+        Parameters
+        ----------
+        records : RecordsInterface
+            Target records.
+        rename_map : Dict[str, str]
+            Names before and after changed.
+
+        Returns
+        -------
+        RecordsInterface
+            Renamed records
+        """
+
+        for before, after in rename_map.items():
+            records.rename_columns({before : after})
+        return records
+
+    def _get_rename_column_map(
+        self,
+        raw_columns: List[str],
+    ) -> Dict[str, str]:
+        """
+        Generate rename map to visualize Node/Topic granularity.
+
+        Parameters
+        ----------
+        raw_columns : List[str]
+            Source columns.
+
+        Returns
+        -------
+        Dict[str, str]
+            Names before and after changed.
+        """
+
+        rename_map: Dict[str, str] = {}
+        end_word: str = '_min'
+        for column in raw_columns:
+            if column.endswith(end_word):
+                rename_map[column] = self._diff_response_time_name
+            elif 'rclcpp_publish' in column:
+                topic_name = column.split('/')[:-2]
+                rename_map[column] = '/'.join(topic_name)
+            elif 'callback_start' in column:
+                node_name = column.split('/')[:-2]
+                rename_map[column] = '/'.join(node_name)
+
+        return rename_map
+
+    @staticmethod
+    def _get_x_axis_values(
+        records: RecordsInterface,
+        column: str,
+        xlabel: str,
+    ) -> RecordsInterface:
+        """
+        Get x axis values.
+
+        Parameters
+        ----------
+        records : RecordsInterface
+            Target records.
+        column : str
+            Target column.
+        xlabel : str
+            Label name.
+
+        Returns
+        -------
+        RecordsInterface
+            Target column's records.
+        """
+
+        series = records.get_column_series(column)
+        record_dict = [{xlabel : _ } for _ in series]
+        record: RecordsInterface = RecordsFactory.create_instance(record_dict, [ColumnValue(xlabel)])
+        return record
+
+    def _to_stacked_bar_records(
+        self,
+        records: RecordsInterface,
+        columns: List[str],
+    ) -> RecordsInterface:
+        """
+        Caluculate stacked bar data.
+
+        Parameters
+        ----------
+        records : RecordsInterface
+            Target records.
+        columns : List[str]
+            Target columns (Node/Topic granularity).
+
+        Returns
+        -------
+        RecordsInterface
+            Stacked bar records.
+        """
+
+        output_records: RecordsInterface = RecordsFactory.create_instance()
+        record_size = len(records.data)
+        for column in columns[:-1]:
+            output_records.append_column(ColumnValue(column), [])
+
+        for column_from, column_to in zip(columns[:-1], columns[1:]):
+            latency_handler = Latency(records, column_from, column_to)
+            assert record_size == len(latency_handler.to_records())
+
+            latency_records = latency_handler.to_records()
+            latency = latency_records.get_column_series('latency')
+
+            output_records = self._append_column_series(output_records, list(latency), column_from)
+
+        return output_records
+
+    @staticmethod
+    def _append_column_series(
+        records: RecordsInterface,
+        series: List[int],
+        column: str,
+    ) -> RecordsInterface:
+        """
+        Append series to records.
+
+        Parameters
+        ----------
+        records : RecordsInterface
+            Source records.
+        series : List[int]
+            Data to append.
+        column : str
+            The column with appneded data.
+
+        Returns
+        -------
+        RecordsInterface
+            Appended records.
+        """
+
+        record_dict = [{column : t} for t in series]
+
+        if len(records.data) == 0:
+            new_records: RecordsInterface = \
+                RecordsFactory.create_instance(record_dict, [ColumnValue(column)])
+            records.concat(new_records)
+        else:
+            records.append_column(ColumnValue(column), series)
+        return records
+
+    def to_dict(self) -> Dict[str, List[int]]:
+        """
+        Get stacked bar dict data.
+
+        Returns
+        -------
+        Dict[str, List[int]]
+            Stacked bar dict data.
+        """
+
+        return self._to_dict(self._stacked_bar_records)
+
+    @staticmethod
+    def _to_dict(records: RecordsInterface) -> Dict[str, List[int]]:
+        """
+        Generate dict from records.
+
+        Parameters
+        ----------
+        records : RecordsInterface
+            Target records.
+
+        Returns
+        -------
+        Dict[str, List[int]]
+            Dict generated from records.
+
+        """
+        columns = records.columns
+        output_dict: Dict[str, List[int]] = {}
+        for column in columns:
+            output_dict[column] = records.get_column_series(column)
+        return output_dict
+
+    @property
+    def columns(self) -> List[str]:
+        return self._columns
+
+    @property
+    def records(self) -> RecordsInterface:
+        return self._stacked_bar_records
+

--- a/src/test/record/records_service/test_stacked_bar.py
+++ b/src/test/record/records_service/test_stacked_bar.py
@@ -1,0 +1,108 @@
+# Copyright 2021 Research Institute of Systems Planning, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from caret_analyze.record import ColumnValue
+from caret_analyze.record import RecordsFactory, RecordsInterface
+from caret_analyze.record import StackedBar
+
+import pytest
+
+
+def create_records(data, columns):
+    records = RecordsFactory.create_instance(data, [ColumnValue(column) for column in columns])
+    return records
+
+def to_dict(records):
+    return [record.data for record in records]
+
+def get_data_set():
+    columns = [
+        '/columns_0/rclcpp_publish_timestamp/0_min',
+        '/columns_1/rclcpp_publish_timestamp/0_max',
+        '/columns_2/rcl_publish_timestamp/0',
+        '/columns_3/dds_write_timestamp/0',
+        '/columns_4/callback_0/callback_start_timestamp/0',
+        '/columns_5/rclcpp_publish_timestamp/0_max',
+        '/columns_6/rcl_publish_timestamp/0',
+        '/columns_7/dds_write_timestamp/0',
+        '/columns_8/callback_0/callback_start_timestamp/0',
+    ]
+
+    # create input and expect data
+    # # columns | c0 | c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 |
+    # # ======================================================
+    # # data    | 0  | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  |
+    # #         | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  |
+    # #         | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10 |
+
+    expect_dict = {
+        '[worst - best] response time' : [1, 1, 1], # c1 - c0
+        '/columns_1'                   : [3, 3, 3], # c4 - c1
+        '/columns_4/callback_0'        : [1, 1, 1], # c5 - c4
+        '/columns_5'                   : [3, 3, 3], # c8 - c5
+        'start time'                   : [0, 1, 2], # c0
+    }
+    expect_columns = [
+        '[worst - best] response time',
+        '/columns_1',
+        '/columns_4/callback_0',
+        '/columns_5',
+    ]
+
+    data_num = 3
+    data = []
+    for i in range(data_num):
+        d = {}
+        for j in range(len(columns)):
+            d[columns[j]] = i + j
+        data.append(d)
+
+    return columns, data, expect_columns, expect_dict
+
+
+class TestStackedBar:
+
+    def test_empty_case(self):
+        records: RecordsInterface = create_records([], [])
+        with pytest.raises(ValueError):
+            StackedBar(records)
+
+    def test_columns(self):
+        columns, data, expect_columns, _ = get_data_set()
+        records: RecordsInterface = create_records(data, columns)
+
+        stacked_bar = StackedBar(records)
+        assert stacked_bar.columns == expect_columns
+
+    def test_to_dict(self):
+        columns, data, _, expect_dict = get_data_set()
+        records: RecordsInterface = create_records(data, columns)
+
+        stacked_bar = StackedBar(records)
+        assert stacked_bar.to_dict() == expect_dict
+
+    def test_records(self):
+        columns, data, expect_columns, pre_expect_dict = get_data_set()
+        records: RecordsInterface = create_records(data, columns)
+        expect_columns += ['start time']
+        expect_dict = []
+        for i in range(len(pre_expect_dict[expect_columns[0]])):
+            d = {}
+            for column in expect_columns:
+                d[column] = pre_expect_dict[column][i]
+            expect_dict.append(d)
+
+        stacked_bar = StackedBar(records)
+        result = to_dict(stacked_bar.records)
+        assert result == expect_dict


### PR DESCRIPTION
## Description

Existing response time class serves only start and end timestamps.
However, to realize stacked bar, a timestamp in each tracepoint is needed.
Hasegawa and I added the API to get it.

## Related links

https://tier4.atlassian.net/browse/T4PB-23676

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
