### PR TITLE
fix: bokeh interger warning

### DIFF
--- a/src/caret_analyze/plot/visualize_lib/bokeh/callback_scheduling.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/callback_scheduling.py
@@ -78,7 +78,8 @@ class BokehCallbackSched:
         # Draw callback scheduling
         color_selector = ColorSelectorFactory.create_instance(self._coloring_rule)
         legend_manager = LegendManager()
-        rect_source_gen = CallbackSchedRectSource(legend_manager, callbacks[0], clip, frame_min, converter)
+        rect_source_gen = CallbackSchedRectSource(legend_manager, callbacks[0],
+                                                  clip, frame_min, converter)
         bar_source_gen = CallbackSchedBarSource(legend_manager, callbacks[0], frame_min, frame_max)
 
         for cbg in self._callback_groups:
@@ -219,7 +220,8 @@ class CallbackSchedRectSource:
             callback_start = self._converter.convert(row[1]) if self._converter else row[1]
             callback_end = self._converter.convert(row[-1]) if self._converter else row[-1]
             rect = RectValues(
-                (callback_start - self._frame_min) * 10**-9, (callback_end - self._frame_min) * 10**-9,
+                (callback_start - self._frame_min) * 10**-9,
+                (callback_end - self._frame_min) * 10**-9,
                 (self._rect_y_base-self.RECT_HEIGHT),
                 (self._rect_y_base+self.RECT_HEIGHT)
             )
@@ -295,7 +297,8 @@ class CallbackSchedBarSource:
 
         """
         rect = RectValues(
-            (self._frame_min - self._frame_min) * 10**-9, (self._frame_max - self._frame_min) * 10**-9,
+            (self._frame_min - self._frame_min) * 10**-9,
+            (self._frame_max - self._frame_min) * 10**-9,
             rect_y_base - 0.5,
             rect_y_base + 0.5
         )

--- a/src/caret_analyze/plot/visualize_lib/bokeh/callback_scheduling.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/callback_scheduling.py
@@ -73,13 +73,12 @@ class BokehCallbackSched:
             converter = None
             frame_min = clip.min_ns
             frame_max = clip.max_ns
-        x_range_name = 'x_plot_axis'
-        apply_x_axis_offset(fig, frame_min, frame_max, x_range_name)
+        apply_x_axis_offset(fig, frame_min, frame_max)
 
         # Draw callback scheduling
         color_selector = ColorSelectorFactory.create_instance(self._coloring_rule)
         legend_manager = LegendManager()
-        rect_source_gen = CallbackSchedRectSource(legend_manager, callbacks[0], clip, converter)
+        rect_source_gen = CallbackSchedRectSource(legend_manager, callbacks[0], clip, frame_min, converter)
         bar_source_gen = CallbackSchedBarSource(legend_manager, callbacks[0], frame_min, frame_max)
 
         for cbg in self._callback_groups:
@@ -96,8 +95,7 @@ class BokehCallbackSched:
                     color=color,
                     alpha=1.0,
                     hover_fill_color=color,
-                    hover_alpha=1.0,
-                    x_range_name=x_range_name
+                    hover_alpha=1.0
                 )
                 legend_manager.add_legend(callback, rect)
                 fig.add_tools(rect_source_gen.create_hover(
@@ -110,8 +108,7 @@ class BokehCallbackSched:
                     hover_fill_color=color,
                     hover_alpha=0.1,
                     fill_alpha=0.1,
-                    level='underlay',
-                    x_range_name=x_range_name
+                    level='underlay'
                 )
                 fig.add_tools(bar_source_gen.create_hover(
                     {'attachment': 'below', 'renderers': [bar]}
@@ -168,6 +165,7 @@ class CallbackSchedRectSource:
         legend_manager: LegendManager,
         target_object: CallbackBase,
         clip: Clip,
+        frame_min: float,
         converter: ClockConverter | None = None
     ) -> None:
         self._hover_keys = HoverKeysFactory.create_instance(
@@ -175,6 +173,7 @@ class CallbackSchedRectSource:
         self._hover_source = HoverSource(self._hover_keys)
         self._legend_manager = legend_manager
         self._clip = clip
+        self._frame_min = frame_min
         self._converter = converter
         self._rect_y_base = 0.0
 
@@ -220,7 +219,7 @@ class CallbackSchedRectSource:
             callback_start = self._converter.convert(row[1]) if self._converter else row[1]
             callback_end = self._converter.convert(row[-1]) if self._converter else row[-1]
             rect = RectValues(
-                callback_start, callback_end,
+                (callback_start - self._frame_min) * 10**-9, (callback_end - self._frame_min) * 10**-9,
                 (self._rect_y_base-self.RECT_HEIGHT),
                 (self._rect_y_base+self.RECT_HEIGHT)
             )
@@ -296,7 +295,7 @@ class CallbackSchedBarSource:
 
         """
         rect = RectValues(
-            self._frame_min, self._frame_max,
+            (self._frame_min - self._frame_min) * 10**-9, (self._frame_max - self._frame_min) * 10**-9,
             rect_y_base - 0.5,
             rect_y_base + 0.5
         )

--- a/src/caret_analyze/plot/visualize_lib/bokeh/callback_scheduling.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/callback_scheduling.py
@@ -297,7 +297,7 @@ class CallbackSchedBarSource:
 
         """
         rect = RectValues(
-            (self._frame_min - self._frame_min) * 10**-9,
+            0,
             (self._frame_max - self._frame_min) * 10**-9,
             rect_y_base - 0.5,
             rect_y_base + 0.5

--- a/src/caret_analyze/plot/visualize_lib/bokeh/message_flow.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/message_flow.py
@@ -77,7 +77,8 @@ class BokehMessageFlow:
         if converter:
             frame_min = converter.convert(frame_min)
             frame_max = converter.convert(frame_max)
-        offset = Offset(converter.convert(clip.min_ns)) if converter else Offset(clip.min_ns)
+        offset =\
+            Offset(round(converter.convert(clip.min_ns))) if converter else Offset(clip.min_ns)
         apply_x_axis_offset(fig, frame_min - offset.value, frame_max - offset.value)
 
         # Format

--- a/src/caret_analyze/plot/visualize_lib/bokeh/message_flow.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/message_flow.py
@@ -79,7 +79,7 @@ class BokehMessageFlow:
             frame_max = converter.convert(frame_max)
         offset =\
             Offset(round(converter.convert(clip.min_ns))) if converter else Offset(clip.min_ns)
-        apply_x_axis_offset(fig, frame_min - offset.value, frame_max - offset.value)
+        apply_x_axis_offset(fig, frame_min, frame_max)
 
         # Format
         formatter = FormatterFactory.create(self._target_path, self._granularity)

--- a/src/caret_analyze/plot/visualize_lib/bokeh/message_flow.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/message_flow.py
@@ -189,7 +189,9 @@ class MessageFlowRectSource:
                     if converter:
                         callback_start = converter.convert(callback_start)
                         callback_end = converter.convert(callback_end)
-                    rect = RectValues((callback_start - offset.value) * 10**-9, (callback_end - offset.value) * 10**-9, y_min, y_max)
+                    rect = RectValues((callback_start - offset.value) * 10**-9,
+                                      (callback_end - offset.value) * 10**-9,
+                                      y_min, y_max)
                     rect_source.stream({
                         **{'x': [rect.x],
                            'y': [rect.y],

--- a/src/caret_analyze/plot/visualize_lib/bokeh/timeseries.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/timeseries.py
@@ -76,8 +76,7 @@ class BokehTimeSeries:
             converter = get_clock_converter(target_objects)
             frame_min_convert = converter.convert(frame_min)
             frame_max_convert = converter.convert(frame_max)
-            x_range_name = 'x_plot_axis'
-            apply_x_axis_offset(fig, frame_min_convert, frame_max_convert, x_range_name)
+            apply_x_axis_offset(fig, frame_min_convert, frame_max_convert)
         elif self._xaxis_type == 'system_time':
             apply_x_axis_offset(fig, frame_min, frame_max)
 
@@ -92,19 +91,11 @@ class BokehTimeSeries:
                 LineSource(legend_manager, target_objects[0], frame_min, self._xaxis_type)
         fig.add_tools(line_source.create_hover())
         for to, timeseries in zip(target_objects, timeseries_records_list):
-            if converter:
-                renderer = fig.line(
-                    'x', 'y',
-                    source=line_source.generate(to, timeseries),
-                    color=color_selector.get_color(),
-                    x_range_name=x_range_name
-                )
-            else:
-                renderer = fig.line(
-                    'x', 'y',
-                    source=line_source.generate(to, timeseries),
-                    color=color_selector.get_color()
-                )
+            renderer = fig.line(
+                'x', 'y',
+                source=line_source.generate(to, timeseries),
+                color=color_selector.get_color()
+            )
             legend_manager.add_legend(to, renderer)
 
         # Draw legends
@@ -219,11 +210,9 @@ class LineSource:
 
         x_item: list[int | float]
         y_item: list[int | float] = values
-        if self._xaxis_type == 'system_time':
+        if self._xaxis_type == 'system_time' or self._xaxis_type == 'sim_time':
             x_item = [(ts-self._frame_min)*10**(-9) for ts in timestamps]
         elif self._xaxis_type == 'index':
             x_item = list(range(0, len(values)))
-        elif self._xaxis_type == 'sim_time':
-            x_item = timestamps
 
         return x_item, y_item

--- a/src/caret_analyze/plot/visualize_lib/bokeh/util/util.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/util/util.py
@@ -99,9 +99,6 @@ def apply_x_axis_offset(
         Minimum UNIX time.
     max_ns : float
         Maximum UNIX time.
-    x_range_name : str, optional
-        Name of the actual range, by default ''.
-        Specify this if you want to refer to the actual range later.
 
     """
     # Initialize variables

--- a/src/caret_analyze/plot/visualize_lib/bokeh/util/util.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/util/util.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import datetime
 
-from bokeh.models import AdaptiveTicker, LinearAxis, Range1d
+from bokeh.models import AdaptiveTicker, Range1d
 from bokeh.plotting import figure as Figure
 
 import numpy as np

--- a/src/caret_analyze/plot/visualize_lib/bokeh/util/util.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/util/util.py
@@ -84,8 +84,7 @@ def init_figure(
 def apply_x_axis_offset(
     fig: Figure,
     min_ns: float,
-    max_ns: float,
-    x_range_name: str = ''
+    max_ns: float
 ) -> None:
     """
     Apply an offset to the x-axis of the graph.
@@ -108,17 +107,12 @@ def apply_x_axis_offset(
     # Initialize variables
     offset_s = min_ns*1.0e-9
     end_s = (max_ns-min_ns)*1.0e-9
-    actual_range = Range1d(start=min_ns, end=max_ns)
     applied_range = Range1d(start=0, end=end_s)
 
     # Set ranges
-    fig.extra_x_ranges = {x_range_name: actual_range}  # type: ignore
     fig.x_range = applied_range  # type: ignore
 
-    # Add xaxis for actual_range
-    xaxis = LinearAxis(x_range_name=x_range_name)
-    xaxis.visible = False  # type: ignore
-    fig.add_layout(xaxis, 'below')
+    # set ticker
     fig.xaxis.ticker = AdaptiveTicker(min_interval=0.1, mantissas=[1, 2, 5])
 
     # Add xgrid


### PR DESCRIPTION
## Description
Changed implementation so that BokehUserWarning (out of range integer) is not generated.
Converted time difference from UnixTime to Time Difference by subtracting offset before giving array to bokeh.

<!-- Write a brief description of this PR. -->
![image](https://github.com/tier4/caret_analyze/assets/48247817/728fd427-d55c-43c8-8326-c784c27e664c)


## Related links
Jira: https://tier4.atlassian.net/browse/RT2-1071

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers
Please check the following:
- implementation problem
- Are there any Warnings?
- Does the main and output match?
- pytest

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
