### PR TITLE
fix:  rename option of ResponseTime

### DIFF
--- a/src/caret_analyze/plot/histogram/histogram_plot_factory.py
+++ b/src/caret_analyze/plot/histogram/histogram_plot_factory.py
@@ -51,7 +51,7 @@ class HistogramPlotFactory:
             supported metrics: [frequency/latency/period/response_time]
         case : str, optional
             Response time calculation method, used only for response time.
-            supported case: [best/worst/worst-in-input/all].
+            supported case: [all/best/worst/worst-with-external-latency].
         visualize_lib : VisualizeLibInterface
             Instance of VisualizeLibInterface used for visualization.
 

--- a/src/caret_analyze/plot/plot_facade.py
+++ b/src/caret_analyze/plot/plot_facade.py
@@ -71,7 +71,7 @@ class Plot:
     def create_response_time_stacked_bar_plot(
         target_object: Path,
         metrics: str = 'latency',
-        case: str = 'worst'
+        case: str = 'all'
     ) -> StackedBarPlot:
         """
         Get StackedBarPlot instance.
@@ -178,7 +178,7 @@ class Plot:
     @staticmethod
     def create_response_time_timeseries_plot(
         *target_objects: Path,
-        case: str = 'best'
+        case: str = 'all'
     ) -> PlotBase:
         """
         Get response time timeseries plot instance.
@@ -350,7 +350,7 @@ class Plot:
     @staticmethod
     def create_response_time_histogram_plot(
         *target_objects: Path,
-        case: str = 'best',
+        case: str = 'all',
     ) -> PlotBase:
         """
         Get response time histogram plot instance.

--- a/src/caret_analyze/plot/plot_facade.py
+++ b/src/caret_analyze/plot/plot_facade.py
@@ -190,7 +190,7 @@ class Plot:
             This also accepts multiple inputs by unpacking.
         case: str, optional
             Response time calculation method, best by default.
-            supported case: [best/worst/worst-in-input/all].
+            supported case: [all/best/worst/worst-with-external-latency].
 
         Returns
         -------
@@ -362,7 +362,7 @@ class Plot:
             This also accepts multiple inputs by unpacking.
         case: str, optional
             Response time calculation method, best by default.
-            supported case: [best/worst/worst-in-input/all].
+            supported case: [all/best/worst/worst-with-external-latency].
 
         Returns
         -------

--- a/src/caret_analyze/plot/plot_facade.py
+++ b/src/caret_analyze/plot/plot_facade.py
@@ -85,7 +85,7 @@ class Plot:
             supported metrics: [latency]
         case : str, optional
             Response time calculation method, worst by default.
-            supported case: [best/worst].
+            supported case: [all/best/worst/worst-with-external-latency].
 
         Returns
         -------

--- a/src/caret_analyze/plot/plot_facade.py
+++ b/src/caret_analyze/plot/plot_facade.py
@@ -84,7 +84,7 @@ class Plot:
             Metrics for stacked bar graph.
             supported metrics: [latency]
         case : str, optional
-            Response time calculation method, worst by default.
+            Response time calculation method, all by default.
             supported case: [all/best/worst/worst-with-external-latency].
 
         Returns
@@ -189,7 +189,7 @@ class Plot:
             Instances that are the sources of the plotting.
             This also accepts multiple inputs by unpacking.
         case: str, optional
-            Response time calculation method, best by default.
+            Response time calculation method, all by default.
             supported case: [all/best/worst/worst-with-external-latency].
 
         Returns
@@ -361,7 +361,7 @@ class Plot:
             Instances that are the sources of the plotting.
             This also accepts multiple inputs by unpacking.
         case: str, optional
-            Response time calculation method, best by default.
+            Response time calculation method, all by default.
             supported case: [all/best/worst/worst-with-external-latency].
 
         Returns

--- a/src/caret_analyze/plot/stacked_bar/latency_stacked_bar.py
+++ b/src/caret_analyze/plot/stacked_bar/latency_stacked_bar.py
@@ -104,14 +104,17 @@ class LatencyStackedBar:
         response_time = ResponseTime(target_object.to_records(),
                                      columns=target_object.column_names)
         # include timestamp of response time (best, worst)
-        if self._case == 'best':
-            return response_time.to_best_case_stacked_bar()
-        if self._case == 'worst-in-input':
-            return response_time.to_worst_in_input_case_stacked_bar()
         if self._case == 'all':
             return response_time.to_all_stacked_bar()
-
-        return response_time.to_stacked_bar()
+        elif self._case == 'best':
+            return response_time.to_best_case_stacked_bar()
+        elif self._case == 'worst':
+            return response_time.to_worst_case_stacked_bar()
+        elif self._case == 'worst-with-external-latency':
+            return response_time.to_worst_with_external_latency_stacked_bar()
+        else:
+            raise ValueError('optional argument "case" must be following: \
+                                "all", "best", "worst", "worst-with-external-latency".')
 
     @property
     def target_objects(self) -> Path:

--- a/src/caret_analyze/plot/stacked_bar/latency_stacked_bar.py
+++ b/src/caret_analyze/plot/stacked_bar/latency_stacked_bar.py
@@ -26,7 +26,7 @@ class LatencyStackedBar:
     def __init__(
         self,
         target_objects: Path,
-        case: str = 'worst',
+        case: str = 'all',
     ) -> None:
         self._target_objects = target_objects
         self._case = case
@@ -111,7 +111,7 @@ class LatencyStackedBar:
         elif self._case == 'worst':
             return response_time.to_worst_case_stacked_bar()
         elif self._case == 'worst-with-external-latency':
-            return response_time.to_worst_with_external_latency_stacked_bar()
+            return response_time.to_worst_with_external_latency_case_stacked_bar()
         else:
             raise ValueError('optional argument "case" must be following: \
                                 "all", "best", "worst", "worst-with-external-latency".')

--- a/src/caret_analyze/plot/stacked_bar/stacked_bar_plot.py
+++ b/src/caret_analyze/plot/stacked_bar/stacked_bar_plot.py
@@ -30,7 +30,7 @@ class StackedBarPlot(PlotBase):
         self,
         metrics: LatencyStackedBar,
         visualize_lib: VisualizeLibInterface,
-        case: str = 'worst',
+        case: str = 'all',
     ) -> None:
         self._metrics = metrics
         self._visualize_lib = visualize_lib

--- a/src/caret_analyze/plot/stacked_bar/stacked_bar_plot_factory.py
+++ b/src/caret_analyze/plot/stacked_bar/stacked_bar_plot_factory.py
@@ -27,7 +27,7 @@ class StackedBarPlotFactory:
         target_objects: Path,
         visualize_lib: VisualizeLibInterface,
         metrics: str = 'latency',
-        case: str = 'worst',
+        case: str = 'all',
     ) -> StackedBarPlot:
         """
         Create stacked bar class.
@@ -42,7 +42,7 @@ class StackedBarPlotFactory:
         visualize_lib : VisualizeLibInterface
             Instance of VisualizeLibInterface used for visualization.
         case : str
-            To choose best or worst case response time.
+            To choose all, best, worst, or worst-with-external-latency case response time.
 
         Returns
         -------

--- a/src/caret_analyze/plot/timeseries/response_time_timeseries.py
+++ b/src/caret_analyze/plot/timeseries/response_time_timeseries.py
@@ -105,13 +105,17 @@ class ResponseTimeTimeSeries(MetricsBase):
         response_timeseries_list: list[RecordsInterface] = []
         for records in timeseries_records_list:
             response = ResponseTime(records)
-            if self._case == 'best':
+            if self._case == 'all':
+                response_timeseries_list.append(response.to_all_records())
+            elif self._case == 'best':
                 response_timeseries_list.append(response.to_best_case_records())
             elif self._case == 'worst':
                 response_timeseries_list.append(response.to_worst_case_records())
-            elif self._case == 'all':
-                response_timeseries_list.append(response.to_all_records())
-            elif self._case == 'worst-in-input':
-                response_timeseries_list.append(response.to_worst_in_input_records())
+            elif self._case == 'worst-with-external-latency':
+                response_timeseries_list.append(
+                    response.to_worst_with_external_latency_case_records())
+            else:
+                raise ValueError('optional argument "case" must be following: \
+                                 "all", "best", "worst", "worst-with-external-latency".')
 
         return response_timeseries_list

--- a/src/caret_analyze/plot/timeseries/timeseries_plot_factory.py
+++ b/src/caret_analyze/plot/timeseries/timeseries_plot_factory.py
@@ -54,7 +54,7 @@ class TimeSeriesPlotFactory:
         visualize_lib : VisualizeLibInterface
             Instance of VisualizeLibInterface used for visualization.
         case : str
-            Parameter specifying best, worst, worst-in-input, or all.
+            Parameter specifying all, best, worst, or worst-with-external-latency.
             Use to create Response time timeseries graph.
 
         Returns

--- a/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
@@ -162,7 +162,7 @@ class Bokeh(VisualizeLibInterface):
             If True, all legends are drawn
             even if the number of legends exceeds the threshold.
         case : str
-            Parameter specifying best, worst, worst-in-input, or all.
+            Parameter specifying all, best, worst, or worst-with-external-latency.
             Use to create Response time timeseries graph.
 
 
@@ -195,7 +195,7 @@ class Bokeh(VisualizeLibInterface):
             Name of metrics.
             "frequency", "latency", "period" or "response_time" can be specified.
         case : str
-            Parameter specifying best, worst, worst-in-input, or all.
+            Parameter specifying all, best, worst, or worst-with-external-latency.
             Use to create Response time histogram graph.
 
 
@@ -220,30 +220,34 @@ class Bokeh(VisualizeLibInterface):
 
         data_list: list[list[int]] = []
         if data_type == 'response_time':
-            if case == 'worst':
-                data_list = [
-                    [_ for _ in m.to_worst_case_records().get_column_series(data_type)
-                     if _ is not None]
-                    for m in metrics if isinstance(m, ResponseTime)
-                    ]
-            elif case == 'worst-in-input':
-                data_list = [
-                    [_ for _ in m.to_worst_in_input_records().get_column_series(data_type)
-                     if _ is not None]
-                    for m in metrics if isinstance(m, ResponseTime)
-                    ]
-            elif case == 'all':
+            if case == 'all':
                 data_list = [
                     [_ for _ in m.to_all_records().get_column_series(data_type)
                      if _ is not None]
                     for m in metrics if isinstance(m, ResponseTime)
                     ]
-            else:
+            elif case == 'best':
                 data_list = [
                     [_ for _ in m.to_best_case_records().get_column_series(data_type)
                      if _ is not None]
                     for m in metrics if isinstance(m, ResponseTime)
                     ]
+            elif case == 'worst':
+                data_list = [
+                    [_ for _ in m.to_worst_case_records().get_column_series(data_type)
+                     if _ is not None]
+                    for m in metrics if isinstance(m, ResponseTime)
+                    ]
+            elif case == 'worst-with-external-latency':
+                data_list = [
+                    [_ for _ in
+                     m.to_worst_with_external_latency_case_records().get_column_series(data_type)
+                     if _ is not None]
+                    for m in metrics if isinstance(m, ResponseTime)
+                    ]
+            else:
+                raise ValueError('optional argument "case" must be following: \
+                                 "all", "best", "worst", "worst-with-external-latency".')
         else:
             data_list = [
                 [_ for _ in m.to_records().get_column_series(data_type) if _ is not None]

--- a/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
@@ -85,7 +85,7 @@ class Bokeh(VisualizeLibInterface):
         xaxis_type: str,
         ywheel_zoom: bool,
         full_legends: bool,
-        case: str,  # best or worst
+        case: str,  # all, best, worst or worst-with-external-latency
     ) -> Figure:
         stacked_bar = BokehStackedBar(metrics, xaxis_type, ywheel_zoom, full_legends, case)
         return stacked_bar.create_figure()

--- a/src/caret_analyze/record/records_service/response_time.py
+++ b/src/caret_analyze/record/records_service/response_time.py
@@ -453,7 +453,7 @@ class ResponseTime:
         """
         Calculate the data of all records for response time.
 
-        The all for response time are included message flow latency.
+        This represents the response time for all cases of message flows with the same output.
 
         Returns
         -------
@@ -471,7 +471,7 @@ class ResponseTime:
         """
         Calculate data of the worst case records for response time.
 
-        The worst case for response time are included message flow latency.
+        This represents the response time for the oldest case in the message flow with the same output.
 
         Returns
         -------
@@ -489,7 +489,7 @@ class ResponseTime:
         """
         Calculate data of the best case records for response time.
 
-        The best case for response time are included message flow latency.
+        This represents the response time for the newest case in the message flow with the same output.
 
         Returns
         -------
@@ -507,7 +507,7 @@ class ResponseTime:
         """
         Calculate data of the worst-with-external-latency case records for response time.
 
-        The worst-with-external-latency case in response time includes message flow latencies
+        This represents the response time for the newest case in the message flow with the same output
         as well as delays caused by various factors such as lost messages.
 
         Returns

--- a/src/caret_analyze/record/records_service/response_time.py
+++ b/src/caret_analyze/record/records_service/response_time.py
@@ -453,7 +453,8 @@ class ResponseTime:
         """
         Calculate the data of all records for response time.
 
-        This represents the response time for all cases of message flows with the same output.
+        This represents the response time for all cases
+        of message flows with the same output.
 
         Returns
         -------
@@ -471,7 +472,8 @@ class ResponseTime:
         """
         Calculate data of the worst case records for response time.
 
-        This represents the response time for the oldest case in the message flow with the same output.
+        This represents the response time for the oldest case
+        in the message flow with the same output.
 
         Returns
         -------
@@ -489,7 +491,8 @@ class ResponseTime:
         """
         Calculate data of the best case records for response time.
 
-        This represents the response time for the newest case in the message flow with the same output.
+        This represents the response time for the newest case
+        in the message flow with the same output.
 
         Returns
         -------
@@ -507,7 +510,8 @@ class ResponseTime:
         """
         Calculate data of the worst-with-external-latency case records for response time.
 
-        This represents the response time for the newest case in the message flow with the same output
+        This represents the response time for the oldest case
+        in the message flow with the same output
         as well as delays caused by various factors such as lost messages.
 
         Returns

--- a/src/caret_analyze/record/records_service/response_time.py
+++ b/src/caret_analyze/record/records_service/response_time.py
@@ -332,6 +332,7 @@ class ResponseMapAll:
                     timestamps = [record.get(column) for record in filled_records_dict[end_ts]
                                   if column in record.columns]
                     record.add(column, min(timestamps))
+                record.drop_columns(list(record.columns - set(self._columns)))
                 filled_records_dict[end_ts].append(record)
 
         columns = [ColumnValue(c) for c in self._columns]
@@ -366,6 +367,7 @@ class ResponseMapAll:
             for column in self._columns:
                 timestamps = [r.get(column) for r in record_list if column in r.columns]
                 worst_record.add(column, min(timestamps))
+            worst_record.drop_columns(list(worst_record.columns - set(self._columns)))
             filled_record_list.append(worst_record)
 
         columns = [ColumnValue(c) for c in self._columns]

--- a/src/caret_analyze/record/records_service/response_time.py
+++ b/src/caret_analyze/record/records_service/response_time.py
@@ -279,7 +279,7 @@ class ResponseMapAll:
 
         return records
 
-    def to_worst_in_input_records(self) -> RecordsInterface:
+    def to_worst_records(self) -> RecordsInterface:
         end_timestamps: list[int] = []
         start_timestamps: list[int] = []
         for start_ts, end_ts in zip(self._start_timestamps, self._end_timestamps):
@@ -342,7 +342,7 @@ class ResponseMapAll:
         stacked_bar_records.sort_column_order()
         return stacked_bar_records
 
-    def to_worst_in_input_case_stacked_bar(self) -> RecordsInterface:
+    def to_worst_stacked_bar(self) -> RecordsInterface:
         end_column_record_dict: dict[int, list[RecordInterface]] = {}
 
         # classify records which have same end timestamp
@@ -361,12 +361,12 @@ class ResponseMapAll:
         # generate worst-case work flow
         filled_record_list: list[RecordInterface] = []
         for record_list in end_column_record_dict.values():
-            worst_in_input_record = RecordFactory.create_instance()
+            worst_record = RecordFactory.create_instance()
 
             for column in self._columns:
                 timestamps = [r.get(column) for r in record_list if column in r.columns]
-                worst_in_input_record.add(column, min(timestamps))
-            filled_record_list.append(worst_in_input_record)
+                worst_record.add(column, min(timestamps))
+            filled_record_list.append(worst_record)
 
         columns = [ColumnValue(c) for c in self._columns]
         stacked_bar_records: RecordsInterface =\
@@ -450,10 +450,77 @@ class ResponseTime:
         self._histogram = ResponseHistogram(self._records, self._timeseries)
 
     def to_all_records(self) -> RecordsInterface:
+        """
+        Calculate the all records data for response time.
+
+        The all for response time are included message flow latency.
+
+        Returns
+        -------
+        RecordsInterface
+            Records of the all response time.
+
+            Columns
+            - {columns[0]}
+            - {'response_time'}
+
+        """
         return self._response_map_all.to_all_records()
 
-    def to_worst_in_input_records(self) -> RecordsInterface:
-        return self._response_map_all.to_worst_in_input_records()
+    def to_worst_case_records(self) -> RecordsInterface:
+        """
+        Calculate the worst case records data for response time.
+
+        The best worst for response time are included message flow latency.
+
+        Returns
+        -------
+        RecordsInterface
+            Records of the worst cases response time.
+
+            Columns
+            - {columns[0]}
+            - {'response_time'}
+
+        """
+        return self._response_map_all.to_worst_records()
+
+    def to_best_case_records(self) -> RecordsInterface:
+        """
+        Calculate the best case records data for response time.
+
+        The best case for response time are included message flow latency.
+
+        Returns
+        -------
+        RecordsInterface
+            Records of the best cases response time.
+
+            Columns
+            - {columns[0]}
+            - {'response_time'}
+
+        """
+        return self._timeseries.to_best_case_records()
+
+    def to_worst_with_external_latency_case_records(self) -> RecordsInterface:
+        """
+        Calculate the worst-with-external-latency case records data for response time.
+
+        The worst-with-external-latency case in response time includes message flow latencies
+        as well as delays caused by various factors such as lost messages.
+
+        Returns
+        -------
+        RecordsInterface
+            Records of the worst-with-external-latency cases response time.
+
+            Columns
+            - {columns[0]}
+            - {'response_time'}
+
+        """
+        return self._timeseries.to_worst_with_external_latency()
 
     def to_stacked_bar(self) -> RecordsInterface:
         """
@@ -526,50 +593,13 @@ class ResponseTime:
             - {columns[n-1]}
 
         """
-        return self._response_map_all.to_worst_in_input_case_stacked_bar()
+        return self._response_map_all.to_worst_stacked_bar()
 
     def to_worst_case_stacked_bar(self) -> RecordsInterface:
         # NOTE:
         # We think this function is unnecessary.
         # If necessary, please contact us.
         raise NotImplementedError()
-
-    def to_best_case_records(self) -> RecordsInterface:
-        """
-        Calculate the best-case records data for response time.
-
-        The best case for response time are included message flow latency.
-
-        Returns
-        -------
-        RecordsInterface
-            Records of the best cases response time.
-
-            Columns
-            - {columns[0]}
-            - {'response_time'}
-
-        """
-        return self._timeseries.to_best_case_records()
-
-    def to_worst_case_records(self) -> RecordsInterface:
-        """
-        Calculate the worst-case records data for response time.
-
-        The worst case in response time includes message flow latencies
-        as well as delays caused by various factors such as lost messages.
-
-        Returns
-        -------
-        RecordsInterface
-            Records of the worst cases response time.
-
-            Columns
-            - {columns[0]}
-            - {'response_time'}
-
-        """
-        return self._timeseries.to_worst_case_records()
 
     def to_best_case_timeseries(self) -> tuple[np.ndarray, np.ndarray]:
         warn('This API will be moved to the Plot package in the near future.', DeprecationWarning)
@@ -964,7 +994,7 @@ class ResponseTimeseries:
         output_column = records.columns[-1]
         return self._to_records(input_column, output_column)
 
-    def to_worst_case_records(self) -> RecordsInterface:
+    def to_worst_with_external_latency(self) -> RecordsInterface:
         records = self._records.to_range_records()
         input_column = records.columns[0]
         output_column = records.columns[-1]
@@ -1145,7 +1175,8 @@ class ResponseHistogram:
             Occurs when the number of response latencies is insufficient.
 
         """
-        latency_ns = self._timeseries.to_worst_case_records().get_column_series('response_time')
+        latency_ns =\
+            self._timeseries.to_worst_with_external_latency().get_column_series('response_time')
         return self._to_histogram([_ for _ in latency_ns if _ is not None], binsize_ns, density)
 
     @staticmethod

--- a/src/caret_analyze/record/records_service/response_time.py
+++ b/src/caret_analyze/record/records_service/response_time.py
@@ -522,24 +522,41 @@ class ResponseTime:
         """
         return self._timeseries.to_worst_with_external_latency()
 
-    def to_stacked_bar(self) -> RecordsInterface:
+    def to_all_stacked_bar(self) -> RecordsInterface:
         """
         Calculate records for stacked bar.
 
         Returns
         -------
         RecordsInterface
-            The best and worst cases are separated into separate columns.
+            Records of the all response time.
 
             Columns
-            - {columns[0]}_min
-            - {columns[0]}_max
+            - {columns[0]}
             - {columns[1]}
             - {...}
             - {columns[n-1]}
 
         """
-        return self._records.to_range_records()
+        return self._response_map_all.to_all_stacked_bar()
+
+    def to_worst_case_stacked_bar(self) -> RecordsInterface:
+        """
+        Calculate records for stacked bar.
+
+        Returns
+        -------
+        RecordsInterface
+            Records of the worst-with-external-latency cases response time.
+
+            Columns
+            - {columns[0]}
+            - {columns[1]}
+            - {...}
+            - {columns[n-1]}
+
+        """
+        return self._response_map_all.to_worst_stacked_bar()
 
     def to_best_case_stacked_bar(self) -> RecordsInterface:
         """
@@ -559,47 +576,24 @@ class ResponseTime:
         """
         return self._records.to_range_records('best')
 
-    def to_all_stacked_bar(self) -> RecordsInterface:
+    def to_worst_with_external_latency_stacked_bar(self) -> RecordsInterface:
         """
         Calculate records for stacked bar.
 
         Returns
         -------
         RecordsInterface
-            Records of the all response time.
+            The best and worst cases are separated into separate columns.
 
             Columns
-            - {columns[0]}
+            - {columns[0]}_min
+            - {columns[0]}_max
             - {columns[1]}
             - {...}
             - {columns[n-1]}
 
         """
-        return self._response_map_all.to_all_stacked_bar()
-
-    def to_worst_in_input_case_stacked_bar(self) -> RecordsInterface:
-        """
-        Calculate records for stacked bar.
-
-        Returns
-        -------
-        RecordsInterface
-            Records of the worst-in-input cases response time.
-
-            Columns
-            - {columns[0]}
-            - {columns[1]}
-            - {...}
-            - {columns[n-1]}
-
-        """
-        return self._response_map_all.to_worst_stacked_bar()
-
-    def to_worst_case_stacked_bar(self) -> RecordsInterface:
-        # NOTE:
-        # We think this function is unnecessary.
-        # If necessary, please contact us.
-        raise NotImplementedError()
+        return self._records.to_range_records('worst-with-external-latency')
 
     def to_best_case_timeseries(self) -> tuple[np.ndarray, np.ndarray]:
         warn('This API will be moved to the Plot package in the near future.', DeprecationWarning)
@@ -719,7 +713,7 @@ class ResponseRecords:
 
     def to_range_records(
         self,
-        case: str = 'worst',
+        case: str = 'worst-with-external-latency',
     ) -> RecordsInterface:
         """
         Calculate response time records.
@@ -727,7 +721,7 @@ class ResponseRecords:
         Returns
         -------
         RecordsInterface
-            The best and worst cases are separated into separate columns.
+            The best and worst-with-external-latency cases are separated into separate columns.
             Columns
             - {columns[0]}_min
             - {columns[0]}_max

--- a/src/caret_analyze/record/records_service/response_time.py
+++ b/src/caret_analyze/record/records_service/response_time.py
@@ -279,7 +279,7 @@ class ResponseMapAll:
 
         return records
 
-    def to_worst_records(self) -> RecordsInterface:
+    def to_worst_case_records(self) -> RecordsInterface:
         end_timestamps: list[int] = []
         start_timestamps: list[int] = []
         for start_ts, end_ts in zip(self._start_timestamps, self._end_timestamps):
@@ -342,7 +342,7 @@ class ResponseMapAll:
         stacked_bar_records.sort_column_order()
         return stacked_bar_records
 
-    def to_worst_stacked_bar(self) -> RecordsInterface:
+    def to_worst_case_stacked_bar(self) -> RecordsInterface:
         end_column_record_dict: dict[int, list[RecordInterface]] = {}
 
         # classify records which have same end timestamp
@@ -471,7 +471,7 @@ class ResponseTime:
         """
         Calculate the worst case records data for response time.
 
-        The best worst for response time are included message flow latency.
+        The worst case for response time are included message flow latency.
 
         Returns
         -------
@@ -483,7 +483,7 @@ class ResponseTime:
             - {'response_time'}
 
         """
-        return self._response_map_all.to_worst_records()
+        return self._response_map_all.to_worst_case_records()
 
     def to_best_case_records(self) -> RecordsInterface:
         """
@@ -520,7 +520,7 @@ class ResponseTime:
             - {'response_time'}
 
         """
-        return self._timeseries.to_worst_with_external_latency()
+        return self._timeseries.to_worst_with_external_latency_case_records()
 
     def to_all_stacked_bar(self) -> RecordsInterface:
         """
@@ -556,7 +556,7 @@ class ResponseTime:
             - {columns[n-1]}
 
         """
-        return self._response_map_all.to_worst_stacked_bar()
+        return self._response_map_all.to_worst_case_stacked_bar()
 
     def to_best_case_stacked_bar(self) -> RecordsInterface:
         """
@@ -576,7 +576,7 @@ class ResponseTime:
         """
         return self._records.to_range_records('best')
 
-    def to_worst_with_external_latency_stacked_bar(self) -> RecordsInterface:
+    def to_worst_with_external_latency_case_stacked_bar(self) -> RecordsInterface:
         """
         Calculate records for stacked bar.
 
@@ -988,7 +988,7 @@ class ResponseTimeseries:
         output_column = records.columns[-1]
         return self._to_records(input_column, output_column)
 
-    def to_worst_with_external_latency(self) -> RecordsInterface:
+    def to_worst_with_external_latency_case_records(self) -> RecordsInterface:
         records = self._records.to_range_records()
         input_column = records.columns[0]
         output_column = records.columns[-1]
@@ -1170,7 +1170,8 @@ class ResponseHistogram:
 
         """
         latency_ns =\
-            self._timeseries.to_worst_with_external_latency().get_column_series('response_time')
+            self._timeseries.to_worst_with_external_latency_case_records()\
+                .get_column_series('response_time')
         return self._to_histogram([_ for _ in latency_ns if _ is not None], binsize_ns, density)
 
     @staticmethod

--- a/src/caret_analyze/record/records_service/response_time.py
+++ b/src/caret_analyze/record/records_service/response_time.py
@@ -451,7 +451,7 @@ class ResponseTime:
 
     def to_all_records(self) -> RecordsInterface:
         """
-        Calculate the all records data for response time.
+        Calculate the data of all records for response time.
 
         The all for response time are included message flow latency.
 
@@ -469,7 +469,7 @@ class ResponseTime:
 
     def to_worst_case_records(self) -> RecordsInterface:
         """
-        Calculate the worst case records data for response time.
+        Calculate data of the worst case records for response time.
 
         The worst case for response time are included message flow latency.
 
@@ -487,7 +487,7 @@ class ResponseTime:
 
     def to_best_case_records(self) -> RecordsInterface:
         """
-        Calculate the best case records data for response time.
+        Calculate data of the best case records for response time.
 
         The best case for response time are included message flow latency.
 
@@ -505,7 +505,7 @@ class ResponseTime:
 
     def to_worst_with_external_latency_case_records(self) -> RecordsInterface:
         """
-        Calculate the worst-with-external-latency case records data for response time.
+        Calculate data of the worst-with-external-latency case records for response time.
 
         The worst-with-external-latency case in response time includes message flow latencies
         as well as delays caused by various factors such as lost messages.

--- a/src/test/record/records_service/test_response_time.py
+++ b/src/test/record/records_service/test_response_time.py
@@ -486,7 +486,7 @@ class TestResponseTimeseries:
         expect = []
         assert to_dict(response_time) == expect
 
-        response_time = response.to_worst_case_records()
+        response_time = response.to_worst_with_external_latency_case_records()
         expect = []
         assert to_dict(response_time) == expect
 
@@ -503,7 +503,7 @@ class TestResponseTimeseries:
         expect = []
         assert to_dict(response_time) == expect
 
-        response_time = response.to_worst_case_records()
+        response_time = response.to_worst_with_external_latency_case_records()
         expect = []
         assert to_dict(response_time) == expect
 
@@ -523,7 +523,7 @@ class TestResponseTimeseries:
         ]
         assert to_dict(response_time) == expect
 
-        response_time = response.to_worst_case_records()
+        response_time = response.to_worst_with_external_latency_case_records()
         expect = [
             {'start_min': 0, 'response_time': 3}
         ]
@@ -549,7 +549,7 @@ class TestResponseTimeseries:
         ]
         assert to_dict(response_time) == expect
 
-        response_time = response.to_worst_case_records()
+        response_time = response.to_worst_with_external_latency_case_records()
         expect = [
             {'start_min': 0, 'response_time': 4},
             {'start_min': 3, 'response_time': 3}
@@ -610,7 +610,7 @@ class TestResponseTimeseries:
                 create_records(self.records_raw, self.columns),
                 columns=self.column_names
             )
-            response_time = response.to_worst_case_records()
+            response_time = response.to_worst_with_external_latency_case_records()
             expect = [
                 {'column0_min': 5, 'response_time': 25},
                 {'column0_min': 20, 'response_time': 25}
@@ -628,7 +628,7 @@ class TestResponseTimeWorstInInput:
         response_time = ResponseTime(records)
 
         expect_raw = []
-        result = to_dict(response_time.to_worst_in_input_records())
+        result = to_dict(response_time.to_worst_case_records())
         assert result == expect_raw
 
     def test_two_column_default_case(self):
@@ -647,7 +647,7 @@ class TestResponseTimeWorstInInput:
             {'start': 3, 'response_time': 1},
             {'start': 11, 'response_time': 1}
         ]
-        result = to_dict(response_time.to_worst_in_input_records())
+        result = to_dict(response_time.to_worst_case_records())
         assert result == expect_raw
 
     def test_three_column_default_case(self):
@@ -666,7 +666,7 @@ class TestResponseTimeWorstInInput:
             {'start': 3, 'response_time': 3},
             {'start': 11, 'response_time': 5}
         ]
-        result = to_dict(response_time.to_worst_in_input_records())
+        result = to_dict(response_time.to_worst_case_records())
         assert result == expect_raw
 
     def test_single_input_multi_output_case(self):
@@ -683,7 +683,7 @@ class TestResponseTimeWorstInInput:
         expect_raw = [
             {'start': 0, 'response_time': 5}
         ]
-        result = to_dict(response_time.to_worst_in_input_records())
+        result = to_dict(response_time.to_worst_case_records())
         assert result == expect_raw
 
     def test_multi_input_single_output_case(self):
@@ -700,7 +700,7 @@ class TestResponseTimeWorstInInput:
         expect_raw = [
             {'start': 0, 'response_time': 13}
         ]
-        result = to_dict(response_time.to_worst_in_input_records())
+        result = to_dict(response_time.to_worst_case_records())
         assert result == expect_raw
 
     def test_drop_case(self):
@@ -718,5 +718,5 @@ class TestResponseTimeWorstInInput:
             {'start': 0, 'response_time': 8},
             {'start': 1, 'response_time': 12}
         ]
-        result = to_dict(response_time.to_worst_in_input_records())
+        result = to_dict(response_time.to_worst_case_records())
         assert result == expect_raw

--- a/src/test/record/records_service/test_response_time.py
+++ b/src/test/record/records_service/test_response_time.py
@@ -51,7 +51,7 @@ class TestResponseRecords:
         response = ResponseTime(records)
 
         expect_raw = []
-        result = to_dict(response.to_worst_with_external_latency_stacked_bar())
+        result = to_dict(response.to_worst_with_external_latency_case_stacked_bar())
         assert result == expect_raw
 
     def test_single_flow_case(self):
@@ -65,7 +65,7 @@ class TestResponseRecords:
 
         expect_raw = [
         ]
-        result = to_dict(response.to_worst_with_external_latency_stacked_bar())
+        result = to_dict(response.to_worst_with_external_latency_case_stacked_bar())
         assert result == expect_raw
 
     def test_double_flow_case(self):
@@ -81,7 +81,7 @@ class TestResponseRecords:
         expect_raw = [
             {'start_min': 0, 'start_max': 2, 'end': 3},
         ]
-        result = to_dict(response.to_worst_with_external_latency_stacked_bar())
+        result = to_dict(response.to_worst_with_external_latency_case_stacked_bar())
         assert result == expect_raw
 
         expect_raw = [
@@ -107,7 +107,7 @@ class TestResponseRecords:
             {'start_min': 0, 'start_max': 3, 'end': 4},
             {'start_min': 3, 'start_max': 6, 'end': 6},
         ]
-        result = to_dict(response.to_worst_with_external_latency_stacked_bar())
+        result = to_dict(response.to_worst_with_external_latency_case_stacked_bar())
         assert result == expect_raw
 
         expect_raw = [
@@ -132,7 +132,7 @@ class TestResponseRecords:
             {'start_min': 0, 'start_max': 2, 'end': 3},
             {'start_min': 2, 'start_max': 10, 'end': 11},
         ]
-        result = to_dict(response.to_worst_with_external_latency_stacked_bar())
+        result = to_dict(response.to_worst_with_external_latency_case_stacked_bar())
         assert result == expect_raw
 
         expect_raw = [
@@ -156,7 +156,7 @@ class TestResponseRecords:
         expect_raw = [
             {'start_min': 0, 'start_max': 2, 'end': 3},
         ]
-        result = to_dict(response.to_worst_with_external_latency_stacked_bar())
+        result = to_dict(response.to_worst_with_external_latency_case_stacked_bar())
         assert result == expect_raw
 
     def test_drop_case(self):
@@ -174,7 +174,7 @@ class TestResponseRecords:
         expect_raw = [
             {'start_min': 2, 'start_max': 3, 'end': 4},
         ]
-        result = to_dict(response.to_worst_with_external_latency_stacked_bar())
+        result = to_dict(response.to_worst_with_external_latency_case_stacked_bar())
         assert result == expect_raw
 
 
@@ -581,7 +581,7 @@ class TestResponseTimeseries:
                 columns=self.column_names
             )
 
-            records = response.to_worst_with_external_latency_stacked_bar()
+            records = response.to_worst_with_external_latency_case_stacked_bar()
 
             expect = [
                 # flow 1 input ~ flow 7 output

--- a/src/test/record/records_service/test_response_time.py
+++ b/src/test/record/records_service/test_response_time.py
@@ -51,7 +51,7 @@ class TestResponseRecords:
         response = ResponseTime(records)
 
         expect_raw = []
-        result = to_dict(response.to_stacked_bar())
+        result = to_dict(response.to_worst_with_external_latency_stacked_bar())
         assert result == expect_raw
 
     def test_single_flow_case(self):
@@ -65,7 +65,7 @@ class TestResponseRecords:
 
         expect_raw = [
         ]
-        result = to_dict(response.to_stacked_bar())
+        result = to_dict(response.to_worst_with_external_latency_stacked_bar())
         assert result == expect_raw
 
     def test_double_flow_case(self):
@@ -81,7 +81,7 @@ class TestResponseRecords:
         expect_raw = [
             {'start_min': 0, 'start_max': 2, 'end': 3},
         ]
-        result = to_dict(response.to_stacked_bar())
+        result = to_dict(response.to_worst_with_external_latency_stacked_bar())
         assert result == expect_raw
 
         expect_raw = [
@@ -107,7 +107,7 @@ class TestResponseRecords:
             {'start_min': 0, 'start_max': 3, 'end': 4},
             {'start_min': 3, 'start_max': 6, 'end': 6},
         ]
-        result = to_dict(response.to_stacked_bar())
+        result = to_dict(response.to_worst_with_external_latency_stacked_bar())
         assert result == expect_raw
 
         expect_raw = [
@@ -132,7 +132,7 @@ class TestResponseRecords:
             {'start_min': 0, 'start_max': 2, 'end': 3},
             {'start_min': 2, 'start_max': 10, 'end': 11},
         ]
-        result = to_dict(response.to_stacked_bar())
+        result = to_dict(response.to_worst_with_external_latency_stacked_bar())
         assert result == expect_raw
 
         expect_raw = [
@@ -156,7 +156,7 @@ class TestResponseRecords:
         expect_raw = [
             {'start_min': 0, 'start_max': 2, 'end': 3},
         ]
-        result = to_dict(response.to_stacked_bar())
+        result = to_dict(response.to_worst_with_external_latency_stacked_bar())
         assert result == expect_raw
 
     def test_drop_case(self):
@@ -174,7 +174,7 @@ class TestResponseRecords:
         expect_raw = [
             {'start_min': 2, 'start_max': 3, 'end': 4},
         ]
-        result = to_dict(response.to_stacked_bar())
+        result = to_dict(response.to_worst_with_external_latency_stacked_bar())
         assert result == expect_raw
 
 
@@ -581,7 +581,7 @@ class TestResponseTimeseries:
                 columns=self.column_names
             )
 
-            records = response.to_stacked_bar()
+            records = response.to_worst_with_external_latency_stacked_bar()
 
             expect = [
                 # flow 1 input ~ flow 7 output

--- a/src/test/record/records_service/test_response_time_all.py
+++ b/src/test/record/records_service/test_response_time_all.py
@@ -238,7 +238,7 @@ class TestWorstInInputStackedBar:
         response_time = ResponseTime(records, columns=self.column_names)
 
         expect_raw = []
-        result = to_dict(response_time.to_worst_in_input_case_stacked_bar())
+        result = to_dict(response_time.to_worst_case_stacked_bar())
         assert result == expect_raw
 
     def test_single_case(self):
@@ -256,7 +256,7 @@ class TestWorstInInputStackedBar:
             {'start': 4, 'middle0': 5, 'middle1': 7, 'end': 8},
             {'start': 6, 'middle0': 7, 'middle1': 8, 'end': 9}
         ]
-        result = to_dict(response_time.to_worst_in_input_case_stacked_bar())
+        result = to_dict(response_time.to_worst_case_stacked_bar())
         assert result == expect_raw
 
     def test_multi_case(self):
@@ -274,7 +274,7 @@ class TestWorstInInputStackedBar:
             {'start': 0, 'middle0': 1, 'middle1': 3, 'end': 4},
             {'start': 2, 'middle0': 3, 'middle1': 5, 'end': 6},
         ]
-        result = to_dict(response_time.to_worst_in_input_case_stacked_bar())
+        result = to_dict(response_time.to_worst_case_stacked_bar())
         assert result == expect_raw
 
     def test_drop_case(self):
@@ -292,5 +292,5 @@ class TestWorstInInputStackedBar:
             {'start': 0, 'middle0': 1, 'middle1': 3, 'end': 4},
             {'start': 2, 'middle0': 3, 'middle1': 4, 'end': 6},
         ]
-        result = to_dict(response_time.to_worst_in_input_case_stacked_bar())
+        result = to_dict(response_time.to_worst_case_stacked_bar())
         assert result == expect_raw


### PR DESCRIPTION
## Description
The current option names for ResponseTime diverge from the intuitive image.
The option names have been changed as follows:
- worst -> worst-with-external-latency
- worst-in-input -> worst

![image](https://github.com/tier4/CARET_analyze/assets/48247817/c0184557-644a-4a55-abf2-c389ce60ca2f)

<!-- Write a brief description of this PR. -->

## Related links
Jira: https://tier4.atlassian.net/browse/RT2-888

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
