### PR TITLE
fix: pandas version to avoid 2.1.0

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 setuptools
 colorcet
-pandas>=1.4.0
+pandas>=1.4.0,<2.1.0
 bokeh<3
 graphviz
 types-pyyaml


### PR DESCRIPTION
## Description

- Pandas v2.1.0 was released on 2023/08/30, but CARET_analysis fails with this version.
- It looks v2.1.0 has a bug: https://github.com/pandas-dev/pandas/issues/54848
- As a workaround, CARET should avoid using v2.1.0

```
takeshiiwanari@dpc2205002:~/work/tracedata/xx1/20230616$ ros2 caret check_ctf -d session-20230616162550_odaiba
/usr/local/lib/python3.10/dist-packages/pandas/core/arrays/masked.py:62: UserWarning: Pandas requires version '1.3.4' or newer of 'bottleneck' (version '1.3.2' currently installed).
  from pandas.core import (
Succeed to find record_cpp_impl. the C++ version will be used.
36347468 events found.
loading: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 36347468/36347468 [11:10<00:00, 54190.36it/s]
WARNING : 2023-08-31 18:43:33 | Trace data from a package built without caret-rclcpp was detected. This trace data may not be analyzed successfully.
36347468 events found.
loading: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 36347468/36347468 [00:20<00:00, 1749640.96it/s]
filtered to 153082 events.
Traceback (most recent call last):
  File "/opt/ros/humble/bin/ros2", line 33, in <module>
    sys.exit(load_entry_point('ros2cli==0.18.6', 'console_scripts', 'ros2')())
  File "/opt/ros/humble/lib/python3.10/site-packages/ros2cli/cli.py", line 89, in main
    rc = extension.main(parser=parser, args=args)
  File "/home/takeshiiwanari/ros2_caret_ws/build/ros2caret/ros2caret/command/caret.py", line 32, in main
    return extension.main(args=args)
  File "/home/takeshiiwanari/ros2_caret_ws/build/ros2caret/ros2caret/verb/check_ctf.py", line 37, in main
    Architecture('lttng', args.trace_dir)
  File "/home/takeshiiwanari/ros2_caret_ws/build/caret_analyze/caret_analyze/architecture/architecture.py", line 54, in __init__
    loaded = ArchitectureLoaded(reader, ignore_topics)
  File "/home/takeshiiwanari/ros2_caret_ws/build/caret_analyze/caret_analyze/architecture/architecture_loaded.py", line 71, in __init__
    nodes_loaded = NodeValuesLoaded(topic_ignored_reader)
  File "/home/takeshiiwanari/ros2_caret_ws/build/caret_analyze/caret_analyze/architecture/architecture_loaded.py", line 294, in __init__
    node, cb_loaded, cbg_loaded = self._create_node(node, reader)
  File "/home/takeshiiwanari/ros2_caret_ws/build/caret_analyze/caret_analyze/architecture/architecture_loaded.py", line 466, in _create_node
    cbg_loaded = CallbackGroupsLoaded(reader, callbacks_loaded, node)
  File "/home/takeshiiwanari/ros2_caret_ws/build/caret_analyze/caret_analyze/architecture/architecture_loaded.py", line 1080, in __init__
    callback_groups = reader.get_callback_groups(node)
  File "/home/takeshiiwanari/ros2_caret_ws/build/caret_analyze/caret_analyze/architecture/architecture_loaded.py", line 1660, in get_callback_groups
    in self._reader.get_callback_groups(node)
  File "/home/takeshiiwanari/ros2_caret_ws/build/caret_analyze/caret_analyze/infra/lttng/architecture_reader_lttng.py", line 110, in get_callback_groups
    return self._lttng.get_callback_groups(node)
  File "/home/takeshiiwanari/ros2_caret_ws/build/caret_analyze/caret_analyze/infra/lttng/lttng.py", line 460, in get_callback_groups
    return self._info.get_callback_groups(node)
  File "/home/takeshiiwanari/ros2_caret_ws/build/caret_analyze/caret_analyze/infra/lttng/lttng_info.py", line 512, in get_callback_groups
    return self._get_callback_groups(node_lttng.node_id)
  File "/home/takeshiiwanari/ros2_caret_ws/build/caret_analyze/caret_analyze/infra/lttng/lttng_info.py", line 459, in _get_callback_groups
    concat = TracePointData.concat(concat_target_dfs, column_names)
  File "/home/takeshiiwanari/ros2_caret_ws/build/caret_analyze/caret_analyze/infra/trace_point_data.py", line 174, in concat
    return TracePointData(pd.concat(concat_targets, axis=0).reset_index(drop=True))
  File "/usr/local/lib/python3.10/dist-packages/pandas/core/reshape/concat.py", line 393, in concat
    return op.get_result()
  File "/usr/local/lib/python3.10/dist-packages/pandas/core/reshape/concat.py", line 680, in get_result
    new_data = concatenate_managers(
  File "/usr/local/lib/python3.10/dist-packages/pandas/core/internals/concat.py", line 180, in concatenate_managers
    values = concat_compat(vals, axis=1, ea_compat_axis=True)
  File "/usr/local/lib/python3.10/dist-packages/pandas/core/dtypes/concat.py", line 135, in concat_compat
    result = np.concatenate(to_concat_arrs, axis=axis)
numpy.exceptions.AxisError: axis 1 is out of bounds for array of dimension 1
```

## Related links

https://tier4.atlassian.net/browse/RT2-941

## Notes for reviewers

None

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
