### PR TITLE
chore: mkdocstrings version to avoid 0.24

### DIFF
--- a/mkdocs-requirements.txt
+++ b/mkdocs-requirements.txt
@@ -11,5 +11,5 @@ mike
 plantuml-markdown
 pymdown-extensions
 python-markdown-math
-mkdocstrings
+mkdocstrings<=0.23
 mkdocstrings[python]


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

- mkdocstrings v0.24.0 was released on 2023/11/14, but `deploy-docs` fails with this version.
  - Failed session log : https://github.com/tier4/caret_analyze/actions/runs/6924178028
  - Change log: https://mkdocstrings.github.io/changelog/#0240-2023-11-14
- As a workaround, CARET should avoid using v0.23.0

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
