### PR TITLE
fix: speeding up by limiting registration to init_events

### DIFF
--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Research Institute of Systems Planning, Inc.
+# Copyright 2021 TIER IV, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -340,7 +340,7 @@ class Lttng(InfraBase):
         data, events, begin, end = self._parse_lttng_data(
             trace_dir_or_events,
             force_conversion,
-            modified_event_filters or [],
+            modified_event_filters,
             store_events
         )
         self.data = data
@@ -365,6 +365,10 @@ class Lttng(InfraBase):
         events = []
         begin: int
         end: int
+
+        if event_filters:
+            for f in event_filters:
+                f.reset()
 
         # TODO(hsgwa): Same implementation duplicated. Refactoring required.
         if isinstance(trace_dir_or_events, str):

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -333,7 +333,8 @@ class Lttng(InfraBase):
         modified_event_filters = []
         if event_filters:
             modified_event_filters = event_filters.copy()
-        if len(list(filter(lambda f: isinstance(f, SameAddressFilter), modified_event_filters))) == 0:
+        if len(list(filter(lambda f: isinstance(f, SameAddressFilter),
+                           modified_event_filters))) == 0:
             modified_event_filters.append(LttngEventFilter.same_address_filter(10))
 
         data, events, begin, end = self._parse_lttng_data(

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -1,4 +1,4 @@
-# Copyright 2021 TIER IV, Inc.
+# Copyright 2021 Research Institute of Systems Planning, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from .events_factory import EventsFactory
-from .lttng_event_filter import LttngEventFilter
+from .lttng_event_filter import LttngEventFilter, SameAddressFilter
 from .ros2_tracing.data_model import Ros2DataModel
 from .ros2_tracing.data_model_service import DataModelService
 from .ros2_tracing.processor import get_field, Ros2Handler
@@ -329,10 +329,17 @@ class Lttng(InfraBase):
         from .records_source import RecordsSource
         from .event_counter import EventCounter
 
+        # Add SameAddressFilter(10) by default
+        modified_event_filters = []
+        if event_filters:
+            modified_event_filters = event_filters.copy()
+        if len(list(filter(lambda f: isinstance(f, SameAddressFilter), modified_event_filters))) == 0:
+            modified_event_filters.append(LttngEventFilter.same_address_filter(10))
+
         data, events, begin, end = self._parse_lttng_data(
             trace_dir_or_events,
             force_conversion,
-            event_filters or [],
+            modified_event_filters or [],
             store_events
         )
         self.data = data
@@ -379,15 +386,20 @@ class Lttng(InfraBase):
 
             init_events = []
             run_events = []
+            filtered_event_count = 0
 
             # distribute all trace events to init_events and run_events
             init_event_names = set(Lttng._prioritized_init_events)
             for event in event_collection:
                 event_name = event[LttngEventFilter.NAME]
+                if len(event_filters) > 0 and \
+                        any(not f.accept(event, common) for f in event_filters):
+                    continue
                 if event_name in init_event_names:
                     init_events.append(event)
                 else:
                     run_events.append(event)
+                filtered_event_count += 1
 
             import functools
             init_events.sort(key=functools.cmp_to_key(Lttng._compare_init_event))
@@ -402,28 +414,16 @@ class Lttng(InfraBase):
                 handler_(event)
 
             handler.create_runtime_handler_map()
-            filtered_event_count = 0
             for event in tqdm(
                     iter(run_events),
                     total=len(run_events),
                     desc='loading',
                     mininterval=1.0):
-                if len(event_filters) > 0 and \
-                        any(not f.accept(event, common) for f in event_filters):
-                    # memo:
-                    # case1 : arch = Architecture('lttng', tracing_log_path)
-                    # since event_filters is set,
-                    # initialization-related trace events are processed,
-                    # but all runtime-related trace events are not processed.
-                    # case2 : lttng = Lttng(tracing_log_path)
-                    # event_filters are not set, so all events are processed
-                    continue
                 if store_events:
                     event_dict = {
                         k: get_field(event, k) for k in event
                     }
                     events.append(event_dict)
-                filtered_event_count += 1
                 event_name = event[LttngEventFilter.NAME]
                 handler_ = handler.handler_map[event_name]
                 handler_(event)
@@ -433,6 +433,7 @@ class Lttng(InfraBase):
                 print('filtered to {} events.'.format(filtered_event_count))
         else:
             # Note: giving events as arguments is used only for debugging.
+            common = LttngEventFilter.Common()
             filtered_event_count = 0
             events = trace_dir_or_events
 
@@ -450,15 +451,20 @@ class Lttng(InfraBase):
 
             init_events = []
             run_events = []
+            filtered_event_count = 0
 
             # distribute all trace events to init_events and run_events
             init_event_names = set(Lttng._prioritized_init_events)
             for event in events:
                 event_name = event[LttngEventFilter.NAME]
+                if len(event_filters) > 0 and \
+                        any(not f.accept(event, common) for f in event_filters):
+                    continue
                 if event_name in init_event_names:
                     init_events.append(event)
                 else:
                     run_events.append(event)
+                filtered_event_count += 1
 
             import functools
             init_events.sort(key=functools.cmp_to_key(Lttng._compare_init_event))
@@ -470,12 +476,8 @@ class Lttng(InfraBase):
 
             handler.create_runtime_handler_map()
             for event in run_events:
-                if len(event_filters) > 0 and \
-                        any(not f.accept(event, common) for f in event_filters):
-                    continue
                 if store_events:
                     events.append(event)
-                filtered_event_count += 1
                 event_name = event[LttngEventFilter.NAME]
                 handler_ = handler.handler_map[event_name]
                 handler_(event)

--- a/src/caret_analyze/infra/lttng/lttng_event_filter.py
+++ b/src/caret_analyze/infra/lttng/lttng_event_filter.py
@@ -55,6 +55,7 @@ class LttngEventFilter(metaclass=ABCMeta):
     def reset(self) -> None:
         pass
 
+
 class SameAddressFilter(LttngEventFilter):
 
     def __init__(self, max_count: int) -> None:
@@ -84,6 +85,7 @@ class SameAddressFilter(LttngEventFilter):
         super().reset()
         self._list_construct_executor.clear()
         self._list_callback_group.clear()
+
 
 class InitEventPassFilter(LttngEventFilter):
 

--- a/src/caret_analyze/infra/lttng/lttng_event_filter.py
+++ b/src/caret_analyze/infra/lttng/lttng_event_filter.py
@@ -52,6 +52,8 @@ class LttngEventFilter(metaclass=ABCMeta):
     def accept(self, event: Event, common: LttngEventFilter.Common) -> bool:
         pass
 
+    def reset(self) -> None:
+        pass
 
 class SameAddressFilter(LttngEventFilter):
 
@@ -78,6 +80,10 @@ class SameAddressFilter(LttngEventFilter):
             return True
         return True
 
+    def reset(self) -> None:
+        super().reset()
+        self._list_construct_executor.clear()
+        self._list_callback_group.clear()
 
 class InitEventPassFilter(LttngEventFilter):
 

--- a/src/caret_analyze/infra/lttng/lttng_event_filter.py
+++ b/src/caret_analyze/infra/lttng/lttng_event_filter.py
@@ -54,6 +54,7 @@ class LttngEventFilter(metaclass=ABCMeta):
 
 
 class SameAddressFilter(LttngEventFilter):
+
     def __init__(self, max_count: int) -> None:
         self._max_count = max_count
         self._list_construct_executor: dict = {}
@@ -63,13 +64,15 @@ class SameAddressFilter(LttngEventFilter):
         event_name = event[self.NAME]
         if event_name == 'ros2_caret:construct_executor':
             event_addr = event['executor_addr']
-            self._list_construct_executor[event_addr] = self._list_construct_executor.get(event_addr, 0) + 1
+            self._list_construct_executor[event_addr] = \
+                self._list_construct_executor.get(event_addr, 0) + 1
             if self._list_construct_executor[event_addr] > self._max_count:
                 return False
             return True
         if event_name == 'ros2_caret:add_callback_group':
             event_addr = event['callback_group_addr']
-            self._list_callback_group[event_addr] = self._list_callback_group.get(event_addr, 0) + 1
+            self._list_callback_group[event_addr] = \
+                self._list_callback_group.get(event_addr, 0) + 1
             if self._list_callback_group[event_addr] > self._max_count:
                 return False
             return True


### PR DESCRIPTION
## Description

speeding up by limiting registration to init_events

## Related links

https://tier4.atlassian.net/browse/RT2-1375

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
