### PR TITLE
fix: include last callback to stacked bar graph

### DIFF
--- a/src/caret_analyze/record/records_service/stacked_bar.py
+++ b/src/caret_analyze/record/records_service/stacked_bar.py
@@ -120,6 +120,10 @@ class StackedBar:
             elif 'callback_start' in column:
                 node_name = column.split('/')[:-2]
                 rename_map[column] = '/'.join(node_name)
+            elif 'callback_end' in column:
+                node_name = column.split('/')[:-2]
+                rename_map[column] = '/'.join(node_name)
+                rename_map[column] += '_end'
 
         return rename_map
 

--- a/src/test/plot/stacked_bar/test_latency_stacked_bar.py
+++ b/src/test/plot/stacked_bar/test_latency_stacked_bar.py
@@ -45,20 +45,22 @@ def get_data_set():
         '/columns_6/rcl_publish_timestamp/0',
         '/columns_7/dds_write_timestamp/0',
         '/columns_8/callback_0/callback_start_timestamp/0',
+        '/columns_9/callback_0/callback_end_timestamp/0',
     ]
 
     # create input and expect data
-    # # columns | c0 | c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 |
-    # # ======================================================
-    # # data    | 0  | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  |
-    # #         | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  |
-    # #         | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10 |
+    # # columns | c0 | c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 | c9 |
+    # # ===========================================================
+    # # data    | 0  | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  |
+    # #         | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10 |
+    # #         | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10 | 11 |
 
     expect_dict = {
         '[worst - best] response time': [1, 1, 1],  # c1 - c0
         '/columns_1':                   [3, 3, 3],  # c4 - c1
         '/columns_4/callback_0':        [1, 1, 1],  # c5 - c4
         '/columns_5':                   [3, 3, 3],  # c8 - c5
+        '/columns_8/callback_0':        [1, 1, 1],  # c9 - c8
         'start time':                   [0, 1, 2],  # c0
     }
     expect_columns = [
@@ -66,6 +68,7 @@ def get_data_set():
         '/columns_1',
         '/columns_4/callback_0',
         '/columns_5',
+        '/columns_8/callback_0',
     ]
 
     data_num = 3

--- a/src/test/record/records_service/test_stacked_bar.py
+++ b/src/test/record/records_service/test_stacked_bar.py
@@ -39,20 +39,22 @@ def get_data_set():
         '/columns_6/rcl_publish_timestamp/0',
         '/columns_7/dds_write_timestamp/0',
         '/columns_8/callback_0/callback_start_timestamp/0',
+        '/columns_9/callback_0/callback_end_timestamp/0',
     ]
 
     # create input and expect data
-    # # columns | c0 | c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 |
-    # # ======================================================
-    # # data    | 0  | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  |
-    # #         | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  |
-    # #         | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10 |
+    # # columns | c0 | c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 | c9 |
+    # # ===========================================================
+    # # data    | 0  | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  |
+    # #         | 1  | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10 |
+    # #         | 2  | 3  | 4  | 5  | 6  | 7  | 8  | 9  | 10 | 11 |
 
     expect_dict = {
         '[worst - best] response time': [1, 1, 1],  # c1 - c0
         '/columns_1':                   [3, 3, 3],  # c4 - c1
         '/columns_4/callback_0':        [1, 1, 1],  # c5 - c4
         '/columns_5':                   [3, 3, 3],  # c8 - c5
+        '/columns_8/callback_0':        [1, 1, 1],  # c9 - c8
         'start time':                   [0, 1, 2],  # c0
     }
     expect_columns = [
@@ -60,6 +62,7 @@ def get_data_set():
         '/columns_1',
         '/columns_4/callback_0',
         '/columns_5',
+        '/columns_8/callback_0',
     ]
 
     data_num = 3


### PR DESCRIPTION
## Description

Include the last callback_end to stacked bar graph

### Before
![image](https://user-images.githubusercontent.com/105265012/228738125-2b408019-3076-4362-8746-8d0d3aa28203.png)

### After
![image](https://user-images.githubusercontent.com/105265012/228738028-3d9d1cd5-e0e7-4f2e-9b46-f51d1d56ee89.png)

### Test code

```py
    target_path = app.get_path(target_path.path_name)
    target_path.include_first_callback = True
    target_path.include_last_callback = True
    message_flow(target_path)
    Plot.create_response_time_stacked_bar_plot(target_path, case='best').show(full_legends=True)
    Plot.create_response_time_stacked_bar_plot(target_path, case='worst').show(full_legends=True)
```

## Related links

https://tier4.atlassian.net/browse/T4PB-26673

## Notes for reviewers

- I fix this issue by myself because I need this urgently
- The first callback is added without any modification. Could you check if it's as expected from the view point of code?

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
