### PR TITLE
refactor(plot): refactor Plot.show() method

### DIFF
--- a/src/caret_analyze/plot/callback_scheduling/callback_scheduling_plot.py
+++ b/src/caret_analyze/plot/callback_scheduling/callback_scheduling_plot.py
@@ -113,18 +113,10 @@ class CallbackSchedulingPlot(PlotBase):
         xaxis_type: Optional[str] = None,
         ywheel_zoom: Optional[bool] = None,
         full_legends: Optional[bool] = None,
-        export_path: Optional[str] = None,  # TODO: remove
         coloring_rule: Optional[str] = None,
-    ) -> Figure:
+    ) -> None:
         p = self.figure(xaxis_type, ywheel_zoom, full_legends, coloring_rule)
-        if export_path:
-            logger.warning("The 'export_path' option is deprecated, please use 'save' method.")
-            self.save(export_path=export_path, xaxis_type=xaxis_type,
-                      ywheel_zoom=ywheel_zoom, full_legends=full_legends)
-        else:
-            show(p)
-
-        return p
+        show(p)
 
     def save(
         self,

--- a/src/caret_analyze/plot/message_flow_old.py
+++ b/src/caret_analyze/plot/message_flow_old.py
@@ -41,7 +41,7 @@ def message_flow(
     plot = Plot.create_message_flow_plot(
         path, granularity, treat_drop_as_delay, lstrip_s, rstrip_s)
     xaxis_type = 'sim_time' if use_sim_time else 'system_time'
-    p = plot.show(xaxis_type=xaxis_type)
+    p = plot.figure(xaxis_type=xaxis_type)
     if export_path:
         plot.save(export_path=export_path, xaxis_type=xaxis_type)
 

--- a/src/caret_analyze/plot/plot_base.py
+++ b/src/caret_analyze/plot/plot_base.py
@@ -48,9 +48,8 @@ class PlotBase(metaclass=ABCMeta):
         xaxis_type: Optional[str] = None,
         ywheel_zoom: Optional[bool] = None,
         full_legends: Optional[bool] = None,
-        export_path: Optional[str] = None,  # TODO: remove
         # TODO: add interactive option
-    ) -> Figure:
+    ) -> None:
         """
         Draw a graph using the bokeh library.
 
@@ -65,13 +64,6 @@ class PlotBase(metaclass=ABCMeta):
         full_legends : bool
             If True, all legends are drawn
             even if the number of legends exceeds the threshold.
-        export_path : str, optional
-            The graph will be saved as a file.
-            This option is deprecated, please use save method.
-
-        Returns
-        -------
-        bokeh.plotting.Figure
 
         Raises
         ------
@@ -80,14 +72,7 @@ class PlotBase(metaclass=ABCMeta):
 
         """
         p = self.figure(xaxis_type, ywheel_zoom, full_legends)
-        if export_path:
-            logger.warning("The 'export_path' option is deprecated, please use 'save' method.")
-            self.save(export_path=export_path, xaxis_type=xaxis_type,
-                      ywheel_zoom=ywheel_zoom, full_legends=full_legends)
-        else:
-            show(p)
-
-        return p
+        show(p)
 
     def save(
         self,


### PR DESCRIPTION
## Description
This PR removes `export_path` argument and set return value to None in show() method.
The `export_path` argument is not required because of the existence of the save() method.

## Related links
- JIRA ticket: https://tier4.atlassian.net/browse/RT2-627
- Discussion: https://tier4.atlassian.net/browse/RT2-445?focusedCommentId=119691
- To reproduce:
  - [ipynb](https://drive.google.com/drive/folders/1WgkHpz2Ic0UT3_uF0rfcVYP7LZKov-Mc?usp=share_link)
  - [architecture file](https://drive.google.com/file/d/1W9PDyj046xzapMA-p3o6HWtUhMA8JhIG/view?usp=share_link)
  - [trace data](https://drive.google.com/file/d/1xy1L4c-eGi9RSHog1qNgovTcwxoM74Z9/view?usp=share_link)

## Notes for reviewers
I have confirmed that there are no regressions using CARET_report.
![Screenshot from 2023-04-11 09-48-03](https://user-images.githubusercontent.com/55824710/231026864-9f55b85f-299f-4f04-a4e0-791edabd1f58.png)

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
