### PR TITLE
fix warning for packages installed with apt

### DIFF
--- a/src/caret_analyze/infra/lttng/event_counter.py
+++ b/src/caret_analyze/infra/lttng/event_counter.py
@@ -103,8 +103,9 @@ class EventCounter:
             set(recorded_trace_points) & {'ros2:rmw_take'}) != 0
 
         if self._has_original_rclcpp_publish:
-            logger.warning('Trace data from a package built without caret-rclcpp was detected. '
-                           'This trace data may not be analyzed successfully.')
+            logger.warning(
+                'This trace data has trace point from a package built without caret-rclcpp. '
+                'Such package cannot be analyzed successfully.')
 
         if (not has_forked_inter_process_trace_points
                 and not has_forked_intra_process_trace_points):


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
 Changed the definition of trace points used by caret in #302 . Along with this change, warnings were added for packages that may have been built without using caret, such as those installed with apt.

 The current warning text is unclear and can be taken as if the entire measurement data cannot be analyzed. In fact, only the parts using packages built without caret cannot be analyzed successfully. The warning text has been modified to conform to the current situation.

- before 
`Trace data from a package built without caret-rclcpp was detected.` 
`This trace data may not be analyzed successfully.`

- after 
`This trace data has trace point from a package built without caret-rclcpp.`
`Such package cannot be analyzed successfully.`

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

- https://github.com/tier4/CARET_analyze/pull/302

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
