### PR TITLE
fix: minor changes for records processing

### DIFF
--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -1063,7 +1063,7 @@ class CallbackGroupsLoaded():
             else:
                 cbg_name = cbg.callback_group_name  \
                     or f'{node.node_name}/service_only_callback_group_' \
-                    + '{len(_srv_only_cbg_dict)}'
+                    + f'{len(_srv_only_cbg_dict)}'
                 _srv_only_cbg_dict[cbg] = len(_srv_only_cbg_dict)
 
             cbg_struct = CallbackGroupStruct(

--- a/src/caret_analyze/infra/lttng/records_source.py
+++ b/src/caret_analyze/infra/lttng/records_source.py
@@ -105,7 +105,7 @@ class RecordsSource():
             progress_label='binding: message_addr and rclcpp_publish',
         )
 
-        rcl_publish_records = self._data.rcl_publish_instances
+        rcl_publish_records = self._data.rcl_publish_instances.clone()
         rcl_publish_records.drop_columns([COLUMN_NAME.PUBLISHER_HANDLE])
         if len(rcl_publish_records) > 0:
             publish = merge_sequential(
@@ -244,7 +244,7 @@ class RecordsSource():
         """
         inter_proc_publish = self._data.rclcpp_publish_instances
 
-        rcl_publish_records = self._data.rcl_publish_instances
+        rcl_publish_records = self._data.rcl_publish_instances.clone()
         rcl_publish_records.drop_columns([COLUMN_NAME.PUBLISHER_HANDLE])
         if len(rcl_publish_records) > 0:
             inter_proc_publish = merge_sequential(
@@ -423,7 +423,7 @@ class RecordsSource():
             - tilde_subscription
 
         """
-        records = self._data.tilde_publish
+        records = self._data.tilde_publish.clone()
         records.rename_columns({'publisher': 'tilde_publisher'})
 
         subscription: List[int] = []


### PR DESCRIPTION
## Description
Minor fixes to problems with warnings when generating Lttng, Architecure objects.

The fixes addressed the following issues.
- Fixes to sequential numbering of service callback groups.
  - `Duplicated callback group name.` warnings are suppressed.
- Fixes to destructive methods in `infra.lttng.records_source.py`.
  - Modified to process cloned data instead of directly referencing data.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
