### PR TITLE
fix: remove temporary fix for version restriction of setuptools

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-setuptools<68.0.0
+setuptools
 colorcet
 pandas>=1.4.0,<2.1.0
 bokeh<3


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
CARET build was failed with `setuptools` 68.0.0. But it was fixed with latest version of `setuptools` 68.2.2.
This PR will remove the temporary fix and use the latest version of `setuptools`.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
https://setuptools.pypa.io/en/stable/history.html

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
