### PR TITLE
fix: stacked bar plot not transparent on click

### DIFF
--- a/src/caret_analyze/plot/visualize_lib/bokeh/stacked_bar.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/stacked_bar.py
@@ -92,7 +92,8 @@ class BokehStackedBar:
                 x='start time',
                 top=y_label,
                 width='x_width_list',
-                source=stacked_bar_source.generate(y_label, stacked_bar_data, x_width_list, bottom_label),
+                source=stacked_bar_source.generate(y_label, stacked_bar_data,
+                                                   x_width_list, bottom_label),
                 color=color_selector.get_color(y_label),
                 bottom=bottom_label
             )
@@ -297,8 +298,8 @@ class StackedBarSource:
             ]
         else:
             latencies = target_data
-        
-        bottom_value = [0] * len(stacked_bar_data[y_label])
+
+        bottom_value: list[float] = [0] * len(stacked_bar_data[y_label])
         label_idx_of_bottom_value = y_labels.index(y_label) + 1
         if label_idx_of_bottom_value < len(y_labels) - 1:
             bottom_value = stacked_bar_data[y_labels[label_idx_of_bottom_value]]


### PR DESCRIPTION
## Description

In graphs generated by `Plot.create_response_time_stacked_bar_plot()`  the ability to make the drawing of certain callbacks semi-transparent is not working correctly.

<!-- Write a brief description of this PR. -->

## Related links

Jira: https://tier4.atlassian.net/browse/RT2-806

See also:
https://github.com/tier4/CARET_analyze/pull/287/files

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
