### PR TITLE
fix: error when drawn empty communication

### DIFF
--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1613,9 +1613,8 @@ class FilteredRecordsSource:
                     ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
                 ]
             )
-        # NOTE: publisher_handles should have only one handle.
-        # We need to check publisher_handles has multiple handles.
-        if publisher_handles[0] not in list(grouped_records.keys()):
+        # NOTE: There is concern that publisher_handles has only one publisher_handle.
+        if not set(publisher_handles) & set(grouped_records.keys()):
             return RecordsFactory.create_instance(
                 None,
                 columns=[

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1613,6 +1613,8 @@ class FilteredRecordsSource:
                     ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
                 ]
             )
+        # NOTE: publisher_handles should have only one handle.
+        # We need to check publisher_handles has multiple handles.
         if publisher_handles[0] not in list(grouped_records.keys()):
             return RecordsFactory.create_instance(
                 None,

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1613,6 +1613,16 @@ class FilteredRecordsSource:
                     ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
                 ]
             )
+        if publisher_handles[0] not in list(grouped_records.keys()):
+            return RecordsFactory.create_instance(
+                None,
+                columns=[
+                    ColumnValue(COLUMN_NAME.PUBLISHER_HANDLE),
+                    ColumnValue(COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP),
+                    ColumnValue(COLUMN_NAME.MESSAGE_TIMESTAMP),
+                    ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
+                ]
+            )
         sample_records = grouped_records[publisher_handles[0]]
         column_values = Columns.from_str(sample_records.columns).to_value()
         pub_records = RecordsFactory.create_instance(None, columns=column_values)

--- a/src/test/infra/lttng/test_latency_definitions.py
+++ b/src/test/infra/lttng/test_latency_definitions.py
@@ -823,7 +823,6 @@ class TestPublisherRecords:
         setup_bridge_get_publisher(publisher_struct_mock, [publisher_lttng_mock])
         pub_records = provider.publish_records(publisher_struct_mock)
         pub_df = pub_records.to_dataframe()
-        print(pub_df)
         pub_df_expect = pd.DataFrame(
             [],
             columns=[

--- a/src/test/infra/lttng/test_latency_definitions.py
+++ b/src/test/infra/lttng/test_latency_definitions.py
@@ -816,9 +816,9 @@ class TestPublisherRecords:
 
         assert generic_df.equals(generic_df_expect)
 
-        # non_comunication
-        non_comunicate_pub_handle = 20
-        publisher_lttng_mock = create_publisher_lttng(non_comunicate_pub_handle)
+        # non_communication
+        non_communicate_pub_handle = 20
+        publisher_lttng_mock = create_publisher_lttng(non_communicate_pub_handle)
         publisher_struct_mock = create_publisher_struct('pub_topic')
         setup_bridge_get_publisher(publisher_struct_mock, [publisher_lttng_mock])
         pub_records = provider.publish_records(publisher_struct_mock)

--- a/src/test/infra/lttng/test_latency_definitions.py
+++ b/src/test/infra/lttng/test_latency_definitions.py
@@ -816,6 +816,25 @@ class TestPublisherRecords:
 
         assert generic_df.equals(generic_df_expect)
 
+        # non_comunication
+        non_comunicate_pub_handle = 20
+        publisher_lttng_mock = create_publisher_lttng(non_comunicate_pub_handle)
+        publisher_struct_mock = create_publisher_struct('pub_topic')
+        setup_bridge_get_publisher(publisher_struct_mock, [publisher_lttng_mock])
+        pub_records = provider.publish_records(publisher_struct_mock)
+        pub_df = pub_records.to_dataframe()
+        print(pub_df)
+        pub_df_expect = pd.DataFrame(
+            [],
+            columns=[
+                f'{publisher_struct_mock.topic_name}/rclcpp_publish_timestamp',
+                f'{publisher_struct_mock.topic_name}/message_timestamp',
+                f'{publisher_struct_mock.topic_name}/source_timestamp',
+            ],
+            dtype='Int64'
+        )
+        assert pub_df.equals(pub_df_expect)
+
 
 class TestSubscriptionRecords:
 


### PR DESCRIPTION
## Description

This is modified PR for https://github.com/tier4/caret_analyze/pull/432 .
When communicaton has no data, graph are not drawn and error.
Modify there is no drawn but legend is displayed.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
