### PR TITLE
ci: upload package list

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -30,6 +30,19 @@ jobs:
       - name: Install dependent packages
         run: python3 -m pip install -r src/requirements.txt
 
+      - name: Get package list
+        run: |
+          dpkg -l > package_list.txt
+          python3 -m pip list > pip_list.txt
+
+      - name: Upload package list
+        uses: actions/upload-artifact@v3
+        with:
+          name: package_list
+          path: |
+            package_list.txt
+            pip_list.txt
+
       - name: Run pytest
         run: |
           . /opt/ros/humble/setup.sh


### PR DESCRIPTION
## Description

This PR modifies `pytest` GitHub Actions workflow to save package list. It helps developers to find causes in case an error happens and it's caused by package version upgraded. The results of `dpkg -l` and `pip3 list` are saved.
Package list can be found in Actions -> pytest -> Artifacts -> package_list

![image](https://github.com/tier4/CARET_analyze/assets/105265012/ac87540f-3f0e-4f74-a677-2cdc3c9c8c81)


## Related links

None

## Notes for reviewers

None

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
