### PR TITLE
fix: log config is not copied after the build

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -6,6 +6,7 @@ setup(
     name=package_name,
     version='0.2.2',
     packages=find_packages(exclude=['test']),
+    package_data={package_name: ['log_config.yaml']},
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),


### PR DESCRIPTION
## Description

Fixed the issue that `log_config.yaml` was not copied when using `colcon build` without `--symlink-install` option.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
