### PR TITLE
fix: temporary handling of mypy warnings

### DIFF
--- a/src/caret_analyze/record/record.py
+++ b/src/caret_analyze/record/record.py
@@ -757,7 +757,7 @@ class Records(RecordsInterface):
                 for processing_record in records_need_to_merge:
                     processing_record.data[sink_from_keys].add(  # type: ignore
                         record.get(copy_from_key))
-                    merge_processing_record_keys(processing_record)
+                    merge_processing_record_keys(processing_record)  # type: ignore
                     # No need for subsequent loops since we integrated them.
                     break
 
@@ -767,9 +767,9 @@ class Records(RecordsInterface):
                     lambda x: record.get(source_key) in x.data[sink_from_keys],  # type: ignore
                     processing_records.values(),
                 ):
-                    addr = processing_record.get(sink_from_key)
+                    addr = processing_record.get(sink_from_key)  # type: ignore
                     merged_addresses.append(addr)
-                    processing_record.merge(record)
+                    processing_record.merge(record)  # type: ignore
                     merged_records.append(processing_record)
                 for addr in merged_addresses:
                     if addr in processing_records:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,3 +5,4 @@ bokeh<3
 graphviz
 types-pyyaml
 pydantic>=1.9.0
+mypy==0.981


### PR DESCRIPTION
## Description
Temporary handling of mypy warnings.
- Add # type: ignore for record.py
  - For safety reasons, it should be removed later.
- Update mypy to v0.981
  - It should be update v1.5.2 later.
<!-- Write a brief description of this PR. -->

## Related links
Jira: https://tier4.atlassian.net/browse/RT2-944
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
