### PR TITLE
fix: mypy warning in type_check_decorator by signiture

### DIFF
--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -54,7 +54,7 @@ try:
 
         """
         error = e.errors()[0]
-        invalid_arg_name: str = error['loc'][0]
+        invalid_arg_name: str | int = error['loc'][0]
         expected_types: list[str] \
             = str(signature.parameters[invalid_arg_name].annotation).split(' | ')
 

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -174,7 +174,8 @@ try:
                 return validate_arguments_wrapper(*args, **kwargs)
             except ValidationError as e:
                 expected_types = _get_expected_types(e)
-                loc_tuple = e.errors()[0]['loc'] if len(e.errors()) == 1 else e.errors()[0]['loc'][:-1]
+                loc_tuple = e.errors()[0]['loc'] if len(e.errors()) == 1\
+                    else e.errors()[0]['loc'][:-1]
                 given_arg_loc_str = _get_given_arg_loc_str(loc_tuple)
                 given_arg_type = _get_given_arg_type(signature(func), args, kwargs, loc_tuple)
 

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -50,7 +50,7 @@ try:
                 '<EXPECT_TYPE>'
 
         """
-        expected_types: list[str] = []
+        expected_types: list[str | int | float] = []
         for error in e.errors():
             if error['type'] == 'type_error.arbitrary_type':  # Custom class type case
                 expected_types.append(error['ctx']['expected_arbitrary_type'])

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -52,10 +52,10 @@ try:
         """
         expected_types: list[str | int | float] = []
         for error in e.errors():
-            if error['type'] == 'type_error.arbitrary_type':  # Custom class type case
-                expected_types.append(error['ctx']['expected_arbitrary_type'])
+            if error['type'] == 'is_instance_of':  # Custom class type case
+                expected_types.append(error['ctx']['class'])
             else:
-                expected_types.append(error['type'].replace('type_error.', ''))
+                expected_types.append(error['type'])
 
         if len(expected_types) > 1:  # Union case
             expected_types_str = str(expected_types)
@@ -174,7 +174,7 @@ try:
                 return validate_arguments_wrapper(*args, **kwargs)
             except ValidationError as e:
                 expected_types = _get_expected_types(e)
-                loc_tuple = e.errors()[0]['loc']
+                loc_tuple = e.errors()[0]['loc'] if len(e.errors()) == 1 else e.errors()[0]['loc'][:-1]
                 given_arg_loc_str = _get_given_arg_loc_str(loc_tuple)
                 given_arg_type = _get_given_arg_type(signature(func), args, kwargs, loc_tuple)
 

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -54,7 +54,7 @@ try:
 
         """
         error = e.errors()[0]
-        invalid_arg_name: str | int = error['loc'][0]
+        invalid_arg_name: str = str(error['loc'][0])
         expected_types: list[str] \
             = str(signature.parameters[invalid_arg_name].annotation).split(' | ')
 

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -55,13 +55,14 @@ try:
         """
         error = e.errors()[0]
         invalid_arg_name: str = str(error['loc'][0])
-        expected_types: list[str] \
-            = str(signature.parameters[invalid_arg_name].annotation).split(' | ')
+        expected_type: str = str(signature.parameters[invalid_arg_name].annotation)
 
         if e.title == 'IterableArg':
-            expected_types = sum([findall(r'.*\[(.*)\]', t) for t in expected_types], [])
+            expected_type = str(findall(r'.*\[(.*)\]', expected_type)[0])
         if e.title == 'DictArg':
-            expected_types = sum([findall(r'.*\[.*, (.*)\]', t) for t in expected_types], [])
+            expected_type = str(findall(r'.*\[.*, (.*)\]', expected_type)[0])
+
+        expected_types: list[str] = expected_type.split(' | ')
 
         if len(expected_types) > 1:  # Union case
             expected_types_str = str(expected_types)

--- a/src/test/common/test_type_check_decorator.py
+++ b/src/test/common/test_type_check_decorator.py
@@ -65,6 +65,15 @@ class TestTypeCheckDecorator:
             iterable_arg([True, 10])
         assert "'i'[1] must be 'bool'. The given argument type is 'int'" in str(e.value)
 
+    def test_type_check_decorator_iterable_with_union(self):
+        @type_check_decorator
+        def iterable_arg(i: list[bool | str]):
+            pass
+
+        with pytest.raises(UnsupportedTypeError) as e:
+            iterable_arg([True, 10])
+        assert "'i'[1] must be ['bool', 'str']. The given argument type is 'int'" in str(e.value)
+
     def test_type_check_decorator_dict(self):
         @type_check_decorator
         def dict_arg(d: dict[str, bool]):
@@ -74,6 +83,17 @@ class TestTypeCheckDecorator:
             dict_arg({'key1': True,
                       'key2': 10})
         assert "'d'[key2] must be 'bool'. The given argument type is 'int'" in str(e.value)
+
+    def test_type_check_decorator_dict_with_union(self):
+        @type_check_decorator
+        def dict_arg(d: dict[str, bool | str]):
+            pass
+
+        with pytest.raises(UnsupportedTypeError) as e:
+            dict_arg({'key1': True,
+                      'key2': 10})
+        assert "'d'[key2] must be ['bool', 'str']. The given argument type is 'int'"\
+            in str(e.value)
 
     def test_type_check_decorator_kwargs(self):
         @type_check_decorator

--- a/src/test/common/test_type_check_decorator.py
+++ b/src/test/common/test_type_check_decorator.py
@@ -35,7 +35,7 @@ class TestTypeCheckDecorator:
 
         with pytest.raises(UnsupportedTypeError) as e:
             bool_arg(10)
-        assert "'b' must be 'bool_parsing'. The given argument type is 'int'" in str(e.value)
+        assert "'b' must be 'bool'. The given argument type is 'int'" in str(e.value)
 
     def test_type_check_decorator_custom_type(self):
 
@@ -54,8 +54,7 @@ class TestTypeCheckDecorator:
 
         with pytest.raises(UnsupportedTypeError) as e:
             union_arg(10)
-        assert "'u' must be ['bool_parsing', 'set_type']. The given argument type is 'int'"\
-            in str(e.value)
+        assert "'u' must be ['bool', 'set']. The given argument type is 'int'" in str(e.value)
 
     def test_type_check_decorator_iterable(self):
         @type_check_decorator
@@ -64,7 +63,7 @@ class TestTypeCheckDecorator:
 
         with pytest.raises(UnsupportedTypeError) as e:
             iterable_arg([True, 10])
-        assert "'i'[1] must be 'bool_parsing'. The given argument type is 'int'" in str(e.value)
+        assert "'i'[1] must be 'bool'. The given argument type is 'int'" in str(e.value)
 
     def test_type_check_decorator_dict(self):
         @type_check_decorator
@@ -74,7 +73,7 @@ class TestTypeCheckDecorator:
         with pytest.raises(UnsupportedTypeError) as e:
             dict_arg({'key1': True,
                       'key2': 10})
-        assert "'d'[key2] must be 'bool_parsing'. The given argument type is 'int'" in str(e.value)
+        assert "'d'[key2] must be 'bool'. The given argument type is 'int'" in str(e.value)
 
     def test_type_check_decorator_kwargs(self):
         @type_check_decorator
@@ -83,4 +82,4 @@ class TestTypeCheckDecorator:
 
         with pytest.raises(UnsupportedTypeError) as e:
             kwarg(k=10)
-        assert "'k' must be 'bool_parsing'. The given argument type is 'int'" in str(e.value)
+        assert "'k' must be 'bool'. The given argument type is 'int'" in str(e.value)

--- a/src/test/common/test_type_check_decorator.py
+++ b/src/test/common/test_type_check_decorator.py
@@ -74,6 +74,11 @@ class TestTypeCheckDecorator:
             iterable_arg([True, 10])
         assert "'i'[1] must be ['bool', 'str']. The given argument type is 'int'" in str(e.value)
 
+    # TODO: test_type_check_decorator_union_with_iterable
+        # @type_check_decorator
+        # def iterable_arg(i: list[bool] | str):
+        #     pass
+
     def test_type_check_decorator_dict(self):
         @type_check_decorator
         def dict_arg(d: dict[str, bool]):
@@ -83,6 +88,11 @@ class TestTypeCheckDecorator:
             dict_arg({'key1': True,
                       'key2': 10})
         assert "'d'[key2] must be 'bool'. The given argument type is 'int'" in str(e.value)
+
+    # TODO: test_type_check_decorator_dict_key
+        # with pytest.raises(UnsupportedTypeError) as e:
+        #     dict_arg({'key1': True,
+        #               1: 10})
 
     def test_type_check_decorator_dict_with_union(self):
         @type_check_decorator

--- a/src/test/common/test_type_check_decorator.py
+++ b/src/test/common/test_type_check_decorator.py
@@ -35,7 +35,7 @@ class TestTypeCheckDecorator:
 
         with pytest.raises(UnsupportedTypeError) as e:
             bool_arg(10)
-        assert "'b' must be 'bool'. The given argument type is 'int'" in str(e.value)
+        assert "'b' must be 'bool_parsing'. The given argument type is 'int'" in str(e.value)
 
     def test_type_check_decorator_custom_type(self):
 
@@ -54,7 +54,7 @@ class TestTypeCheckDecorator:
 
         with pytest.raises(UnsupportedTypeError) as e:
             union_arg(10)
-        assert "'u' must be ['bool', 'set']. The given argument type is 'int'" in str(e.value)
+        assert "'u' must be ['bool_parsing', 'set_type']. The given argument type is 'int'" in str(e.value)
 
     def test_type_check_decorator_iterable(self):
         @type_check_decorator
@@ -63,7 +63,7 @@ class TestTypeCheckDecorator:
 
         with pytest.raises(UnsupportedTypeError) as e:
             iterable_arg([True, 10])
-        assert "'i'[1] must be 'bool'. The given argument type is 'int'" in str(e.value)
+        assert "'i'[1] must be 'bool_parsing'. The given argument type is 'int'" in str(e.value)
 
     def test_type_check_decorator_dict(self):
         @type_check_decorator
@@ -73,7 +73,7 @@ class TestTypeCheckDecorator:
         with pytest.raises(UnsupportedTypeError) as e:
             dict_arg({'key1': True,
                       'key2': 10})
-        assert "'d'[key2] must be 'bool'. The given argument type is 'int'" in str(e.value)
+        assert "'d'[key2] must be 'bool_parsing'. The given argument type is 'int'" in str(e.value)
 
     def test_type_check_decorator_kwargs(self):
         @type_check_decorator
@@ -82,4 +82,4 @@ class TestTypeCheckDecorator:
 
         with pytest.raises(UnsupportedTypeError) as e:
             kwarg(k=10)
-        assert "'k' must be 'bool'. The given argument type is 'int'" in str(e.value)
+        assert "'k' must be 'bool_parsing'. The given argument type is 'int'" in str(e.value)

--- a/src/test/common/test_type_check_decorator.py
+++ b/src/test/common/test_type_check_decorator.py
@@ -54,7 +54,8 @@ class TestTypeCheckDecorator:
 
         with pytest.raises(UnsupportedTypeError) as e:
             union_arg(10)
-        assert "'u' must be ['bool_parsing', 'set_type']. The given argument type is 'int'" in str(e.value)
+        assert "'u' must be ['bool_parsing', 'set_type']. The given argument type is 'int'"\
+            in str(e.value)
 
     def test_type_check_decorator_iterable(self):
         @type_check_decorator


### PR DESCRIPTION
## Description
In pydantic 2.1.1, pytest related to @type_check_decorator is causing an error.
This PR fixes the errors noted by mypy and unit tests (test_type_check_decorator.py).

The pydantic identification names of the types refer to the following: https://docs.pydantic.dev/latest/errors/validation_errors/

<!-- Write a brief description of this PR. -->
## Related links
reference: https://github.com/tier4/CARET_analyze/pull/302
reference: https://github.com/tier4/CARET_analyze/pull/311

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
