### PR TITLE
fix(message_flow): include last callback to message flow with granularity='node'

### DIFF
--- a/src/caret_analyze/plot/visualize_lib/bokeh/message_flow_source.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/message_flow_source.py
@@ -293,8 +293,8 @@ class NodeLevelFormatter(DataFrameFormatter):
             if parsed_before.node_name is not None and parsed.node_name is not None and \
                     parsed_before.node_name == parsed.node_name and \
                     'rclcpp_publish' not in parsed.tracepoint_name and \
-                    not ('callback_start' not in parsed_before.tracepoint_name and
-                         'callback_end' not in parsed.tracepoint_name):
+                    not ('callback_start' in parsed_before.tracepoint_name and
+                         'callback_end' in parsed.tracepoint_name):
                 drop_columns.append(column_name)
 
             if parsed_before.topic_name is not None and parsed.topic_name is not None and \

--- a/src/caret_analyze/plot/visualize_lib/bokeh/message_flow_source.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/message_flow_source.py
@@ -292,7 +292,9 @@ class NodeLevelFormatter(DataFrameFormatter):
             # the last publish column of the node.
             if parsed_before.node_name is not None and parsed.node_name is not None and \
                     parsed_before.node_name == parsed.node_name and \
-                    'rclcpp_publish' not in parsed.tracepoint_name:
+                    'rclcpp_publish' not in parsed.tracepoint_name and \
+                    not ('callback_start' not in parsed_before.tracepoint_name and
+                         'callback_end' not in parsed.tracepoint_name):
                 drop_columns.append(column_name)
 
             if parsed_before.topic_name is not None and parsed.topic_name is not None and \


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
The first and last callback times added to `message_flow` at https://github.com/tier4/CARET_analyze/pull/263. A bug was found where the last callback was not included when the `message_flow` was used with option `granularity='node'`. This problem was caused by the way the column name was formatted when `granularity='node'`.

### Before
![image](https://user-images.githubusercontent.com/114902604/229083777-a71e89b6-c582-48d3-949e-9a8a4142ec86.png)

### After
![image](https://user-images.githubusercontent.com/114902604/229084216-0abf8742-98ab-497d-84d5-8bdd70624ce5.png)

## Related links
- https://github.com/tier4/CARET_analyze/pull/263

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
