### PR TITLE
fix: remove tid from callback record

### DIFF
--- a/src/caret_analyze/infra/lttng/records_source.py
+++ b/src/caret_analyze/infra/lttng/records_source.py
@@ -660,7 +660,8 @@ class RecordsSource():
 
         records.drop_columns(
             [
-                COLUMN_NAME.IS_INTRA_PROCESS
+                COLUMN_NAME.IS_INTRA_PROCESS,
+                COLUMN_NAME.TID
             ]
         )
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
### overview
In https://github.com/tier4/CARET_analyze/pull/263, I added `tid` (thread id) information to the `rclcpp_callback_start` event to evaluate the time from the start node callback to publish. This caused a discrepancy in the list of column names between Records and Record.

example:
```
lttng = Lttng(rosbag_path)
arch = Architecture('lttng', rosbag_path)
app = Application(arch, lttng)

cb = app.callbacks[0]
records = cb.to_records()

print(records.columns)

    >>> ['/actuator_dummy_node/callback_0/callback_start_timestamp',
              '/actuator_dummy_node/callback_0/callback_end_timestamp']

print(records.data[0].columns)

    >>>> {'/actuator_dummy_node/callback_0/callback_end_timestamp',
                '/actuator_dummy_node/callback_0/callback_start_timestamp',
                'tid'}
```

### changes
remove `tid` from record columns.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
- https://github.com/tier4/CARET_analyze/pull/263
## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
