### PR TITLE
chore: upgrade pandas version

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 setuptools<68.0.0
 colorcet
-pandas>=1.4.0,<2.1.0
+pandas>=2.1.1
 bokeh<3
 graphviz
 types-pyyaml


### PR DESCRIPTION
## Description

In [this PR](https://github.com/tier4/CARET_analyze/pull/324), pandas==2.1.0 is ignored and an older version is installed as a workaround. Since newer version of pandas is released, the workaround should be removed.

## Related links

https://tier4.atlassian.net/browse/RT2-942

## Notes for reviewers

I confirmed the error which occurred with pandas==2.1.0 is fixed

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
