### PR TITLE
fix: specify setuptools version >= 68.2.2

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-setuptools
+setuptools>=68.2.2
 colorcet
 pandas>=1.4.0
 bokeh<3


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
CARET_analyze causes installation errors with setuptools 68.0.0, this PR specified the latest version (68.2.2) or higher, just in case.

build results:
```
Finished <<< caret_trace [18.0s]

Summary: 23 packages finished [51.7s]
  13 packages had stderr output: caret_analyze caret_analyze_cpp_impl caret_trace cyclonedds rclcpp ros2caret ros2trace test_tracetools_launch tracetools tracetools_launch tracetools_read tracetools_test tracetools_trace
```

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
