### PR TITLE
feat(plot): draw callback latency at fitst and last in chain_latency

### DIFF
--- a/src/caret_analyze/plot/graphviz/chain_latency.py
+++ b/src/caret_analyze/plot/graphviz/chain_latency.py
@@ -99,7 +99,13 @@ def get_attr_node(
     lstrip_s: float,
     rstrip_s: float
 ) -> GraphAttr:
-    def calc_latency(target_df: pd.DataFrame) -> np.ndarray:
+    def calc_latency_from_path_df(target_columns: list[str]) -> np.ndarray:
+        target_df = path.to_dataframe(
+            remove_dropped=remove_dropped,
+            treat_drop_as_delay=treat_drop_as_delay,
+            lstrip_s=lstrip_s,
+            rstrip_s=rstrip_s,
+        )[target_columns]
         source_stamps_ns = np.array(target_df.iloc[:, 0].values)
         dest_stamps_ns = np.array(target_df.iloc[:, -1].values)
         latency_ns = dest_stamps_ns - source_stamps_ns
@@ -116,24 +122,12 @@ def get_attr_node(
 
         if i == 0 and path.include_first_callback:
             first_cb_columns = path.column_names[0:2]
-            first_cb_df = path.to_dataframe(
-                remove_dropped=remove_dropped,
-                treat_drop_as_delay=treat_drop_as_delay,
-                lstrip_s=lstrip_s,
-                rstrip_s=rstrip_s,
-            )[first_cb_columns]
-            latency = calc_latency(first_cb_df)
+            latency = calc_latency_from_path_df(first_cb_columns)
             label += '\n' + to_label(latency)
 
         elif i == len(path.node_paths)-1 and path.include_last_callback:
             last_cb_columns = path.column_names[-2:]
-            last_cb_df = path.to_dataframe(
-                remove_dropped=remove_dropped,
-                treat_drop_as_delay=treat_drop_as_delay,
-                lstrip_s=lstrip_s,
-                rstrip_s=rstrip_s,
-            )[last_cb_columns]
-            latency = calc_latency(last_cb_df)
+            latency = calc_latency_from_path_df(last_cb_columns)
             label += '\n' + to_label(latency)
 
         elif node_path.column_names != []:


### PR DESCRIPTION
## Description
This PR fixes to draw callback latencies at the first and last for `chain_latency`.

## Related links
- Ticket: https://tier4.atlassian.net/browse/RT2-700
- Discussion: https://emb4hq.slack.com/archives/C05311Y9L2X/p1683795835886779
- To reproduce: https://drive.google.com/drive/folders/12UGwclt5yaY9UfuP38OFvcN7GyrvWjbN?usp=share_link

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
