### PR TITLE
chore(histogram): display number for Y-axis instead of probability

### DIFF
--- a/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
@@ -276,7 +276,7 @@ class Bokeh(VisualizeLibInterface):
                              color=color_selector.get_color())
             legend_manager.add_legend(target_object, quad)
             hover = HoverTool(
-                tooltips=[(x_label, '@left'), ('Number', '@top')], renderers=[quad]
+                tooltips=[(x_label, '@left'), ('The number of samples', '@top')], renderers=[quad]
                 )
             plot.add_tools(hover)
 

--- a/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
@@ -217,7 +217,7 @@ class Bokeh(VisualizeLibInterface):
         plot: Figure = Figure(
             title=f'Histogram of {data_type}'
             if case is None else f'Histogram of {data_type} --- {case} case ---',
-            x_axis_label=x_label, y_axis_label='Probability', width=800
+            x_axis_label=x_label, y_axis_label='The number of samples', width=800
             )
 
         data_list: list[list[int]] = []
@@ -269,14 +269,14 @@ class Bokeh(VisualizeLibInterface):
             )
 
         for hist_type, target_object in zip(data_list, target_objects):
-            hist, bins = histogram(hist_type, 20, (min_value, max_value), density=True)
+            hist, bins = histogram(hist_type, 20, (min_value, max_value), density=False)
             quad = plot.quad(top=hist, bottom=0,
                              left=bins[:-1], right=bins[1:],
                              line_color='white', alpha=0.5,
                              color=color_selector.get_color())
             legend_manager.add_legend(target_object, quad)
             hover = HoverTool(
-                tooltips=[(x_label, '@left'), ('Probability', '@top')], renderers=[quad]
+                tooltips=[(x_label, '@left'), ('Number', '@top')], renderers=[quad]
                 )
             plot.add_tools(hover)
 


### PR DESCRIPTION
## Description

### Why this change is needed

- Current implementation for histogram graph uses `Probability` for Y-axis. However, `Probability` (`density=True`) calculated by numpy.histogram is a little confusing. According to [the reference](https://numpy.org/doc/stable/reference/generated/numpy.histogram.html), ` the sum of the histogram values will not be equal to 1 unless bins of unity width are chosen` . So in our usage, the sum doesn't become 1. We can see the trend of Histogram but Y-axis value itself is  useless
- I propose using the number of samples so that a viewer can see the meaningful value. Also, a viewer can judge if the graph is created with enough samples or not

### Before
![bokeh_plot](https://github.com/tier4/caret_analyze/assets/11009876/d903d334-3aa5-48f0-9b3d-a3fb6497b9ec)
![bokeh_plot(1)](https://github.com/tier4/caret_analyze/assets/11009876/39ce79fc-51b9-4732-abd3-b5fa76a96c30)

### After
![bokeh_plot(2)](https://github.com/tier4/caret_analyze/assets/11009876/6b9769e2-2d76-4c13-987e-d2226f7ac7e6)
![bokeh_plot(3)](https://github.com/tier4/caret_analyze/assets/11009876/d7fd760e-a5fa-4e8c-8207-33c1dd5a8da1)

## Related links

None

## Notes for reviewers

- It's just my suggestion. Please give me your feedback if you think we should keep using `Probability`
- Only Y-axis changes

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
