### PR TITLE
fix:  using caret_record_cpp_impl on GitHub Actions

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -46,15 +46,13 @@ jobs:
       - name: Clone caret_analyze_cpp_impl
         run: |
           git clone https://github.com/tier4/caret_analyze_cpp_impl.git
-          cd caret_analyze_cpp_impl/
-          mv CARET_analyze_cpp_impl src
 
       - name: Restore Cache
         id: cpp_impl-cache
         uses: actions/cache/restore@v3
         with:
           path: caret_analyze_cpp_impl/install
-          key: ${{ runner.os }}-node-cpp_impl-${{ hashFiles('caret_analyze_cpp_impl/src/**') }}
+          key: ${{ runner.os }}-node-cpp_impl-${{ hashFiles('caret_analyze_cpp_impl/CARET_analyze_cpp_impl/**') }}
 
       - name: Build caret_analyze_cpp_impl
         if: steps.cpp_impl-cache.outputs.cache-hit != 'true'
@@ -69,11 +67,12 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: caret_analyze_cpp_impl/install
-          key: ${{ runner.os }}-node-cpp_impl-${{ hashFiles('caret_analyze_cpp_impl/src/**') }}
+          key: ${{ runner.os }}-node-cpp_impl-${{ hashFiles('caret_analyze_cpp_impl/CARET_analyze_cpp_impl/**') }}
 
       - name: Run pytest
         run: |
-          mv caret_analyze_cpp_impl/install /__w
-          export PYTHONPATH=/__w/install/caret_analyze_cpp_impl/lib/python3.10/site-packages:$PYTHONPATH
           . /opt/ros/humble/setup.sh
+          source caret_analyze_cpp_impl/install/setup.bash
+          cd src
           python3 -m pytest
+        shell: bash

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -79,3 +79,4 @@ jobs:
         run: |
           echo "If pytest failure, are you sending both caret_analyze_cpp_impl and caret_analyze on this PR?"
           echo "this pytest action may fail because it tests new caret_analyze in combination with old caret_analyze_cpp_impl."
+          exit 1

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -26,7 +26,6 @@ jobs:
           # sudo rosdep init
           rosdep update
           rosdep install -i --from-paths . -y --rosdistro humble
-
       - name: Install dependent packages
         run: python3 -m pip install -r src/requirements.txt
 
@@ -34,7 +33,6 @@ jobs:
         run: |
           dpkg -l > package_list.txt
           python3 -m pip list > pip_list.txt
-
       - name: Upload package list
         uses: actions/upload-artifact@v3
         with:
@@ -42,11 +40,9 @@ jobs:
           path: |
             package_list.txt
             pip_list.txt
-
       - name: Clone caret_analyze_cpp_impl
         run: |
           git clone https://github.com/tier4/caret_analyze_cpp_impl.git
-
       - name: Restore Cache
         id: cpp_impl-cache
         uses: actions/cache/restore@v3
@@ -70,13 +66,16 @@ jobs:
           key: ${{ runner.os }}-node-cpp_impl-${{ hashFiles('caret_analyze_cpp_impl/CARET_analyze_cpp_impl/**') }}
 
       - name: Run pytest
+        id: pytest_action
         run: |
           . /opt/ros/humble/setup.sh
           source caret_analyze_cpp_impl/install/setup.bash
           cd src
           python3 -m pytest
-          if [ $? -ne 0 ]; then
-          echo "Are you sending both caret_analyze_cpp_impl and caret_analyze on this PR?"
-          echo "this pytest action may fail because it tests new caret_analyze in combination with old caret_analyze_cpp_impl"
-          fi
         shell: bash
+
+      - name: If pytest failure
+        if: failure() && steps.pytest_action.outcome == 'failure'
+        run: |
+          echo "If pytest failure, are you sending both caret_analyze_cpp_impl and caret_analyze on this PR?"
+          echo "this pytest action may fail because it tests new caret_analyze in combination with old caret_analyze_cpp_impl."

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -77,6 +77,6 @@ jobs:
       - name: If pytest failure
         if: failure() && steps.pytest_action.outcome == 'failure'
         run: |
-          echo "If pytest failure, are you sending both caret_analyze_cpp_impl and caret_analyze on this PR?"
-          echo "this pytest action may fail because it tests new caret_analyze in combination with old caret_analyze_cpp_impl."
+          echo "Did you send PR to both caret_analyze and caret_analyze_cpp_impl?"
+          echo "In that case, this pytest action may fail because it tests new caret_analyze in combination with old caret_analyze_cpp_impl."
           exit 1

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -43,33 +43,33 @@ jobs:
             package_list.txt
             pip_list.txt
 
-      - name: Clone caret_analyze_cpp_imple
+      - name: Clone caret_analyze_cpp_impl
         run: |
           git clone https://github.com/tier4/caret_analyze_cpp_impl.git
           cd caret_analyze_cpp_impl/
           mv CARET_analyze_cpp_impl src
 
       - name: Restore Cache
-        id: cppimpl-cache
+        id: cpp_impl-cache
         uses: actions/cache/restore@v3
         with:
           path: caret_analyze_cpp_impl/install
-          key: ${{ runner.os }}-node-cppimple-${{ hashFiles('caret_analyze_cpp_impl/src/**') }}
+          key: ${{ runner.os }}-node-cpp_impl-${{ hashFiles('caret_analyze_cpp_impl/src/**') }}
 
-      - name: Build caret_analyze_cpp_imple
-        if: steps.cppimpl-cache.outputs.cache-hit != 'true'
+      - name: Build caret_analyze_cpp_impl
+        if: steps.cpp_impl-cache.outputs.cache-hit != 'true'
         run: |
           source /opt/ros/humble/setup.bash
           cd caret_analyze_cpp_impl/
           colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
         shell: bash
 
-      - name: Cache caret_analyze_cpp_imple
-        if: steps.cppimpl-cache.outputs.cache-hit != 'true'
+      - name: Cache caret_analyze_cpp_impl
+        if: steps.cpp_impl-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v3
         with:
           path: caret_analyze_cpp_impl/install
-          key: ${{ runner.os }}-node-cppimple-${{ hashFiles('caret_analyze_cpp_impl/src/**') }}
+          key: ${{ runner.os }}-node-cpp_impl-${{ hashFiles('caret_analyze_cpp_impl/src/**') }}
 
       - name: Run pytest
         run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -43,7 +43,37 @@ jobs:
             package_list.txt
             pip_list.txt
 
+      - name: Clone caret_analyze_cpp_imple
+        run: |
+          git clone https://github.com/tier4/caret_analyze_cpp_impl.git
+          cd caret_analyze_cpp_impl/
+          mv CARET_analyze_cpp_impl src
+
+      - name: Restore Cache
+        id: cppimpl-cache
+        uses: actions/cache/restore@v3
+        with:
+          path: caret_analyze_cpp_impl/install
+          key: ${{ runner.os }}-node-cppimple-${{ hashFiles('caret_analyze_cpp_impl/src/**') }}
+
+      - name: Build caret_analyze_cpp_imple
+        if: steps.cppimpl-cache.outputs.cache-hit != 'true'
+        run: |
+          source /opt/ros/humble/setup.bash
+          cd caret_analyze_cpp_impl/
+          colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+        shell: bash
+
+      - name: Cache caret_analyze_cpp_imple
+        if: steps.cppimpl-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: caret_analyze_cpp_impl/install
+          key: ${{ runner.os }}-node-cppimple-${{ hashFiles('caret_analyze_cpp_impl/src/**') }}
+
       - name: Run pytest
         run: |
+          mv caret_analyze_cpp_impl/install /__w
+          export PYTHONPATH=/__w/install/caret_analyze_cpp_impl/lib/python3.10/site-packages:$PYTHONPATH
           . /opt/ros/humble/setup.sh
           python3 -m pytest

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -75,4 +75,8 @@ jobs:
           source caret_analyze_cpp_impl/install/setup.bash
           cd src
           python3 -m pytest
+          if [ $? -ne 0 ]; then
+          echo "Are you sending both caret_analyze_cpp_impl and caret_analyze on this PR?"
+          echo "this pytest action may fail because it tests new caret_analyze in combination with old caret_analyze_cpp_impl"
+          fi
         shell: bash

--- a/src/test/record/test_record.py
+++ b/src/test/record/test_record.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from copy import deepcopy
-import os
 from typing import Any
 
 from caret_analyze.exceptions import InvalidArgumentError
@@ -36,16 +35,9 @@ try:
     RecordsCppImpl = cpp_impl.RecordsCppImpl
     CppImplEnabled = True
 except ModuleNotFoundError as e:
-    if 'GITHUB_ACTION' in os.environ:
-        # skip cpp_impl tests
-        # Because caret_analyze does not use caret_analyze_cpp_Impl on github actions.
-        RecordCppImpl = None
-        RecordsCppImpl = None
-        CppImplEnabled = False
-    else:
-        raise ModuleNotFoundError(
-            'Failed to load RecordsCppImpl, ',
-            'possibly due to missing information in the PYTHONPATH environment variable.') from e
+    raise ModuleNotFoundError(
+        'Failed to load RecordsCppImpl, ',
+        'possibly due to missing information in the PYTHONPATH environment variable.') from e
 
 
 def to_cpp_record(record: RecordInterface) -> RecordCppImpl | None:


### PR DESCRIPTION
## Description


In the "Records" class (used in GitHub Actions) and the "RecordsCppImpl" class (used in the local execution environment), it has been observed that they exhibit different behaviors for the same input. To address this issue, "RecordsCppImpl" will be built and used in GitHub Actions. Additionally, when there are no changes in "RecordsCppImpl," caching will be employed to optimize the build process for increased speed.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

https://tier4.atlassian.net/browse/RT2-590
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
