### PR TITLE
fix: restrict max_construction_order at serch for node callbacks

### DIFF
--- a/src/caret_analyze/__init__.py
+++ b/src/caret_analyze/__init__.py
@@ -16,7 +16,7 @@
 from pathlib import Path
 
 from .architecture import \
-    Architecture, check_procedure, MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+    Architecture, check_procedure, DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from .common import init_logger, Progress
 from .infra.lttng import Lttng, LttngEventFilter
 from .runtime.application import Application
@@ -26,7 +26,7 @@ __all__ = [
     'Architecture',
     'Lttng',
     'LttngEventFilter',
-    'MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING',
+    'DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING',
     'Progress',
     'check_procedure'
 ]

--- a/src/caret_analyze/__init__.py
+++ b/src/caret_analyze/__init__.py
@@ -15,7 +15,8 @@
 
 from pathlib import Path
 
-from .architecture import Architecture, check_procedure
+from .architecture import \
+    Architecture, check_procedure, MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from .common import init_logger, Progress
 from .infra.lttng import Lttng, LttngEventFilter
 from .runtime.application import Application
@@ -25,6 +26,7 @@ __all__ = [
     'Architecture',
     'Lttng',
     'LttngEventFilter',
+    'MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING',
     'Progress',
     'check_procedure'
 ]

--- a/src/caret_analyze/architecture/__init__.py
+++ b/src/caret_analyze/architecture/__init__.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .architecture import Architecture, MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+from .architecture import Architecture, DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from .util import check_procedure
 
 __all__ = [
     'Architecture',
     'check_procedure',
-    'MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING'
+    'DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING'
 ]

--- a/src/caret_analyze/architecture/__init__.py
+++ b/src/caret_analyze/architecture/__init__.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .architecture import Architecture
+from .architecture import Architecture, MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from .util import check_procedure
 
 __all__ = [
     'Architecture',
-    'check_procedure'
+    'check_procedure',
+    'MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING'
 ]

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -36,13 +36,16 @@ from ..value_objects.node import DiffNode
 
 logger = logging.getLogger(__name__)
 
+MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING = 10
+
 
 class Architecture(Summarizable):
     def __init__(
         self,
         file_type: str,
         file_path: str,
-        max_callback_construction_order_on_path_searching: int = 10
+        max_callback_construction_order_on_path_searching: int =
+            MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
     ) -> None:
         from .architecture_reader_factory import ArchitectureReaderFactory
         from .architecture_loaded import ArchitectureLoaded

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -18,7 +18,7 @@ from collections.abc import Callable, Collection, Sequence
 import logging
 
 from .architecture_exporter import ArchitectureExporter
-from .architecture_loaded import NodeValuesLoaded
+from .architecture_loaded import NodeValuesLoaded, MAX_CONSTRUCTION_ORDER
 from .combine_path import CombinePath
 
 from .reader_interface import ArchitectureReader, IGNORE_TOPICS
@@ -35,8 +35,6 @@ from ..value_objects import (CallbackGroupStructValue, CallbackStructValue,
 from ..value_objects.node import DiffNode
 
 logger = logging.getLogger(__name__)
-
-MAX_CONSTRUCTION_ORDER = 10
 
 class Architecture(Summarizable):
     def __init__(

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -42,19 +42,22 @@ class Architecture(Summarizable):
         self,
         file_type: str,
         file_path: str,
-        max_construction_order: int = 10
+        max_callback_construction_order_on_path_searching: int = 10
     ) -> None:
         from .architecture_reader_factory import ArchitectureReaderFactory
         from .architecture_loaded import ArchitectureLoaded
 
-        self._max_construction_order = max_construction_order
+        self._max_callback_construction_order_on_path_searching = \
+            max_callback_construction_order_on_path_searching
 
         # /parameter events and /rosout measurements are not yet supported.
         ignore_topics: list[str] = IGNORE_TOPICS
 
         reader = ArchitectureReaderFactory.create_instance(
             file_type, file_path)
-        loaded = ArchitectureLoaded(reader, ignore_topics, max_construction_order)
+        loaded = ArchitectureLoaded(reader,
+                                    ignore_topics,
+                                    max_callback_construction_order_on_path_searching)
 
         self._nodes: list[NodeStruct] = loaded.nodes
         self._communications: list[CommunicationStruct] = loaded.communications
@@ -386,10 +389,12 @@ class Architecture(Summarizable):
         context_reader = AssignContextReader(node)
         context_reader.update_message_context(context_type,
                                               subscribe_topic_name, publish_topic_name)
-        node.update_node_path(NodeValuesLoaded._search_node_paths(
-                                                    node,
-                                                    context_reader,
-                                                    self._max_construction_order))
+        node.update_node_path(
+            NodeValuesLoaded._search_node_paths(
+                                node,
+                                context_reader,
+                                self._max_callback_construction_order_on_path_searching)
+                            )
 
     def insert_publisher_callback(self, node_name: str,
                                   publish_topic_name: str, callback_name: str) -> None:
@@ -410,8 +415,12 @@ class Architecture(Summarizable):
 
         node.insert_publisher_callback(publish_topic_name, callback_name)
 
-        node.update_node_path(NodeValuesLoaded._search_node_paths(node,
-                              AssignContextReader(node), self._max_construction_order))
+        node.update_node_path(
+            NodeValuesLoaded._search_node_paths(
+                                node,
+                                AssignContextReader(node),
+                                self._max_callback_construction_order_on_path_searching)
+                            )
 
     def insert_variable_passing(self, node_name: str,
                                 callback_name_write: str, callback_name_read: str) -> None:
@@ -432,8 +441,12 @@ class Architecture(Summarizable):
 
         node.insert_variable_passing(callback_name_write, callback_name_read)
 
-        node.update_node_path(NodeValuesLoaded._search_node_paths(node,
-                              AssignContextReader(node), self._max_construction_order))
+        node.update_node_path(
+            NodeValuesLoaded._search_node_paths(
+                                node,
+                                AssignContextReader(node),
+                                self._max_callback_construction_order_on_path_searching)
+                            )
 
     def remove_publisher_callback(self, node_name: str,
                                   publish_topic_name: str, callback_name: str) -> None:
@@ -454,8 +467,12 @@ class Architecture(Summarizable):
 
         node.remove_publisher_and_callback(publish_topic_name, callback_name)
 
-        node.update_node_path(NodeValuesLoaded._search_node_paths(node,
-                              AssignContextReader(node), self._max_construction_order))
+        node.update_node_path(
+            NodeValuesLoaded._search_node_paths(
+                                node,
+                                AssignContextReader(node),
+                                self._max_callback_construction_order_on_path_searching)
+                            )
 
     def remove_variable_passing(self, node_name: str,
                                 callback_name_write: str, callback_name_read: str) -> None:
@@ -488,8 +505,12 @@ class Architecture(Summarizable):
                     context_reader.remove_callback_chain(callback_write.subscribe_topic_name,
                                                          publish_topic_name)
 
-            node.update_node_path(NodeValuesLoaded._search_node_paths(node,
-                                  context_reader, self._max_construction_order))
+            node.update_node_path(
+                NodeValuesLoaded._search_node_paths(
+                                    node,
+                                    context_reader,
+                                    self._max_callback_construction_order_on_path_searching)
+                                )
 
     def rename_callback(self, src: str, dst: str) -> None:
         """

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -36,12 +36,14 @@ from ..value_objects.node import DiffNode
 
 logger = logging.getLogger(__name__)
 
+MAX_CONSTRUCTION_ORDER = 10
 
 class Architecture(Summarizable):
     def __init__(
         self,
         file_type: str,
         file_path: str,
+        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> None:
         from .architecture_reader_factory import ArchitectureReaderFactory
         from .architecture_loaded import ArchitectureLoaded
@@ -51,7 +53,7 @@ class Architecture(Summarizable):
 
         reader = ArchitectureReaderFactory.create_instance(
             file_type, file_path)
-        loaded = ArchitectureLoaded(reader, ignore_topics)
+        loaded = ArchitectureLoaded(reader, ignore_topics, max_construction_order=max_construction_order)
 
         self._nodes: list[NodeStruct] = loaded.nodes
         self._communications: list[CommunicationStruct] = loaded.communications

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -18,7 +18,7 @@ from collections.abc import Callable, Collection, Sequence
 import logging
 
 from .architecture_exporter import ArchitectureExporter
-from .architecture_loaded import NodeValuesLoaded, MAX_CONSTRUCTION_ORDER
+from .architecture_loaded import MAX_CONSTRUCTION_ORDER, NodeValuesLoaded
 from .combine_path import CombinePath
 
 from .reader_interface import ArchitectureReader, IGNORE_TOPICS
@@ -36,6 +36,7 @@ from ..value_objects.node import DiffNode
 
 logger = logging.getLogger(__name__)
 
+
 class Architecture(Summarizable):
     def __init__(
         self,
@@ -43,9 +44,6 @@ class Architecture(Summarizable):
         file_path: str,
         max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> None:
-        if max_construction_order == 0:
-            max_construction_order = MAX_CONSTRUCTION_ORDER
-
         from .architecture_reader_factory import ArchitectureReaderFactory
         from .architecture_loaded import ArchitectureLoaded
 
@@ -54,7 +52,9 @@ class Architecture(Summarizable):
 
         reader = ArchitectureReaderFactory.create_instance(
             file_type, file_path)
-        loaded = ArchitectureLoaded(reader, ignore_topics, max_construction_order=max_construction_order)
+        loaded = ArchitectureLoaded(reader,
+                                    ignore_topics,
+                                    max_construction_order=max_construction_order)
 
         self._nodes: list[NodeStruct] = loaded.nodes
         self._communications: list[CommunicationStruct] = loaded.communications

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -36,7 +36,7 @@ from ..value_objects.node import DiffNode
 
 logger = logging.getLogger(__name__)
 
-MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING = 10
+DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING = 10
 
 
 class Architecture(Summarizable):
@@ -45,7 +45,7 @@ class Architecture(Summarizable):
         file_type: str,
         file_path: str,
         max_callback_construction_order_on_path_searching: int =
-            MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+            DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
     ) -> None:
         from .architecture_reader_factory import ArchitectureReaderFactory
         from .architecture_loaded import ArchitectureLoaded

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -43,6 +43,9 @@ class Architecture(Summarizable):
         file_path: str,
         max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> None:
+        if max_construction_order == 0:
+            max_construction_order = MAX_CONSTRUCTION_ORDER
+
         from .architecture_reader_factory import ArchitectureReaderFactory
         from .architecture_loaded import ArchitectureLoaded
 

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -18,7 +18,7 @@ from collections.abc import Callable, Collection, Sequence
 import logging
 
 from .architecture_exporter import ArchitectureExporter
-from .architecture_loaded import MAX_CONSTRUCTION_ORDER, NodeValuesLoaded
+from .architecture_loaded import NodeValuesLoaded
 from .combine_path import CombinePath
 
 from .reader_interface import ArchitectureReader, IGNORE_TOPICS
@@ -42,19 +42,19 @@ class Architecture(Summarizable):
         self,
         file_type: str,
         file_path: str,
-        max_construction_order: int = MAX_CONSTRUCTION_ORDER
+        max_construction_order: int = 10
     ) -> None:
         from .architecture_reader_factory import ArchitectureReaderFactory
         from .architecture_loaded import ArchitectureLoaded
+
+        self._max_construction_order = max_construction_order
 
         # /parameter events and /rosout measurements are not yet supported.
         ignore_topics: list[str] = IGNORE_TOPICS
 
         reader = ArchitectureReaderFactory.create_instance(
             file_type, file_path)
-        loaded = ArchitectureLoaded(reader,
-                                    ignore_topics,
-                                    max_construction_order=max_construction_order)
+        loaded = ArchitectureLoaded(reader, ignore_topics, max_construction_order)
 
         self._nodes: list[NodeStruct] = loaded.nodes
         self._communications: list[CommunicationStruct] = loaded.communications
@@ -386,7 +386,10 @@ class Architecture(Summarizable):
         context_reader = AssignContextReader(node)
         context_reader.update_message_context(context_type,
                                               subscribe_topic_name, publish_topic_name)
-        node.update_node_path(NodeValuesLoaded._search_node_paths(node, context_reader))
+        node.update_node_path(NodeValuesLoaded._search_node_paths(
+                                                    node,
+                                                    context_reader,
+                                                    self._max_construction_order))
 
     def insert_publisher_callback(self, node_name: str,
                                   publish_topic_name: str, callback_name: str) -> None:
@@ -408,7 +411,7 @@ class Architecture(Summarizable):
         node.insert_publisher_callback(publish_topic_name, callback_name)
 
         node.update_node_path(NodeValuesLoaded._search_node_paths(node,
-                              AssignContextReader(node)))
+                              AssignContextReader(node), self._max_construction_order))
 
     def insert_variable_passing(self, node_name: str,
                                 callback_name_write: str, callback_name_read: str) -> None:
@@ -430,7 +433,7 @@ class Architecture(Summarizable):
         node.insert_variable_passing(callback_name_write, callback_name_read)
 
         node.update_node_path(NodeValuesLoaded._search_node_paths(node,
-                              AssignContextReader(node)))
+                              AssignContextReader(node), self._max_construction_order))
 
     def remove_publisher_callback(self, node_name: str,
                                   publish_topic_name: str, callback_name: str) -> None:
@@ -452,7 +455,7 @@ class Architecture(Summarizable):
         node.remove_publisher_and_callback(publish_topic_name, callback_name)
 
         node.update_node_path(NodeValuesLoaded._search_node_paths(node,
-                              AssignContextReader(node)))
+                              AssignContextReader(node), self._max_construction_order))
 
     def remove_variable_passing(self, node_name: str,
                                 callback_name_write: str, callback_name_read: str) -> None:
@@ -486,7 +489,7 @@ class Architecture(Summarizable):
                                                          publish_topic_name)
 
             node.update_node_path(NodeValuesLoaded._search_node_paths(node,
-                                  context_reader))
+                                  context_reader, self._max_construction_order))
 
     def rename_callback(self, src: str, dst: str) -> None:
         """

--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -1615,12 +1615,6 @@ class CallbackPathSearched():
                 if max_construction_order != 0:
                     if write_callback.construction_order > max_construction_order or \
                         read_callback.construction_order > max_construction_order:
-                            """
-                            if node.node_name not in skip_nodes:
-                                skip_nodes.append(node.node_name)
-                                logger.warn(f'skip due to callback construction_order over'
-                                            f'({max_construction_order}): {node.node_name}')
-                            """
                             skip_nodes.append(node.node_name)
                             continue
                 searched_paths = searcher.search(write_callback, read_callback, node)

--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -52,8 +52,6 @@ from ..value_objects import (CallbackGroupValue,
 
 logger = getLogger(__name__)
 
-MAX_CONSTRUCTION_ORDER = 10
-
 
 def indexed_name(base_name: str, i: int, num_digit: int):
     index_str = str(i).zfill(num_digit)
@@ -65,14 +63,14 @@ class ArchitectureLoaded():
         self,
         reader: ArchitectureReader,
         ignore_topics: list[str],
-        max_construction_order: int = MAX_CONSTRUCTION_ORDER
+        max_construction_order: int
     ) -> None:
 
         topic_ignored_reader = TopicIgnoredReader(reader, ignore_topics)
 
         self._nodes: list[NodeStruct]
         nodes_loaded = NodeValuesLoaded(topic_ignored_reader,
-                                        max_construction_order=max_construction_order)
+                                        max_construction_order)
 
         self._nodes = nodes_loaded.data
 
@@ -278,7 +276,7 @@ class NodeValuesLoaded():
     def __init__(
         self,
         reader: ArchitectureReader,
-        max_construction_order: int = MAX_CONSTRUCTION_ORDER
+        max_construction_order: int
     ) -> None:
         self._reader = reader
         nodes_struct: list[NodeStruct] = []
@@ -299,7 +297,7 @@ class NodeValuesLoaded():
                 node, cb_loaded, cbg_loaded = self._create_node(
                     node,
                     reader,
-                    max_construction_order=max_construction_order
+                    max_construction_order
                 )
                 nodes_struct.append(node)
                 self._cb_loaded.append(cb_loaded)
@@ -455,7 +453,7 @@ class NodeValuesLoaded():
     def _create_node(
         node: NodeValue,
         reader: ArchitectureReader,
-        max_construction_order: int = MAX_CONSTRUCTION_ORDER
+        max_construction_order: int
     ) -> tuple[NodeStruct, CallbacksLoaded, CallbackGroupsLoaded]:
 
         callbacks_loaded = CallbacksLoaded(reader, node)
@@ -490,7 +488,7 @@ class NodeValuesLoaded():
                     NodeValuesLoaded._search_node_paths(
                         node_struct,
                         reader,
-                        max_construction_order=max_construction_order
+                        max_construction_order
                     )
             node_path_added = NodeStruct(
                 node_struct.node_name, node_struct.publishers,
@@ -512,7 +510,7 @@ class NodeValuesLoaded():
     def _search_node_paths(
         node: NodeStruct,
         reader: ArchitectureReader,
-        max_construction_order: int = MAX_CONSTRUCTION_ORDER
+        max_construction_order: int
     ) -> list[NodePathStruct]:
 
         node_paths: list[NodePathStruct] = []
@@ -1604,7 +1602,7 @@ class CallbackPathSearched():
     def __init__(
         self,
         node: NodeStruct,
-        max_construction_order: int = MAX_CONSTRUCTION_ORDER
+        max_construction_order: int
     ) -> None:
         from .graph_search import CallbackPathSearcher
         self._data: list[NodePathStruct]

--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -1614,17 +1614,16 @@ class CallbackPathSearched():
 
         if callbacks is not None:
             skip_count = 0
-            import sys
-            construction_order = {'min': sys.maxsize, 'max': 0}
+            max_ignored_construction_order = 0
             for write_callback, read_callback in product(callbacks, callbacks):
                 if max_callback_construction_order != 0:
                     if write_callback.construction_order > max_callback_construction_order or \
                        read_callback.construction_order > max_callback_construction_order:
                         skip_count += 1
-                        construction_order['min'] = min(construction_order['min'],
-                                                        write_callback.construction_order)
-                        construction_order['max'] = max(construction_order['max'],
-                                                        write_callback.construction_order)
+                        max_ignored_construction_order = max(
+                            max_ignored_construction_order,
+                            write_callback.construction_order
+                        )
                         continue
                 searched_paths = searcher.search(write_callback, read_callback, node)
                 for path in searched_paths:
@@ -1641,7 +1640,7 @@ class CallbackPathSearched():
                     f'contains callbacks whose construction_order are greater than '
                     f'{max_callback_construction_order}. '
                     f'{skip_count} paths are ignored as a result. '
-                    f'(max construction_order: {construction_order["max"]})'
+                    f'(max construction_order: {max_ignored_construction_order})'
                 )
 
         self._data = paths

--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -57,18 +57,20 @@ def indexed_name(base_name: str, i: int, num_digit: int):
     index_str = str(i).zfill(num_digit)
     return f'{base_name}_{index_str}'
 
+MAX_CONSTRUCTION_ORDER = 10
 
 class ArchitectureLoaded():
     def __init__(
         self,
         reader: ArchitectureReader,
-        ignore_topics: list[str]
+        ignore_topics: list[str],
+        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> None:
 
         topic_ignored_reader = TopicIgnoredReader(reader, ignore_topics)
 
         self._nodes: list[NodeStruct]
-        nodes_loaded = NodeValuesLoaded(topic_ignored_reader)
+        nodes_loaded = NodeValuesLoaded(topic_ignored_reader, max_construction_order=max_construction_order)
 
         self._nodes = nodes_loaded.data
 
@@ -274,6 +276,7 @@ class NodeValuesLoaded():
     def __init__(
         self,
         reader: ArchitectureReader,
+        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> None:
         self._reader = reader
         nodes_struct: list[NodeStruct] = []
@@ -291,7 +294,7 @@ class NodeValuesLoaded():
 
         for node in Progress.tqdm(nodes, 'Loading nodes.'):
             try:
-                node, cb_loaded, cbg_loaded = self._create_node(node, reader)
+                node, cb_loaded, cbg_loaded = self._create_node(node, reader, max_construction_order=max_construction_order)
                 nodes_struct.append(node)
                 self._cb_loaded.append(cb_loaded)
                 self._cbg_loaded.append(cbg_loaded)
@@ -446,6 +449,7 @@ class NodeValuesLoaded():
     def _create_node(
         node: NodeValue,
         reader: ArchitectureReader,
+        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> tuple[NodeStruct, CallbacksLoaded, CallbackGroupsLoaded]:
 
         callbacks_loaded = CallbacksLoaded(reader, node)
@@ -476,7 +480,7 @@ class NodeValuesLoaded():
         )
 
         try:
-            node_paths = NodeValuesLoaded._search_node_paths(node_struct, reader)
+            node_paths = NodeValuesLoaded._search_node_paths(node_struct, reader, max_construction_order=max_construction_order)
             node_path_added = NodeStruct(
                 node_struct.node_name, node_struct.publishers,
                 node_struct.subscriptions,
@@ -496,14 +500,15 @@ class NodeValuesLoaded():
     @staticmethod
     def _search_node_paths(
         node: NodeStruct,
-        reader: ArchitectureReader
+        reader: ArchitectureReader,
+        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> list[NodePathStruct]:
 
         node_paths: list[NodePathStruct] = []
 
         # add callback-graph paths
         logger.info('[callback_chain]')
-        node_paths += list(CallbackPathSearched(node).data)
+        node_paths += list(CallbackPathSearched(node, max_construction_order).data)
 
         # add pub-sub pair graph paths
         logger.info('\n[pub-sub pair]')
@@ -1588,6 +1593,7 @@ class CallbackPathSearched():
     def __init__(
         self,
         node: NodeStruct,
+        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> None:
         from .graph_search import CallbackPathSearcher
         self._data: list[NodePathStruct]
@@ -1599,6 +1605,10 @@ class CallbackPathSearched():
 
         if callbacks is not None:
             for write_callback, read_callback in product(callbacks, callbacks):
+                if max_construction_order != 0:
+                    if write_callback.construction_order > max_construction_order or \
+                       read_callback.construction_order > max_construction_order:
+                           continue
                 searched_paths = searcher.search(write_callback, read_callback, node)
                 for path in searched_paths:
                     msg = 'Path Added: '

--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -1602,7 +1602,7 @@ class CallbackPathSearched():
     def __init__(
         self,
         node: NodeStruct,
-        max_callback_construction_order_on_path_searching: int
+        max_callback_construction_order: int
     ) -> None:
         from .graph_search import CallbackPathSearcher
         self._data: list[NodePathStruct]
@@ -1617,11 +1617,9 @@ class CallbackPathSearched():
             import sys
             construction_order = {'min': sys.maxsize, 'max': 0}
             for write_callback, read_callback in product(callbacks, callbacks):
-                if max_callback_construction_order_on_path_searching != 0:
-                    if (write_callback.construction_order >
-                            max_callback_construction_order_on_path_searching or
-                            read_callback.construction_order >
-                            max_callback_construction_order_on_path_searching):
+                if max_callback_construction_order != 0:
+                    if write_callback.construction_order > max_callback_construction_order or \
+                       read_callback.construction_order > max_callback_construction_order:
                         skip_count += 1
                         construction_order['min'] = min(construction_order['min'],
                                                         write_callback.construction_order)
@@ -1639,11 +1637,11 @@ class CallbackPathSearched():
 
             if skip_count:
                 logger.warn(
-                    f'contains callbacks whose construction_order are greater than'
-                    f' ({max_callback_construction_order_on_path_searching})'
-                    f': {node.node_name} ({skip_count=})'
-                    f' construction_order'
-                    f' ({construction_order["min"]} - {construction_order["max"]})'
+                    f'{node.node_name} '
+                    f'contains callbacks whose construction_order are greater than '
+                    f'{max_callback_construction_order}. '
+                    f'{skip_count} paths are ignored as a result. '
+                    f'(max construction_order: {construction_order["max"]})'
                 )
 
         self._data = paths

--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -1615,10 +1615,13 @@ class CallbackPathSearched():
                 if max_construction_order != 0:
                     if write_callback.construction_order > max_construction_order or \
                         read_callback.construction_order > max_construction_order:
+                            """
                             if node.node_name not in skip_nodes:
                                 skip_nodes.append(node.node_name)
                                 logger.warn(f'skip due to callback construction_order over'
                                             f'({max_construction_order}): {node.node_name}')
+                            """
+                            skip_nodes.append(node.node_name)
                             continue
                 searched_paths = searcher.search(write_callback, read_callback, node)
                 for path in searched_paths:
@@ -1628,6 +1631,12 @@ class CallbackPathSearched():
                     msg += f'callbacks: {path.callback_names}'
                     logger.info(msg)
                 paths += searched_paths
+
+            from collections import Counter
+            skip_node_counts = Counter(skip_nodes)
+            for name, count in skip_node_counts.items():
+                logger.warn(f'skip due to callback construction_order over'
+                            f'({max_construction_order}): {name} ({count})')
 
         self._data = paths
 

--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -54,6 +54,7 @@ logger = getLogger(__name__)
 
 MAX_CONSTRUCTION_ORDER = 10
 
+
 def indexed_name(base_name: str, i: int, num_digit: int):
     index_str = str(i).zfill(num_digit)
     return f'{base_name}_{index_str}'
@@ -70,7 +71,7 @@ class ArchitectureLoaded():
         topic_ignored_reader = TopicIgnoredReader(reader, ignore_topics)
 
         self._nodes: list[NodeStruct]
-        nodes_loaded = NodeValuesLoaded(topic_ignored_reader, 
+        nodes_loaded = NodeValuesLoaded(topic_ignored_reader,
                                         max_construction_order=max_construction_order)
 
         self._nodes = nodes_loaded.data
@@ -295,9 +296,11 @@ class NodeValuesLoaded():
 
         for node in Progress.tqdm(nodes, 'Loading nodes.'):
             try:
-                node, cb_loaded, cbg_loaded = self._create_node(node, 
-                                                                reader, 
-                                                                max_construction_order=max_construction_order)
+                node, cb_loaded, cbg_loaded = self._create_node(
+                    node,
+                    reader,
+                    max_construction_order=max_construction_order
+                )
                 nodes_struct.append(node)
                 self._cb_loaded.append(cb_loaded)
                 self._cbg_loaded.append(cbg_loaded)
@@ -484,9 +487,11 @@ class NodeValuesLoaded():
 
         try:
             node_paths = \
-                    NodeValuesLoaded._search_node_paths(node_struct, 
-                                                        reader, 
-                                                        max_construction_order=max_construction_order)
+                    NodeValuesLoaded._search_node_paths(
+                        node_struct,
+                        reader,
+                        max_construction_order=max_construction_order
+                    )
             node_path_added = NodeStruct(
                 node_struct.node_name, node_struct.publishers,
                 node_struct.subscriptions,
@@ -1614,9 +1619,9 @@ class CallbackPathSearched():
             for write_callback, read_callback in product(callbacks, callbacks):
                 if max_construction_order != 0:
                     if write_callback.construction_order > max_construction_order or \
-                        read_callback.construction_order > max_construction_order:
-                            skip_nodes.append(node.node_name)
-                            continue
+                            read_callback.construction_order > max_construction_order:
+                        skip_nodes.append(node.node_name)
+                        continue
                 searched_paths = searcher.search(write_callback, read_callback, node)
                 for path in searched_paths:
                     msg = 'Path Added: '

--- a/src/caret_analyze/architecture/util.py
+++ b/src/caret_analyze/architecture/util.py
@@ -39,7 +39,7 @@ def check_procedure(
     reader = ArchitectureReaderFactory.create_instance(file_type, file_path)
     node = Util.find_one(lambda x: x.node_name == node_name, app_arch._nodes)
 
-    paths = NodeValuesLoaded._search_node_paths(node, reader)
+    paths = NodeValuesLoaded._search_node_paths(node, reader, app_arch._max_construction_order)
 
     root_logger.removeHandler(handler)
     return tuple(v.to_value() for v in paths)

--- a/src/caret_analyze/architecture/util.py
+++ b/src/caret_analyze/architecture/util.py
@@ -39,7 +39,11 @@ def check_procedure(
     reader = ArchitectureReaderFactory.create_instance(file_type, file_path)
     node = Util.find_one(lambda x: x.node_name == node_name, app_arch._nodes)
 
-    paths = NodeValuesLoaded._search_node_paths(node, reader, app_arch._max_construction_order)
+    paths = NodeValuesLoaded._search_node_paths(
+                                node,
+                                reader,
+                                app_arch._max_callback_construction_order_on_path_searching
+                            )
 
     root_logger.removeHandler(handler)
     return tuple(v.to_value() for v in paths)

--- a/src/test/architecture/test_architecture.py
+++ b/src/test/architecture/test_architecture.py
@@ -21,7 +21,7 @@ from logging import WARNING
 from string import Template
 
 from caret_analyze.architecture import Architecture
-from caret_analyze.architecture.architecture_loaded import ArchitectureLoaded, MAX_CONSTRUCTION_ORDER
+from caret_analyze.architecture.architecture_loaded import ArchitectureLoaded
 from caret_analyze.architecture.architecture_reader_factory import \
     ArchitectureReaderFactory
 from caret_analyze.architecture.graph_search import NodePathSearcher
@@ -131,13 +131,11 @@ def create_arch(mocker):
 def create_node(
     create_publisher: Callable[[str, str], PublisherStructValue],
     create_subscription: Callable[[str, str], SubscriptionStructValue],
-    max_construction_order: int = MAX_CONSTRUCTION_ORDER
 ):
     def _create_node(
         node_name: str,
         sub_topic_name: str | None,
         pub_topic_name: str | None,
-        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> NodeStructValue:
         pubs: tuple[PublisherStructValue, ...]
         subs: tuple[SubscriptionStructValue, ...]

--- a/src/test/architecture/test_architecture.py
+++ b/src/test/architecture/test_architecture.py
@@ -130,12 +130,12 @@ def create_arch(mocker):
 @pytest.fixture
 def create_node(
     create_publisher: Callable[[str, str], PublisherStructValue],
-    create_subscription: Callable[[str, str], SubscriptionStructValue],
+    create_subscription: Callable[[str, str], SubscriptionStructValue]
 ):
     def _create_node(
         node_name: str,
         sub_topic_name: str | None,
-        pub_topic_name: str | None,
+        pub_topic_name: str | None
     ) -> NodeStructValue:
         pubs: tuple[PublisherStructValue, ...]
         subs: tuple[SubscriptionStructValue, ...]

--- a/src/test/architecture/test_architecture.py
+++ b/src/test/architecture/test_architecture.py
@@ -21,7 +21,7 @@ from logging import WARNING
 from string import Template
 
 from caret_analyze.architecture import Architecture
-from caret_analyze.architecture.architecture_loaded import ArchitectureLoaded
+from caret_analyze.architecture.architecture_loaded import ArchitectureLoaded, MAX_CONSTRUCTION_ORDER
 from caret_analyze.architecture.architecture_reader_factory import \
     ArchitectureReaderFactory
 from caret_analyze.architecture.graph_search import NodePathSearcher
@@ -130,12 +130,14 @@ def create_arch(mocker):
 @pytest.fixture
 def create_node(
     create_publisher: Callable[[str, str], PublisherStructValue],
-    create_subscription: Callable[[str, str], SubscriptionStructValue]
+    create_subscription: Callable[[str, str], SubscriptionStructValue],
+    max_construction_order: int = MAX_CONSTRUCTION_ORDER
 ):
     def _create_node(
         node_name: str,
         sub_topic_name: str | None,
-        pub_topic_name: str | None
+        pub_topic_name: str | None,
+        max_construction_order: int = MAX_CONSTRUCTION_ORDER
     ) -> NodeStructValue:
         pubs: tuple[PublisherStructValue, ...]
         subs: tuple[SubscriptionStructValue, ...]

--- a/src/test/architecture/test_architecture_loader.py
+++ b/src/test/architecture/test_architecture_loader.py
@@ -240,7 +240,7 @@ class TestNodesInfoLoaded():
         def create_node(
             node,
             reader,
-            max_construction_order: int
+            max_callback_construction_order_on_path_searching: int
         ):
             node_mock = mocker.Mock(spec=NodeStruct)
             cb_loaded_mock = mocker.Mock(spec=CallbacksLoaded)

--- a/src/test/architecture/test_architecture_loader.py
+++ b/src/test/architecture/test_architecture_loader.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from caret_analyze.architecture.architecture import \
-    MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+    DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from caret_analyze.architecture.architecture_loaded import (ArchitectureLoaded,
                                                             CallbackGroupsLoaded,
                                                             CallbackPathSearched,
@@ -88,7 +88,7 @@ class TestArchitectureLoaded:
         mocker.patch.object(path_loaded, 'data', [])
 
         arch = ArchitectureLoaded(reader_mock, [],
-                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
+                                  DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         assert len(arch.paths) == 0
         assert len(arch.executors) == 0
         assert len(arch.nodes) == 0
@@ -151,7 +151,7 @@ class TestArchitectureLoaded:
         mocker.patch('caret_analyze.architecture.architecture_loaded.TopicIgnoredReader',
                      return_value=reader_mock)
         arch = ArchitectureLoaded(reader_mock, [],
-                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
+                                  DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         assert len(arch.paths) == 1
         assert len(arch.executors) == 1
         assert len(arch.nodes) == 1
@@ -173,7 +173,7 @@ class TestNodesInfoLoaded():
             reader_mock, 'get_nodes', return_value=[])
 
         loader = NodeValuesLoaded(reader_mock,
-                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
+                                  DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         nodes = loader.data
         assert len(nodes) == 0
 
@@ -194,7 +194,7 @@ class TestNodesInfoLoaded():
                             return_value=[node])
 
         loader = NodeValuesLoaded(reader_mock,
-                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
+                                  DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         nodes = loader.data
         assert nodes == [node_mock]
 
@@ -214,7 +214,7 @@ class TestNodesInfoLoaded():
                             return_value=[node_a, node_b])
 
         loader = NodeValuesLoaded(reader_mock,
-                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
+                                  DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         nodes = loader.data
         assert len(nodes) == 1
         assert 'Duplicated node name.' in caplog.messages[0]
@@ -227,7 +227,7 @@ class TestNodesInfoLoaded():
                             return_value=[node_a, node_b])
 
         loader = NodeValuesLoaded(reader_mock,
-                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
+                                  DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         nodes = loader.data
         assert len(nodes) == 1
         assert 'Duplicated node id.' in caplog.messages[0]
@@ -260,7 +260,7 @@ class TestNodesInfoLoaded():
                             side_effect=create_node)
 
         loader = NodeValuesLoaded(reader_mock,
-                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
+                                  DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         nodes = loader.data
         assert nodes[0].node_name == 'a'
         assert nodes[1].node_name == 'b'
@@ -306,7 +306,7 @@ class TestNodesInfoLoaded():
         node, _, _ = NodeValuesLoaded._create_node(
             node_value,
             reader_mock,
-            MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+            DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
         )
 
         assert node.node_name == 'node'
@@ -409,7 +409,7 @@ class TestNodesInfoLoaded():
         node, _, _ = NodeValuesLoaded._create_node(
             node_value,
             reader_mock,
-            MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+            DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
         )
 
         assert node.node_name == 'node'
@@ -441,7 +441,7 @@ class TestNodesInfoLoaded():
                             return_value=[node])
 
         loaded = NodeValuesLoaded(reader_mock,
-                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
+                                  DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         assert loaded.find_callback('callback_id') == cb_mock
 
         mocker.patch.object(cb_loaded_mock, 'find_callback',
@@ -460,7 +460,7 @@ class TestNodesInfoLoaded():
                             return_value=(node_mock, cb_loaded_mock, cbg_loaded_mock))
 
         nodes_loaded = NodeValuesLoaded(reader_mock,
-                                        MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
+                                        DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
 
         node_mock = mocker.Mock(spec=NodeStruct)
         mocker.patch.object(Util, 'find_one', return_value=node_mock)
@@ -484,7 +484,7 @@ class TestNodesInfoLoaded():
                             return_value=(node_mock, cb_loaded_mock, cbg_loaded_mock))
 
         nodes_loaded = NodeValuesLoaded(reader_mock,
-                                        MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
+                                        DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
 
         mocker.patch.object(nodes_loaded, 'find_node',
                             return_value=node_mock)
@@ -552,7 +552,7 @@ class TestNodesInfoLoaded():
         mocker.patch.object(reader_mock, 'get_nodes', return_value=[node])
 
         loaded = NodeValuesLoaded(reader_mock,
-                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
+                                  DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         assert loaded.find_callbacks(['callback_id']) == [cb_mock]
 
         mocker.patch.object(cb_loaded_mock, 'search_callbacks', return_value=[])
@@ -580,7 +580,7 @@ class TestNodesInfoLoaded():
         mocker.patch.object(reader_mock, 'get_nodes', return_value=[node])
 
         loaded = NodeValuesLoaded(reader_mock,
-                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
+                                  DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
 
         cb_mock = mocker.Mock(spec=CallbackStruct)
         cb_loaded_mock = mocker.Mock(spec=CallbacksLoaded)
@@ -735,7 +735,7 @@ class TestNodePathLoaded:
         node_mock = mocker.Mock(spec=NodeStruct)
         mocker.patch.object(node_mock, 'callbacks', [])
         searched = CallbackPathSearched(node_mock,
-                                        MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
+                                        DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         assert len(searched.data) == 0
 
     def test_full(self, mocker):
@@ -744,7 +744,8 @@ class TestNodePathLoaded:
                      return_value=searcher_mock)
 
         callback_mock = mocker.Mock(spec=CallbackStruct)
-        callback_mock.construction_order = MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING - 1
+        callback_mock.construction_order = \
+            DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING - 1
         node_path_mock = mocker.Mock(NodePathStruct)
         mocker.patch.object(searcher_mock, 'search',
                             return_value=[node_path_mock])
@@ -755,7 +756,7 @@ class TestNodePathLoaded:
         node_mock = mocker.Mock(spec=NodeStruct)
         mocker.patch.object(node_mock, 'callbacks', callbacks)
         searched = CallbackPathSearched(node_mock,
-                                        MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
+                                        DEFAULT_MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
 
         import itertools
         product = list(itertools.product(callbacks, callbacks))

--- a/src/test/architecture/test_architecture_loader.py
+++ b/src/test/architecture/test_architecture_loader.py
@@ -18,6 +18,7 @@ from caret_analyze.architecture.architecture_loaded import (ArchitectureLoaded,
                                                             CallbacksLoaded,
                                                             CommValuesLoaded,
                                                             ExecutorValuesLoaded,
+                                                            MAX_CONSTRUCTION_ORDER,
                                                             NodePathCreated,
                                                             NodeValuesLoaded,
                                                             PathValuesLoaded,
@@ -237,7 +238,11 @@ class TestNodesInfoLoaded():
         mocker.patch.object(
             reader_mock, 'get_nodes', return_value=[node_b, node_c, node_a])
 
-        def create_node(node, reader):
+        def create_node(
+            node,
+            reader,
+            max_construction_order: int = MAX_CONSTRUCTION_ORDER
+        ):
             node_mock = mocker.Mock(spec=NodeStruct)
             cb_loaded_mock = mocker.Mock(spec=CallbacksLoaded)
             cbg_loaded_mock = mocker.Mock(spec=CallbackGroupsLoaded)
@@ -713,6 +718,7 @@ class TestNodePathLoaded:
 
     def test_full(self, mocker):
         searcher_mock = mocker.Mock(spec=CallbackPathSearcher)
+        searcher_mock.max_construction_order = MAX_CONSTRUCTION_ORDER
         mocker.patch('caret_analyze.architecture.graph_search.CallbackPathSearcher',
                      return_value=searcher_mock)
 

--- a/src/test/architecture/test_architecture_loader.py
+++ b/src/test/architecture/test_architecture_loader.py
@@ -718,11 +718,11 @@ class TestNodePathLoaded:
 
     def test_full(self, mocker):
         searcher_mock = mocker.Mock(spec=CallbackPathSearcher)
-        searcher_mock.max_construction_order = MAX_CONSTRUCTION_ORDER
         mocker.patch('caret_analyze.architecture.graph_search.CallbackPathSearcher',
                      return_value=searcher_mock)
 
         callback_mock = mocker.Mock(spec=CallbackStruct)
+        callback_mock.construction_order = MAX_CONSTRUCTION_ORDER - 1
         node_path_mock = mocker.Mock(NodePathStruct)
         mocker.patch.object(searcher_mock, 'search',
                             return_value=[node_path_mock])
@@ -732,7 +732,7 @@ class TestNodePathLoaded:
         callbacks = (callback_mock, callback_mock)
         node_mock = mocker.Mock(spec=NodeStruct)
         mocker.patch.object(node_mock, 'callbacks', callbacks)
-        searched = CallbackPathSearched(node_mock)
+        searched = CallbackPathSearched(node_mock, MAX_CONSTRUCTION_ORDER)
 
         import itertools
         product = list(itertools.product(callbacks, callbacks))

--- a/src/test/architecture/test_architecture_loader.py
+++ b/src/test/architecture/test_architecture_loader.py
@@ -18,7 +18,6 @@ from caret_analyze.architecture.architecture_loaded import (ArchitectureLoaded,
                                                             CallbacksLoaded,
                                                             CommValuesLoaded,
                                                             ExecutorValuesLoaded,
-                                                            MAX_CONSTRUCTION_ORDER,
                                                             NodePathCreated,
                                                             NodeValuesLoaded,
                                                             PathValuesLoaded,
@@ -86,7 +85,7 @@ class TestArchitectureLoaded:
         mocker.patch.object(exec_loaded, 'data', [])
         mocker.patch.object(path_loaded, 'data', [])
 
-        arch = ArchitectureLoaded(reader_mock, [])
+        arch = ArchitectureLoaded(reader_mock, [], 10)
         assert len(arch.paths) == 0
         assert len(arch.executors) == 0
         assert len(arch.nodes) == 0
@@ -148,7 +147,7 @@ class TestArchitectureLoaded:
 
         mocker.patch('caret_analyze.architecture.architecture_loaded.TopicIgnoredReader',
                      return_value=reader_mock)
-        arch = ArchitectureLoaded(reader_mock, [])
+        arch = ArchitectureLoaded(reader_mock, [], 10)
         assert len(arch.paths) == 1
         assert len(arch.executors) == 1
         assert len(arch.nodes) == 1
@@ -169,7 +168,7 @@ class TestNodesInfoLoaded():
         mocker.patch.object(
             reader_mock, 'get_nodes', return_value=[])
 
-        loader = NodeValuesLoaded(reader_mock)
+        loader = NodeValuesLoaded(reader_mock, 10)
         nodes = loader.data
         assert len(nodes) == 0
 
@@ -189,7 +188,7 @@ class TestNodesInfoLoaded():
         mocker.patch.object(reader_mock, 'get_nodes',
                             return_value=[node])
 
-        loader = NodeValuesLoaded(reader_mock)
+        loader = NodeValuesLoaded(reader_mock, 10)
         nodes = loader.data
         assert nodes == [node_mock]
 
@@ -208,7 +207,7 @@ class TestNodesInfoLoaded():
         mocker.patch.object(reader_mock, 'get_nodes',
                             return_value=[node_a, node_b])
 
-        loader = NodeValuesLoaded(reader_mock)
+        loader = NodeValuesLoaded(reader_mock, 10)
         nodes = loader.data
         assert len(nodes) == 1
         assert 'Duplicated node name.' in caplog.messages[0]
@@ -220,7 +219,7 @@ class TestNodesInfoLoaded():
         mocker.patch.object(reader_mock, 'get_nodes',
                             return_value=[node_a, node_b])
 
-        loader = NodeValuesLoaded(reader_mock)
+        loader = NodeValuesLoaded(reader_mock, 10)
         nodes = loader.data
         assert len(nodes) == 1
         assert 'Duplicated node id.' in caplog.messages[0]
@@ -241,7 +240,7 @@ class TestNodesInfoLoaded():
         def create_node(
             node,
             reader,
-            max_construction_order: int = MAX_CONSTRUCTION_ORDER
+            max_construction_order: int
         ):
             node_mock = mocker.Mock(spec=NodeStruct)
             cb_loaded_mock = mocker.Mock(spec=CallbacksLoaded)
@@ -252,7 +251,7 @@ class TestNodesInfoLoaded():
         mocker.patch.object(NodeValuesLoaded, '_create_node',
                             side_effect=create_node)
 
-        loader = NodeValuesLoaded(reader_mock)
+        loader = NodeValuesLoaded(reader_mock, 10)
         nodes = loader.data
         assert nodes[0].node_name == 'a'
         assert nodes[1].node_name == 'b'
@@ -295,7 +294,7 @@ class TestNodesInfoLoaded():
         mocker.patch.object(cbs_loaded, 'data', [])
 
         node_value = NodeValue('node', 'node')
-        node, _, _ = NodeValuesLoaded._create_node(node_value, reader_mock)
+        node, _, _ = NodeValuesLoaded._create_node(node_value, reader_mock, 10)
 
         assert node.node_name == 'node'
         assert node.publishers == []
@@ -394,7 +393,7 @@ class TestNodesInfoLoaded():
             NodeValuesLoaded, '_search_node_paths', return_value=[path, path_])
 
         node_value = NodeValue('node', 'node')
-        node, _, _ = NodeValuesLoaded._create_node(node_value, reader_mock)
+        node, _, _ = NodeValuesLoaded._create_node(node_value, reader_mock, 10)
 
         assert node.node_name == 'node'
         assert node.publishers == [publisher]
@@ -424,7 +423,7 @@ class TestNodesInfoLoaded():
         mocker.patch.object(reader_mock, 'get_nodes',
                             return_value=[node])
 
-        loaded = NodeValuesLoaded(reader_mock)
+        loaded = NodeValuesLoaded(reader_mock, 10)
         assert loaded.find_callback('callback_id') == cb_mock
 
         mocker.patch.object(cb_loaded_mock, 'find_callback',
@@ -442,7 +441,7 @@ class TestNodesInfoLoaded():
         mocker.patch.object(NodeValuesLoaded, '_create_node',
                             return_value=(node_mock, cb_loaded_mock, cbg_loaded_mock))
 
-        nodes_loaded = NodeValuesLoaded(reader_mock)
+        nodes_loaded = NodeValuesLoaded(reader_mock, 10)
 
         node_mock = mocker.Mock(spec=NodeStruct)
         mocker.patch.object(Util, 'find_one', return_value=node_mock)
@@ -465,7 +464,7 @@ class TestNodesInfoLoaded():
         mocker.patch.object(NodeValuesLoaded, '_create_node',
                             return_value=(node_mock, cb_loaded_mock, cbg_loaded_mock))
 
-        nodes_loaded = NodeValuesLoaded(reader_mock)
+        nodes_loaded = NodeValuesLoaded(reader_mock, 10)
 
         mocker.patch.object(nodes_loaded, 'find_node',
                             return_value=node_mock)
@@ -532,7 +531,7 @@ class TestNodesInfoLoaded():
         node = NodeValue('node', None)
         mocker.patch.object(reader_mock, 'get_nodes', return_value=[node])
 
-        loaded = NodeValuesLoaded(reader_mock)
+        loaded = NodeValuesLoaded(reader_mock, 10)
         assert loaded.find_callbacks(['callback_id']) == [cb_mock]
 
         mocker.patch.object(cb_loaded_mock, 'search_callbacks', return_value=[])
@@ -559,7 +558,7 @@ class TestNodesInfoLoaded():
         node = NodeValue('node', None)
         mocker.patch.object(reader_mock, 'get_nodes', return_value=[node])
 
-        loaded = NodeValuesLoaded(reader_mock)
+        loaded = NodeValuesLoaded(reader_mock, 10)
 
         cb_mock = mocker.Mock(spec=CallbackStruct)
         cb_loaded_mock = mocker.Mock(spec=CallbacksLoaded)
@@ -713,7 +712,7 @@ class TestNodePathLoaded:
         mocker.patch.object(searcher_mock, 'search', return_value=[])
         node_mock = mocker.Mock(spec=NodeStruct)
         mocker.patch.object(node_mock, 'callbacks', [])
-        searched = CallbackPathSearched(node_mock)
+        searched = CallbackPathSearched(node_mock, 10)
         assert len(searched.data) == 0
 
     def test_full(self, mocker):
@@ -722,7 +721,7 @@ class TestNodePathLoaded:
                      return_value=searcher_mock)
 
         callback_mock = mocker.Mock(spec=CallbackStruct)
-        callback_mock.construction_order = MAX_CONSTRUCTION_ORDER - 1
+        callback_mock.construction_order = 10 - 1
         node_path_mock = mocker.Mock(NodePathStruct)
         mocker.patch.object(searcher_mock, 'search',
                             return_value=[node_path_mock])
@@ -732,7 +731,7 @@ class TestNodePathLoaded:
         callbacks = (callback_mock, callback_mock)
         node_mock = mocker.Mock(spec=NodeStruct)
         mocker.patch.object(node_mock, 'callbacks', callbacks)
-        searched = CallbackPathSearched(node_mock, MAX_CONSTRUCTION_ORDER)
+        searched = CallbackPathSearched(node_mock, 10)
 
         import itertools
         product = list(itertools.product(callbacks, callbacks))

--- a/src/test/architecture/test_architecture_loader.py
+++ b/src/test/architecture/test_architecture_loader.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from caret_analyze.architecture.architecture import \
+    MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
 from caret_analyze.architecture.architecture_loaded import (ArchitectureLoaded,
                                                             CallbackGroupsLoaded,
                                                             CallbackPathSearched,
@@ -85,7 +87,8 @@ class TestArchitectureLoaded:
         mocker.patch.object(exec_loaded, 'data', [])
         mocker.patch.object(path_loaded, 'data', [])
 
-        arch = ArchitectureLoaded(reader_mock, [], 10)
+        arch = ArchitectureLoaded(reader_mock, [],
+                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         assert len(arch.paths) == 0
         assert len(arch.executors) == 0
         assert len(arch.nodes) == 0
@@ -147,7 +150,8 @@ class TestArchitectureLoaded:
 
         mocker.patch('caret_analyze.architecture.architecture_loaded.TopicIgnoredReader',
                      return_value=reader_mock)
-        arch = ArchitectureLoaded(reader_mock, [], 10)
+        arch = ArchitectureLoaded(reader_mock, [],
+                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         assert len(arch.paths) == 1
         assert len(arch.executors) == 1
         assert len(arch.nodes) == 1
@@ -168,7 +172,8 @@ class TestNodesInfoLoaded():
         mocker.patch.object(
             reader_mock, 'get_nodes', return_value=[])
 
-        loader = NodeValuesLoaded(reader_mock, 10)
+        loader = NodeValuesLoaded(reader_mock,
+                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         nodes = loader.data
         assert len(nodes) == 0
 
@@ -188,7 +193,8 @@ class TestNodesInfoLoaded():
         mocker.patch.object(reader_mock, 'get_nodes',
                             return_value=[node])
 
-        loader = NodeValuesLoaded(reader_mock, 10)
+        loader = NodeValuesLoaded(reader_mock,
+                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         nodes = loader.data
         assert nodes == [node_mock]
 
@@ -207,7 +213,8 @@ class TestNodesInfoLoaded():
         mocker.patch.object(reader_mock, 'get_nodes',
                             return_value=[node_a, node_b])
 
-        loader = NodeValuesLoaded(reader_mock, 10)
+        loader = NodeValuesLoaded(reader_mock,
+                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         nodes = loader.data
         assert len(nodes) == 1
         assert 'Duplicated node name.' in caplog.messages[0]
@@ -219,7 +226,8 @@ class TestNodesInfoLoaded():
         mocker.patch.object(reader_mock, 'get_nodes',
                             return_value=[node_a, node_b])
 
-        loader = NodeValuesLoaded(reader_mock, 10)
+        loader = NodeValuesLoaded(reader_mock,
+                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         nodes = loader.data
         assert len(nodes) == 1
         assert 'Duplicated node id.' in caplog.messages[0]
@@ -251,7 +259,8 @@ class TestNodesInfoLoaded():
         mocker.patch.object(NodeValuesLoaded, '_create_node',
                             side_effect=create_node)
 
-        loader = NodeValuesLoaded(reader_mock, 10)
+        loader = NodeValuesLoaded(reader_mock,
+                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         nodes = loader.data
         assert nodes[0].node_name == 'a'
         assert nodes[1].node_name == 'b'
@@ -294,7 +303,11 @@ class TestNodesInfoLoaded():
         mocker.patch.object(cbs_loaded, 'data', [])
 
         node_value = NodeValue('node', 'node')
-        node, _, _ = NodeValuesLoaded._create_node(node_value, reader_mock, 10)
+        node, _, _ = NodeValuesLoaded._create_node(
+            node_value,
+            reader_mock,
+            MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+        )
 
         assert node.node_name == 'node'
         assert node.publishers == []
@@ -393,7 +406,11 @@ class TestNodesInfoLoaded():
             NodeValuesLoaded, '_search_node_paths', return_value=[path, path_])
 
         node_value = NodeValue('node', 'node')
-        node, _, _ = NodeValuesLoaded._create_node(node_value, reader_mock, 10)
+        node, _, _ = NodeValuesLoaded._create_node(
+            node_value,
+            reader_mock,
+            MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING
+        )
 
         assert node.node_name == 'node'
         assert node.publishers == [publisher]
@@ -423,7 +440,8 @@ class TestNodesInfoLoaded():
         mocker.patch.object(reader_mock, 'get_nodes',
                             return_value=[node])
 
-        loaded = NodeValuesLoaded(reader_mock, 10)
+        loaded = NodeValuesLoaded(reader_mock,
+                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         assert loaded.find_callback('callback_id') == cb_mock
 
         mocker.patch.object(cb_loaded_mock, 'find_callback',
@@ -441,7 +459,8 @@ class TestNodesInfoLoaded():
         mocker.patch.object(NodeValuesLoaded, '_create_node',
                             return_value=(node_mock, cb_loaded_mock, cbg_loaded_mock))
 
-        nodes_loaded = NodeValuesLoaded(reader_mock, 10)
+        nodes_loaded = NodeValuesLoaded(reader_mock,
+                                        MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
 
         node_mock = mocker.Mock(spec=NodeStruct)
         mocker.patch.object(Util, 'find_one', return_value=node_mock)
@@ -464,7 +483,8 @@ class TestNodesInfoLoaded():
         mocker.patch.object(NodeValuesLoaded, '_create_node',
                             return_value=(node_mock, cb_loaded_mock, cbg_loaded_mock))
 
-        nodes_loaded = NodeValuesLoaded(reader_mock, 10)
+        nodes_loaded = NodeValuesLoaded(reader_mock,
+                                        MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
 
         mocker.patch.object(nodes_loaded, 'find_node',
                             return_value=node_mock)
@@ -531,7 +551,8 @@ class TestNodesInfoLoaded():
         node = NodeValue('node', None)
         mocker.patch.object(reader_mock, 'get_nodes', return_value=[node])
 
-        loaded = NodeValuesLoaded(reader_mock, 10)
+        loaded = NodeValuesLoaded(reader_mock,
+                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         assert loaded.find_callbacks(['callback_id']) == [cb_mock]
 
         mocker.patch.object(cb_loaded_mock, 'search_callbacks', return_value=[])
@@ -558,7 +579,8 @@ class TestNodesInfoLoaded():
         node = NodeValue('node', None)
         mocker.patch.object(reader_mock, 'get_nodes', return_value=[node])
 
-        loaded = NodeValuesLoaded(reader_mock, 10)
+        loaded = NodeValuesLoaded(reader_mock,
+                                  MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
 
         cb_mock = mocker.Mock(spec=CallbackStruct)
         cb_loaded_mock = mocker.Mock(spec=CallbacksLoaded)
@@ -712,7 +734,8 @@ class TestNodePathLoaded:
         mocker.patch.object(searcher_mock, 'search', return_value=[])
         node_mock = mocker.Mock(spec=NodeStruct)
         mocker.patch.object(node_mock, 'callbacks', [])
-        searched = CallbackPathSearched(node_mock, 10)
+        searched = CallbackPathSearched(node_mock,
+                                        MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
         assert len(searched.data) == 0
 
     def test_full(self, mocker):
@@ -721,7 +744,7 @@ class TestNodePathLoaded:
                      return_value=searcher_mock)
 
         callback_mock = mocker.Mock(spec=CallbackStruct)
-        callback_mock.construction_order = 10 - 1
+        callback_mock.construction_order = MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING - 1
         node_path_mock = mocker.Mock(NodePathStruct)
         mocker.patch.object(searcher_mock, 'search',
                             return_value=[node_path_mock])
@@ -731,7 +754,8 @@ class TestNodePathLoaded:
         callbacks = (callback_mock, callback_mock)
         node_mock = mocker.Mock(spec=NodeStruct)
         mocker.patch.object(node_mock, 'callbacks', callbacks)
-        searched = CallbackPathSearched(node_mock, 10)
+        searched = CallbackPathSearched(node_mock,
+                                        MAX_CALLBACK_CONSTRUCTION_ORDER_ON_PATH_SEARCHING)
 
         import itertools
         product = list(itertools.product(callbacks, callbacks))


### PR DESCRIPTION
## Description

Restrict construction_order when searching for node callbacks paths.

## Related links

[https://tier4.atlassian.net/browse/RT2-1261](https://tier4.atlassian.net/browse/RT2-1261)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
