### PR TITLE
feat: refactor best/worst record api in response time

### DIFF
--- a/src/caret_analyze/record/records_service/response_time.py
+++ b/src/caret_analyze/record/records_service/response_time.py
@@ -257,6 +257,12 @@ class ResponseMapAll:
                 continue
             start_ts = record.get(self._start_column)
 
+            if end_ts < start_ts:
+                warn('Record data is invalid. '
+                     'The end time of the path is recorded before the start time.',
+                     UserWarning)
+                continue
+
             if start_ts not in self._start_timestamps:
                 self._start_timestamps.insert(0, start_ts)
                 self._end_timestamps.insert(0, end_ts)

--- a/src/caret_analyze/record/records_service/response_time.py
+++ b/src/caret_analyze/record/records_service/response_time.py
@@ -275,7 +275,6 @@ class ResponseMapAll:
                 idx = end_timestamps.index(end_ts)
                 if start_ts < start_timestamps[idx]:
                     start_timestamps[idx] = start_ts
-                    end_timestamps[idx] = end_ts
 
         for start_ts, end_ts in zip(start_timestamps, end_timestamps):
             record = {
@@ -299,7 +298,6 @@ class ResponseMapAll:
                 idx = end_timestamps.index(end_ts)
                 if start_ts > start_timestamps[idx]:
                     start_timestamps[idx] = start_ts
-                    end_timestamps[idx] = end_ts
 
         for start_ts, end_ts in zip(start_timestamps, end_timestamps):
             record = {

--- a/src/caret_analyze/record/records_service/response_time.py
+++ b/src/caret_analyze/record/records_service/response_time.py
@@ -286,9 +286,10 @@ class ResponseMapAll:
                     worst_to_best_timestamps[idx] = start_ts - prev_start_ts
 
         records = self._create_empty_records()
-        for start_ts, end_ts, worst_to_best_ts in zip(start_timestamps,
-                                                      end_timestamps,
-                                                      worst_to_best_timestamps):
+        for start_ts, end_ts, worst_to_best_ts in sorted(zip(start_timestamps,
+                                                             end_timestamps,
+                                                             worst_to_best_timestamps),
+                                                         key=lambda x: x[0]):
             record = {
                 self._start_column: start_ts - worst_to_best_ts,
                 'response_time': end_ts - (start_ts - worst_to_best_ts)
@@ -311,7 +312,7 @@ class ResponseMapAll:
                     start_timestamps[idx] = start_ts
 
         records = self._create_empty_records()
-        for start_ts, end_ts in zip(start_timestamps, end_timestamps):
+        for start_ts, end_ts in sorted(zip(start_timestamps, end_timestamps), key=lambda x: x[0]):
             record = {
                 self._start_column: start_ts,
                 'response_time': end_ts - start_ts
@@ -345,7 +346,7 @@ class ResponseMapAll:
                     start_timestamps[idx] = start_ts
 
         records = self._create_empty_records()
-        for start_ts, end_ts in zip(start_timestamps, end_timestamps):
+        for start_ts, end_ts in sorted(zip(start_timestamps, end_timestamps), key=lambda x: x[0]):
             record = {
                 self._start_column: start_ts,
                 'response_time': end_ts - start_ts

--- a/src/caret_analyze/record/records_service/response_time.py
+++ b/src/caret_analyze/record/records_service/response_time.py
@@ -267,7 +267,7 @@ class ResponseMapAll:
                     self._end_timestamps[idx] = end_ts
                     self._records[idx] = record
 
-    def to_worst_records(self) -> RecordsInterface:
+    def to_worst_with_external_latency_case_records(self) -> RecordsInterface:
 
         end_timestamps: list[int] = []
         start_timestamps: list[int] = []
@@ -297,7 +297,7 @@ class ResponseMapAll:
 
         return records
 
-    def to_best_records(self) -> RecordsInterface:
+    def to_best_case_records(self) -> RecordsInterface:
 
         end_timestamps: list[int] = []
         start_timestamps: list[int] = []
@@ -504,12 +504,6 @@ class ResponseTime:
         self._timeseries = ResponseTimeseries(self._records)
         self._histogram = ResponseHistogram(self._records, self._timeseries)
 
-    def to_best_records(self) -> RecordsInterface:
-        return self._response_map_all.to_best_records()
-
-    def to_worst_records(self) -> RecordsInterface:
-        return self._response_map_all.to_worst_records()
-
     def to_all_records(self) -> RecordsInterface:
         """
         Calculate the data of all records for response time.
@@ -565,7 +559,7 @@ class ResponseTime:
             - {'response_time'}
 
         """
-        return self._timeseries.to_best_case_records()
+        return self._response_map_all.to_best_case_records()
 
     def to_worst_with_external_latency_case_records(self) -> RecordsInterface:
         """
@@ -585,7 +579,7 @@ class ResponseTime:
             - {'response_time'}
 
         """
-        return self._timeseries.to_worst_with_external_latency_case_records()
+        return self._response_map_all.to_worst_with_external_latency_case_records()
 
     def to_all_stacked_bar(self) -> RecordsInterface:
         """

--- a/src/caret_analyze/record/records_service/response_time.py
+++ b/src/caret_analyze/record/records_service/response_time.py
@@ -262,6 +262,54 @@ class ResponseMapAll:
                     self._start_timestamps[idx] = start_ts
                     self._end_timestamps[idx] = end_ts
 
+    def to_worst_records(self) -> RecordsInterface:
+        records = self._create_empty_records()
+
+        end_timestamps: list[int] = []
+        start_timestamps: list[int] = []
+        for start_ts, end_ts in zip(self._start_timestamps[:-1], self._end_timestamps[1:]):
+            if end_ts not in end_timestamps:
+                start_timestamps.append(start_ts)
+                end_timestamps.append(end_ts)
+            else:
+                idx = end_timestamps.index(end_ts)
+                if start_ts < start_timestamps[idx]:
+                    start_timestamps[idx] = start_ts
+                    end_timestamps[idx] = end_ts
+
+        for start_ts, end_ts in zip(start_timestamps, end_timestamps):
+            record = {
+                self._start_column: start_ts,
+                'response_time': end_ts - start_ts
+            }
+            records.append(record)
+
+        return records
+
+    def to_best_records(self) -> RecordsInterface:
+        records = self._create_empty_records()
+
+        end_timestamps: list[int] = []
+        start_timestamps: list[int] = []
+        for start_ts, end_ts in zip(self._start_timestamps, self._end_timestamps):
+            if end_ts not in end_timestamps:
+                start_timestamps.append(start_ts)
+                end_timestamps.append(end_ts)
+            else:
+                idx = end_timestamps.index(end_ts)
+                if start_ts > start_timestamps[idx]:
+                    start_timestamps[idx] = start_ts
+                    end_timestamps[idx] = end_ts
+
+        for start_ts, end_ts in zip(start_timestamps, end_timestamps):
+            record = {
+                self._start_column: start_ts,
+                'response_time': end_ts - start_ts
+            }
+            records.append(record)
+
+        return records
+
     def to_all_records(self) -> RecordsInterface:
         records = self._create_empty_records()
 
@@ -347,6 +395,12 @@ class ResponseTime:
         self._records = ResponseRecords(response_map)
         self._timeseries = ResponseTimeseries(self._records)
         self._histogram = ResponseHistogram(self._records, self._timeseries)
+
+    def to_best_records(self) -> RecordsInterface:
+        return self._response_map_all.to_best_records()
+
+    def to_worst_records(self) -> RecordsInterface:
+        return self._response_map_all.to_worst_records()
 
     def to_all_records(self) -> RecordsInterface:
         return self._response_map_all.to_all_records()

--- a/src/test/infra/lttng/test_latency_definitions.py
+++ b/src/test/infra/lttng/test_latency_definitions.py
@@ -972,7 +972,7 @@ class TestNodeRecords:
                             f'{callback.callback_name}/callback_end_timestamp': 2,
                         }
                     ],
-                    [
+                    columns=[
                         ColumnValue(f'{callback.callback_name}/callback_start_timestamp'),
                         ColumnValue(f'{callback.callback_name}/callback_end_timestamp'),
                     ]
@@ -984,7 +984,7 @@ class TestNodeRecords:
                         f'{callback_.callback_name}/callback_end_timestamp': 4,
                     }
                 ],
-                [
+                columns=[
                     ColumnValue(f'{callback_.callback_name}/callback_start_timestamp'),
                     ColumnValue(f'{callback_.callback_name}/callback_end_timestamp'),
                 ]
@@ -1000,7 +1000,7 @@ class TestNodeRecords:
                         f'{callback_.callback_name}/callback_start_timestamp': 3,
                     }
                 ],
-                [
+                columns=[
                     ColumnValue(f'{callback.callback_name}/callback_end_timestamp'),
                     ColumnValue(f'{callback_.callback_name}/callback_start_timestamp'),
                 ]

--- a/src/test/record/records_service/test_response_time.py
+++ b/src/test/record/records_service/test_response_time.py
@@ -500,7 +500,9 @@ class TestResponseTimeseries:
         response = ResponseTime(records)
 
         response_time = response.to_best_case_records()
-        expect = []
+        expect = [
+            {'start': 0, 'response_time': 1}
+        ]
         assert to_dict(response_time) == expect
 
         response_time = response.to_worst_with_external_latency_case_records()
@@ -519,13 +521,14 @@ class TestResponseTimeseries:
 
         response_time = response.to_best_case_records()
         expect = [
-            {'start_max': 2, 'response_time': 1}
+            {'start': 0, 'response_time': 1},
+            {'start': 2, 'response_time': 1}
         ]
         assert to_dict(response_time) == expect
 
         response_time = response.to_worst_with_external_latency_case_records()
         expect = [
-            {'start_min': 0, 'response_time': 3}
+            {'start': 0, 'response_time': 3}
         ]
         assert to_dict(response_time) == expect
 
@@ -617,106 +620,3 @@ class TestResponseTimeseries:
             ]
             assert to_dict(response_time) == expect
 
-
-class TestResponseTimeWorstInInput:
-
-    def test_empty_case(self):
-        records_raw = []
-        columns = [ColumnValue('start'), ColumnValue('end')]
-        records = create_records(records_raw, columns)
-
-        response_time = ResponseTime(records)
-
-        expect_raw = []
-        result = to_dict(response_time.to_worst_case_records())
-        assert result == expect_raw
-
-    def test_two_column_default_case(self):
-        records_raw = [
-            {'start': 0, 'end': 2},
-            {'start': 3, 'end': 4},
-            {'start': 11, 'end': 12}
-        ]
-        columns = [ColumnValue('start'), ColumnValue('end')]
-        records = create_records(records_raw, columns)
-
-        response_time = ResponseTime(records)
-
-        expect_raw = [
-            {'start': 0, 'response_time': 2},
-            {'start': 3, 'response_time': 1},
-            {'start': 11, 'response_time': 1}
-        ]
-        result = to_dict(response_time.to_worst_case_records())
-        assert result == expect_raw
-
-    def test_three_column_default_case(self):
-        records_raw = [
-            {'start': 0, 'middle': 1, 'end': 2},
-            {'start': 3, 'middle': 4, 'end': 6},
-            {'start': 11, 'middle': 13, 'end': 16}
-        ]
-        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
-        records = create_records(records_raw, columns)
-
-        response_time = ResponseTime(records)
-
-        expect_raw = [
-            {'start': 0, 'response_time': 2},
-            {'start': 3, 'response_time': 3},
-            {'start': 11, 'response_time': 5}
-        ]
-        result = to_dict(response_time.to_worst_case_records())
-        assert result == expect_raw
-
-    def test_single_input_multi_output_case(self):
-        records_raw = [
-            {'start': 0, 'middle': 4, 'end': 5},
-            {'start': 0, 'middle': 4, 'end': 6},
-            {'start': 0, 'middle': 12, 'end': 13}
-        ]
-        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
-        records = create_records(records_raw, columns)
-
-        response_time = ResponseTime(records)
-
-        expect_raw = [
-            {'start': 0, 'response_time': 5}
-        ]
-        result = to_dict(response_time.to_worst_case_records())
-        assert result == expect_raw
-
-    def test_multi_input_single_output_case(self):
-        records_raw = [
-            {'start': 0, 'middle': 4, 'end': 13},
-            {'start': 1, 'middle': 4, 'end': 13},
-            {'start': 5, 'middle': 12, 'end': 13}
-        ]
-        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
-        records = create_records(records_raw, columns)
-
-        response_time = ResponseTime(records)
-
-        expect_raw = [
-            {'start': 0, 'response_time': 13}
-        ]
-        result = to_dict(response_time.to_worst_case_records())
-        assert result == expect_raw
-
-    def test_drop_case(self):
-        records_raw = [
-            {'start': 0, 'middle': 4, 'end': 8},
-            {'start': 1, 'middle': 4},
-            {'start': 5, 'middle': 12, 'end': 13}
-        ]
-        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
-        records = create_records(records_raw, columns)
-
-        response_time = ResponseTime(records)
-
-        expect_raw = [
-            {'start': 0, 'response_time': 8},
-            {'start': 1, 'response_time': 12}
-        ]
-        result = to_dict(response_time.to_worst_case_records())
-        assert result == expect_raw

--- a/src/test/record/records_service/test_response_time.py
+++ b/src/test/record/records_service/test_response_time.py
@@ -595,28 +595,3 @@ class TestResponseTimeseries:
 
             output_dict = to_dict(records)
             assert output_dict == expect
-
-        def test_to_best_case_timeseries(self):
-            response = ResponseTime(
-                create_records(self.records_raw, self.columns),
-                columns=self.column_names
-            )
-            response_time = response.to_best_case_records()
-            expect = [
-                {'column0_max': 20, 'response_time': 10},
-                {'column0_max': 35, 'response_time': 10}
-            ]
-            assert to_dict(response_time) == expect
-
-        def test_to_worst_case_timeseries(self):
-            response = ResponseTime(
-                create_records(self.records_raw, self.columns),
-                columns=self.column_names
-            )
-            response_time = response.to_worst_with_external_latency_case_records()
-            expect = [
-                {'column0_min': 5, 'response_time': 25},
-                {'column0_min': 20, 'response_time': 25}
-            ]
-            assert to_dict(response_time) == expect
-

--- a/src/test/record/records_service/test_response_time.py
+++ b/src/test/record/records_service/test_response_time.py
@@ -474,64 +474,6 @@ class TestResponseHistogram:
 
 class TestResponseTimeseries:
 
-    def test_empty_flow_case(self):
-        records_raw = [
-        ]
-        columns = [ColumnValue('start'), ColumnValue('end')]
-
-        records = create_records(records_raw, columns)
-        response = ResponseTime(records)
-
-        response_time = response.to_best_case_records()
-        expect = []
-        assert to_dict(response_time) == expect
-
-        response_time = response.to_worst_with_external_latency_case_records()
-        expect = []
-        assert to_dict(response_time) == expect
-
-    def test_single_flow_case(self):
-        records_raw = [
-            {'start': 0, 'end': 1},
-        ]
-        columns = [ColumnValue('start'), ColumnValue('end')]
-
-        records = create_records(records_raw, columns)
-        response = ResponseTime(records)
-
-        response_time = response.to_best_case_records()
-        expect = [
-            {'start': 0, 'response_time': 1}
-        ]
-        assert to_dict(response_time) == expect
-
-        response_time = response.to_worst_with_external_latency_case_records()
-        expect = []
-        assert to_dict(response_time) == expect
-
-    def test_double_flow_case(self):
-        records_raw = [
-            {'start': 0, 'end': 1},
-            {'start': 2, 'end': 3},
-        ]
-        columns = [ColumnValue('start'), ColumnValue('end')]
-
-        records = create_records(records_raw, columns)
-        response = ResponseTime(records)
-
-        response_time = response.to_best_case_records()
-        expect = [
-            {'start': 0, 'response_time': 1},
-            {'start': 2, 'response_time': 1}
-        ]
-        assert to_dict(response_time) == expect
-
-        response_time = response.to_worst_with_external_latency_case_records()
-        expect = [
-            {'start': 0, 'response_time': 3}
-        ]
-        assert to_dict(response_time) == expect
-
     # NOTE: Is this test up to specification?
     def test_cross_flow_case(self):
         records_raw = [
@@ -558,6 +500,7 @@ class TestResponseTimeseries:
             {'start_min': 3, 'response_time': 3}
         ]
         assert to_dict(response_time) == expect
+
 
     class TestMultiColumnCase:
         records_raw = [

--- a/src/test/record/records_service/test_response_time.py
+++ b/src/test/record/records_service/test_response_time.py
@@ -474,34 +474,6 @@ class TestResponseHistogram:
 
 class TestResponseTimeseries:
 
-    # NOTE: Is this test up to specification?
-    def test_cross_flow_case(self):
-        records_raw = [
-            {'start': 0, 'end': 10},
-            {'start': 3, 'end': 4},
-            {'start': 4, 'end': 8},
-            {'start': 6, 'end': 6},
-        ]
-        columns = [ColumnValue('start'), ColumnValue('end')]
-
-        records = create_records(records_raw, columns)
-        response = ResponseTime(records)
-
-        response_time = response.to_best_case_records()
-        expect = [
-            {'start_max': 3, 'response_time': 1},
-            {'start_max': 6, 'response_time': 0}
-        ]
-        assert to_dict(response_time) == expect
-
-        response_time = response.to_worst_with_external_latency_case_records()
-        expect = [
-            {'start_min': 0, 'response_time': 4},
-            {'start_min': 3, 'response_time': 3}
-        ]
-        assert to_dict(response_time) == expect
-
-
     class TestMultiColumnCase:
         records_raw = [
             {'column0': 5, 'column1': 10, 'column2': 15},  # flow 1 [used as first data]

--- a/src/test/record/records_service/test_response_time_all.py
+++ b/src/test/record/records_service/test_response_time_all.py
@@ -326,8 +326,7 @@ class TestResponseTimeWorstWithExternalLatency:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 13},
-            {'start': 1, 'response_time': 12}
+            {'start': 0, 'response_time': 13}
         ]
         result = to_dict(response_time.to_worst_with_external_latency_case_records())
         assert result == expect_raw

--- a/src/test/record/records_service/test_response_time_all.py
+++ b/src/test/record/records_service/test_response_time_all.py
@@ -139,6 +139,7 @@ class TestResponseTimeAll:
         result = to_dict(response_time.to_all_records())
         assert result == expect_raw
 
+
 class TestResponseTimeBest:
 
     def test_empty_case(self):
@@ -243,6 +244,7 @@ class TestResponseTimeBest:
         ]
         result = to_dict(response_time.to_best_records())
         assert result == expect_raw
+
 
 class TestResponseTimeWorst:
 

--- a/src/test/record/records_service/test_response_time_all.py
+++ b/src/test/record/records_service/test_response_time_all.py
@@ -152,7 +152,7 @@ class TestResponseTimeBest:
 
         expect_raw = [
         ]
-        result = to_dict(response_time.to_best_records())
+        result = to_dict(response_time.to_best_case_records())
         assert result == expect_raw
 
     def test_two_column_default_case(self):
@@ -171,7 +171,7 @@ class TestResponseTimeBest:
             {'start': 3, 'response_time': 1},
             {'start': 11, 'response_time': 1}
         ]
-        result = to_dict(response_time.to_best_records())
+        result = to_dict(response_time.to_best_case_records())
         assert result == expect_raw
 
     def test_three_column_default_case(self):
@@ -190,7 +190,7 @@ class TestResponseTimeBest:
             {'start': 3, 'response_time': 3},
             {'start': 11, 'response_time': 5}
         ]
-        result = to_dict(response_time.to_best_records())
+        result = to_dict(response_time.to_best_case_records())
         assert result == expect_raw
 
     def test_single_input_multi_output_case(self):
@@ -207,7 +207,7 @@ class TestResponseTimeBest:
         expect_raw = [
             {'start': 0, 'response_time': 5}
         ]
-        result = to_dict(response_time.to_best_records())
+        result = to_dict(response_time.to_best_case_records())
         assert result == expect_raw
 
     def test_multi_input_single_output_case(self):
@@ -224,11 +224,11 @@ class TestResponseTimeBest:
         expect_raw = [
             {'start': 5, 'response_time': 8}
         ]
-        result = to_dict(response_time.to_best_records())
+        result = to_dict(response_time.to_best_case_records())
         assert result == expect_raw
 
 
-class TestResponseTimeWorst:
+class TestResponseTimeWorstWithExternalLatency:
 
     def test_empty_case(self):
         records_raw = [
@@ -240,7 +240,7 @@ class TestResponseTimeWorst:
 
         expect_raw = [
         ]
-        result = to_dict(response_time.to_worst_records())
+        result = to_dict(response_time.to_worst_with_external_latency_case_records())
         assert result == expect_raw
 
     def test_two_column_default_case(self):
@@ -258,7 +258,7 @@ class TestResponseTimeWorst:
             {'start': 0, 'response_time': 4},
             {'start': 3, 'response_time': 9}
         ]
-        result = to_dict(response_time.to_worst_records())
+        result = to_dict(response_time.to_worst_with_external_latency_case_records())
         assert result == expect_raw
 
     def test_three_column_default_case(self):
@@ -276,7 +276,7 @@ class TestResponseTimeWorst:
             {'start': 0, 'response_time': 6},
             {'start': 3, 'response_time': 13}
         ]
-        result = to_dict(response_time.to_worst_records())
+        result = to_dict(response_time.to_worst_with_external_latency_case_records())
         assert result == expect_raw
 
     def test_single_input_multi_output_case(self):
@@ -294,7 +294,7 @@ class TestResponseTimeWorst:
         expect_raw = [
             {'start': 0, 'response_time': 11},
         ]
-        result = to_dict(response_time.to_worst_records())
+        result = to_dict(response_time.to_worst_with_external_latency_case_records())
         assert result == expect_raw
 
     def test_multi_input_single_output_case(self):
@@ -311,7 +311,111 @@ class TestResponseTimeWorst:
         expect_raw = [
             {'start': 0, 'response_time': 13}
         ]
-        result = to_dict(response_time.to_worst_records())
+        result = to_dict(response_time.to_worst_with_external_latency_case_records())
+        assert result == expect_raw
+
+    def test_drop_case(self):
+        records_raw = [
+            {'start': 0, 'middle': 4, 'end': 8},
+            {'start': 1, 'middle': 4},
+            {'start': 5, 'middle': 12, 'end': 13}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+            {'start': 0, 'response_time': 13},
+            {'start': 1, 'response_time': 12}
+        ]
+        result = to_dict(response_time.to_worst_with_external_latency_case_records())
+        assert result == expect_raw
+
+
+class TestResponseTimeWorst:
+
+    def test_empty_case(self):
+        records_raw = []
+        columns = [ColumnValue('start'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = []
+        result = to_dict(response_time.to_worst_case_records())
+        assert result == expect_raw
+
+    def test_two_column_default_case(self):
+        records_raw = [
+            {'start': 0, 'end': 2},
+            {'start': 3, 'end': 4},
+            {'start': 11, 'end': 12}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+            {'start': 0, 'response_time': 2},
+            {'start': 3, 'response_time': 1},
+            {'start': 11, 'response_time': 1}
+        ]
+        result = to_dict(response_time.to_worst_case_records())
+        assert result == expect_raw
+
+    def test_three_column_default_case(self):
+        records_raw = [
+            {'start': 0, 'middle': 1, 'end': 2},
+            {'start': 3, 'middle': 4, 'end': 6},
+            {'start': 11, 'middle': 13, 'end': 16}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+            {'start': 0, 'response_time': 2},
+            {'start': 3, 'response_time': 3},
+            {'start': 11, 'response_time': 5}
+        ]
+        result = to_dict(response_time.to_worst_case_records())
+        assert result == expect_raw
+
+    def test_single_input_multi_output_case(self):
+        records_raw = [
+            {'start': 0, 'middle': 4, 'end': 5},
+            {'start': 0, 'middle': 4, 'end': 6},
+            {'start': 0, 'middle': 12, 'end': 13}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+            {'start': 0, 'response_time': 5}
+        ]
+        result = to_dict(response_time.to_worst_case_records())
+        assert result == expect_raw
+
+    def test_multi_input_single_output_case(self):
+        records_raw = [
+            {'start': 0, 'middle': 4, 'end': 13},
+            {'start': 1, 'middle': 4, 'end': 13},
+            {'start': 5, 'middle': 12, 'end': 13}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+            {'start': 0, 'response_time': 13}
+        ]
+        result = to_dict(response_time.to_worst_case_records())
         assert result == expect_raw
 
     def test_drop_case(self):
@@ -327,9 +431,9 @@ class TestResponseTimeWorst:
 
         expect_raw = [
             {'start': 0, 'response_time': 8},
-            {'start': 5, 'response_time': 8}
+            {'start': 1, 'response_time': 12}
         ]
-        result = to_dict(response_time.to_best_records())
+        result = to_dict(response_time.to_worst_case_records())
         assert result == expect_raw
 
 
@@ -411,6 +515,7 @@ class TestAllStackedBar:
         ]
         result = to_dict(response_time.to_all_stacked_bar())
         assert result == expect_raw
+
 
 class TestWorstInInputStackedBar:
 

--- a/src/test/record/records_service/test_response_time_all.py
+++ b/src/test/record/records_service/test_response_time_all.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
+
 from caret_analyze.record import ColumnValue
 from caret_analyze.record import ResponseTime
 from caret_analyze.record.record_factory import RecordsFactory
@@ -160,6 +162,36 @@ class TestResponseTimeAll:
         ]
         assert to_dict(response_time) == expect
 
+    def test_invalid_value_case(self):
+        records_raw = [
+            {'start': 0, 'end': 2},
+            {'start': 3, 'end': 2},
+            {'start': 3, 'end': 4},
+            {'start': 11, 'end': 12},
+            {'start': 13, 'end': 12}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            warning_message =\
+                'Record data is invalid. '\
+                'The end time of the path is recorded before the start time.'
+
+            response_time = ResponseTime(records)
+
+            assert issubclass(w[0].category, UserWarning)
+            assert str(w[0].message) == warning_message
+
+            expect_raw = [
+                {'start': 0, 'response_time': 2},
+                {'start': 3, 'response_time': 1},
+                {'start': 11, 'response_time': 1}
+            ]
+            result = to_dict(response_time.to_all_records())
+            assert result == expect_raw
+
 
 class TestResponseTimeBest:
 
@@ -267,6 +299,36 @@ class TestResponseTimeBest:
             {'start': 6, 'response_time': 0}
         ]
         assert to_dict(response_time) == expect
+
+    def test_invalid_value_case(self):
+        records_raw = [
+            {'start': 0, 'end': 2},
+            {'start': 3, 'end': 2},
+            {'start': 3, 'end': 4},
+            {'start': 11, 'end': 12},
+            {'start': 13, 'end': 12}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            warning_message =\
+                'Record data is invalid. '\
+                'The end time of the path is recorded before the start time.'
+
+            response_time = ResponseTime(records)
+
+            assert issubclass(w[0].category, UserWarning)
+            assert str(w[0].message) == warning_message
+
+            expect_raw = [
+                {'start': 0, 'response_time': 2},
+                {'start': 3, 'response_time': 1},
+                {'start': 11, 'response_time': 1},
+            ]
+            result = to_dict(response_time.to_best_case_records())
+            assert result == expect_raw
 
 
 class TestResponseTimeWorstWithExternalLatency:
@@ -392,6 +454,35 @@ class TestResponseTimeWorstWithExternalLatency:
         ]
         assert to_dict(response_time) == expect
 
+    def test_invalid_value_case(self):
+        records_raw = [
+            {'start': 0, 'end': 2},
+            {'start': 3, 'end': 2},
+            {'start': 3, 'end': 4},
+            {'start': 11, 'end': 12},
+            {'start': 13, 'end': 12}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            warning_message =\
+                'Record data is invalid. '\
+                'The end time of the path is recorded before the start time.'
+
+            response_time = ResponseTime(records)
+
+            assert issubclass(w[0].category, UserWarning)
+            assert str(w[0].message) == warning_message
+
+            expect_raw = [
+                {'start': 0, 'response_time': 4},
+                {'start': 3, 'response_time': 9}
+            ]
+            result = to_dict(response_time.to_worst_with_external_latency_case_records())
+            assert result == expect_raw
+
 
 class TestResponseTimeWorst:
 
@@ -515,6 +606,36 @@ class TestResponseTimeWorst:
             {'start': 6, 'response_time': 0}
         ]
         assert to_dict(response_time) == expect
+
+    def test_invalid_value_case(self):
+        records_raw = [
+            {'start': 0, 'end': 2},
+            {'start': 3, 'end': 2},
+            {'start': 3, 'end': 4},
+            {'start': 11, 'end': 12},
+            {'start': 13, 'end': 12}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            warning_message =\
+                'Record data is invalid. '\
+                'The end time of the path is recorded before the start time.'
+
+            response_time = ResponseTime(records)
+
+            assert issubclass(w[0].category, UserWarning)
+            assert str(w[0].message) == warning_message
+
+            expect_raw = [
+                {'start': 0, 'response_time': 2},
+                {'start': 3, 'response_time': 1},
+                {'start': 11, 'response_time': 1},
+            ]
+            result = to_dict(response_time.to_worst_case_records())
+            assert result == expect_raw
 
 
 class TestAllStackedBar:

--- a/src/test/record/records_service/test_response_time_all.py
+++ b/src/test/record/records_service/test_response_time_all.py
@@ -139,6 +139,27 @@ class TestResponseTimeAll:
         result = to_dict(response_time.to_all_records())
         assert result == expect_raw
 
+    def test_cross_flow_case(self):
+        records_raw = [
+            {'start': 0, 'end': 10},
+            {'start': 3, 'end': 4},
+            {'start': 4, 'end': 10},
+            {'start': 6, 'end': 6},
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+
+        records = create_records(records_raw, columns)
+        response = ResponseTime(records)
+
+        response_time = response.to_all_records()
+        expect = [
+            {'start': 0, 'response_time': 10},
+            {'start': 3, 'response_time': 1},
+            {'start': 4, 'response_time': 6},
+            {'start': 6, 'response_time': 0}
+        ]
+        assert to_dict(response_time) == expect
+
 
 class TestResponseTimeBest:
 
@@ -226,6 +247,26 @@ class TestResponseTimeBest:
         ]
         result = to_dict(response_time.to_best_case_records())
         assert result == expect_raw
+
+    def test_cross_flow_case(self):
+        records_raw = [
+            {'start': 0, 'end': 10},
+            {'start': 3, 'end': 4},
+            {'start': 4, 'end': 10},
+            {'start': 6, 'end': 6},
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+
+        records = create_records(records_raw, columns)
+        response = ResponseTime(records)
+
+        response_time = response.to_best_case_records()
+        expect = [
+            {'start': 3, 'response_time': 1},
+            {'start': 4, 'response_time': 6},
+            {'start': 6, 'response_time': 0}
+        ]
+        assert to_dict(response_time) == expect
 
 
 class TestResponseTimeWorstWithExternalLatency:
@@ -331,6 +372,26 @@ class TestResponseTimeWorstWithExternalLatency:
         result = to_dict(response_time.to_worst_with_external_latency_case_records())
         assert result == expect_raw
 
+    def test_cross_flow_case(self):
+        records_raw = [
+            {'start': 0, 'end': 10},
+            {'start': 3, 'end': 4},
+            {'start': 4, 'end': 10},
+            {'start': 6, 'end': 6},
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+
+        records = create_records(records_raw, columns)
+        response = ResponseTime(records)
+
+        response_time = response.to_worst_with_external_latency_case_records()
+        expect = [
+            {'start': 0, 'response_time': 4},
+            {'start': 3, 'response_time': 7},
+            {'start': 4, 'response_time': 2}
+        ]
+        assert to_dict(response_time) == expect
+
 
 class TestResponseTimeWorst:
 
@@ -434,6 +495,26 @@ class TestResponseTimeWorst:
         ]
         result = to_dict(response_time.to_worst_case_records())
         assert result == expect_raw
+
+    def test_cross_flow_case(self):
+        records_raw = [
+            {'start': 0, 'end': 10},
+            {'start': 3, 'end': 4},
+            {'start': 4, 'end': 10},
+            {'start': 6, 'end': 6},
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+
+        records = create_records(records_raw, columns)
+        response = ResponseTime(records)
+
+        response_time = response.to_worst_case_records()
+        expect = [
+            {'start': 0, 'response_time': 10},
+            {'start': 3, 'response_time': 1},
+            {'start': 6, 'response_time': 0}
+        ]
+        assert to_dict(response_time) == expect
 
 
 class TestAllStackedBar:

--- a/src/test/record/records_service/test_response_time_all.py
+++ b/src/test/record/records_service/test_response_time_all.py
@@ -138,3 +138,211 @@ class TestResponseTimeAll:
         ]
         result = to_dict(response_time.to_all_records())
         assert result == expect_raw
+
+class TestResponseTimeBest:
+
+    def test_empty_case(self):
+        records_raw = [
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+        ]
+        result = to_dict(response_time.to_best_records())
+        assert result == expect_raw
+
+    def test_two_column_default_case(self):
+        records_raw = [
+            {'start': 0, 'end': 2},
+            {'start': 3, 'end': 4},
+            {'start': 11, 'end': 12}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+            {'start': 0, 'response_time': 2},
+            {'start': 3, 'response_time': 1},
+            {'start': 11, 'response_time': 1}
+        ]
+        result = to_dict(response_time.to_best_records())
+        assert result == expect_raw
+
+    def test_three_column_default_case(self):
+        records_raw = [
+            {'start': 0, 'middle': 1, 'end': 2},
+            {'start': 3, 'middle': 4, 'end': 6},
+            {'start': 11, 'middle': 13, 'end': 16}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+            {'start': 0, 'response_time': 2},
+            {'start': 3, 'response_time': 3},
+            {'start': 11, 'response_time': 5}
+        ]
+        result = to_dict(response_time.to_best_records())
+        assert result == expect_raw
+
+    def test_single_input_multi_output_case(self):
+        records_raw = [
+            {'start': 0, 'middle': 4, 'end': 5},
+            {'start': 0, 'middle': 4, 'end': 6},
+            {'start': 0, 'middle': 12, 'end': 13}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+            {'start': 0, 'response_time': 5}
+        ]
+        result = to_dict(response_time.to_best_records())
+        assert result == expect_raw
+
+    def test_multi_input_single_output_case(self):
+        records_raw = [
+            {'start': 0, 'middle': 4, 'end': 13},
+            {'start': 1, 'middle': 4, 'end': 13},
+            {'start': 5, 'middle': 12, 'end': 13}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+            {'start': 5, 'response_time': 8}
+        ]
+        result = to_dict(response_time.to_best_records())
+        assert result == expect_raw
+
+    def test_drop_case(self):
+        records_raw = [
+            {'start': 0, 'middle': 4, 'end': 8},
+            {'start': 1, 'middle': 4},
+            {'start': 5, 'middle': 12, 'end': 13}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+            {'start': 0, 'response_time': 8},
+            {'start': 5, 'response_time': 8}
+        ]
+        result = to_dict(response_time.to_best_records())
+        assert result == expect_raw
+
+class TestResponseTimeWorst:
+
+    def test_empty_case(self):
+        records_raw = [
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+        ]
+        result = to_dict(response_time.to_worst_records())
+        assert result == expect_raw
+
+    def test_two_column_default_case(self):
+        records_raw = [
+            {'start': 0, 'end': 2},
+            {'start': 3, 'end': 4},
+            {'start': 11, 'end': 12}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+            {'start': 0, 'response_time': 4},
+            {'start': 3, 'response_time': 9}
+        ]
+        result = to_dict(response_time.to_worst_records())
+        assert result == expect_raw
+
+    def test_three_column_default_case(self):
+        records_raw = [
+            {'start': 0, 'middle': 1, 'end': 2},
+            {'start': 3, 'middle': 4, 'end': 6},
+            {'start': 11, 'middle': 13, 'end': 16}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+            {'start': 0, 'response_time': 6},
+            {'start': 3, 'response_time': 13}
+        ]
+        result = to_dict(response_time.to_worst_records())
+        assert result == expect_raw
+
+    def test_single_input_multi_output_case(self):
+        records_raw = [
+            {'start': 0, 'middle': 4, 'end': 5},
+            {'start': 0, 'middle': 4, 'end': 6},
+            {'start': 3, 'middle': 10, 'end': 11},
+            {'start': 3, 'middle': 12, 'end': 13}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+            {'start': 0, 'response_time': 11},
+        ]
+        result = to_dict(response_time.to_worst_records())
+        assert result == expect_raw
+
+    def test_multi_input_single_output_case(self):
+        records_raw = [
+            {'start': 0, 'middle': 4, 'end': 13},
+            {'start': 1, 'middle': 4, 'end': 13},
+            {'start': 5, 'middle': 12, 'end': 13}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+            {'start': 0, 'response_time': 13}
+        ]
+        result = to_dict(response_time.to_worst_records())
+        assert result == expect_raw
+
+    def test_drop_case(self):
+        records_raw = [
+            {'start': 0, 'middle': 4, 'end': 8},
+            {'start': 1, 'middle': 4},
+            {'start': 5, 'middle': 12, 'end': 13}
+        ]
+        columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
+        records = create_records(records_raw, columns)
+
+        response_time = ResponseTime(records)
+
+        expect_raw = [
+            {'start': 0, 'response_time': 13}
+        ]
+        result = to_dict(response_time.to_worst_records())
+        assert result == expect_raw


### PR DESCRIPTION
## Description
The method of calculating ResponseTime for the `best` and `worst-with-external-latency` cases has been changed to be the same as for `all` and `worst` case.

<!-- Write a brief description of this PR. -->

## Related links
Jira: https://tier4.atlassian.net/browse/RT2-889

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
