### PR TITLE
feat: cut response times which have  first end timestamps

### DIFF
--- a/src/caret_analyze/record/records_service/response_time.py
+++ b/src/caret_analyze/record/records_service/response_time.py
@@ -271,6 +271,20 @@ class ResponseMapAll:
                     self._end_timestamps[idx] = end_ts
                     self._records[idx] = record
 
+        min_endstamp_idx = [
+            i for i, v in enumerate(self._end_timestamps) if v == min(self._end_timestamps)
+            ]
+
+        self._start_timestamps = [
+            v for i, v in enumerate(self._start_timestamps) if i not in min_endstamp_idx
+            ]
+        self._end_timestamps = [
+            v for i, v in enumerate(self._end_timestamps) if i not in min_endstamp_idx
+            ]
+        self._records = [
+            v for i, v in enumerate(self._records) if i not in min_endstamp_idx
+            ]
+
     def to_worst_with_external_latency_case_records(
         self,
         converter: ClockConverter | None = None

--- a/src/caret_analyze/record/records_service/response_time.py
+++ b/src/caret_analyze/record/records_service/response_time.py
@@ -271,18 +271,18 @@ class ResponseMapAll:
                     self._end_timestamps[idx] = end_ts
                     self._records[idx] = record
 
-        min_endstamp_idx = [
+        min_end_timestamp_idx = [
             i for i, v in enumerate(self._end_timestamps) if v == min(self._end_timestamps)
             ]
 
         self._start_timestamps = [
-            v for i, v in enumerate(self._start_timestamps) if i not in min_endstamp_idx
+            v for i, v in enumerate(self._start_timestamps) if i not in min_end_timestamp_idx
             ]
         self._end_timestamps = [
-            v for i, v in enumerate(self._end_timestamps) if i not in min_endstamp_idx
+            v for i, v in enumerate(self._end_timestamps) if i not in min_end_timestamp_idx
             ]
         self._records = [
-            v for i, v in enumerate(self._records) if i not in min_endstamp_idx
+            v for i, v in enumerate(self._records) if i not in min_end_timestamp_idx
             ]
 
     def to_worst_with_external_latency_case_records(

--- a/src/test/record/records_service/test_response_time_all.py
+++ b/src/test/record/records_service/test_response_time_all.py
@@ -1012,7 +1012,6 @@ class TestWorstInInputStackedBar:
         response_time = ResponseTime(records, columns=self.column_names)
 
         expect_raw = [
-            {'start': 0, 'middle0': 1, 'middle1': 2, 'end': 3},
             {'start': 4, 'middle0': 5, 'middle1': 7, 'end': 8},
             {'start': 6, 'middle0': 7, 'middle1': 8, 'end': 9}
         ]
@@ -1031,7 +1030,6 @@ class TestWorstInInputStackedBar:
         response_time = ResponseTime(records, columns=self.column_names)
 
         expect_raw = [
-            {'start': 0, 'middle0': 1, 'middle1': 3, 'end': 4},
             {'start': 2, 'middle0': 3, 'middle1': 5, 'end': 6},
         ]
         result = to_dict(response_time.to_worst_case_stacked_bar())
@@ -1049,7 +1047,6 @@ class TestWorstInInputStackedBar:
         response_time = ResponseTime(records, columns=self.column_names)
 
         expect_raw = [
-            {'start': 0, 'middle0': 1, 'middle1': 3, 'end': 4},
             {'start': 2, 'middle0': 3, 'middle1': 4, 'end': 6},
         ]
         result = to_dict(response_time.to_worst_case_stacked_bar())

--- a/src/test/record/records_service/test_response_time_all.py
+++ b/src/test/record/records_service/test_response_time_all.py
@@ -89,7 +89,6 @@ class TestResponseTimeAll:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 2},
             {'start': 3, 'response_time': 1},
             {'start': 11, 'response_time': 1}
         ]
@@ -97,7 +96,6 @@ class TestResponseTimeAll:
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 2},
             {'start': create_converter.round_convert(3), 'response_time': 1},
             {'start': create_converter.round_convert(11), 'response_time': 1}
         ]
@@ -116,7 +114,6 @@ class TestResponseTimeAll:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 2},
             {'start': 3, 'response_time': 3},
             {'start': 11, 'response_time': 5}
         ]
@@ -124,7 +121,6 @@ class TestResponseTimeAll:
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 2},
             {'start': create_converter.round_convert(3), 'response_time': 3},
             {'start': create_converter.round_convert(11), 'response_time': 5}
         ]
@@ -133,9 +129,10 @@ class TestResponseTimeAll:
 
     def test_single_input_multi_output_case(self, create_converter):
         records_raw = [
-            {'start': 0, 'middle': 4, 'end': 5},
-            {'start': 0, 'middle': 4, 'end': 6},
-            {'start': 0, 'middle': 12, 'end': 13}
+            {'start': 0, 'middle': 2, 'end': 4},
+            {'start': 1, 'middle': 4, 'end': 5},
+            {'start': 1, 'middle': 4, 'end': 6},
+            {'start': 1, 'middle': 12, 'end': 13}
         ]
         columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
         records = create_records(records_raw, columns)
@@ -143,21 +140,22 @@ class TestResponseTimeAll:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 5}
+            {'start': 1, 'response_time': 4}
         ]
         result = to_dict(response_time.to_all_records())
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 5}
+            {'start': create_converter.round_convert(1), 'response_time': 4}
         ]
         result = to_dict(response_time.to_all_records(converter=create_converter.get_converter()))
         assert result == expect_raw
 
     def test_multi_input_single_output_case(self, create_converter):
         records_raw = [
-            {'start': 0, 'middle': 4, 'end': 13},
+            {'start': 0, 'middle': 3, 'end': 12},
             {'start': 1, 'middle': 4, 'end': 13},
+            {'start': 2, 'middle': 4, 'end': 13},
             {'start': 5, 'middle': 12, 'end': 13}
         ]
         columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
@@ -166,16 +164,16 @@ class TestResponseTimeAll:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 13},
             {'start': 1, 'response_time': 12},
+            {'start': 2, 'response_time': 11},
             {'start': 5, 'response_time': 8}
         ]
         result = to_dict(response_time.to_all_records())
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 13},
             {'start': create_converter.round_convert(1), 'response_time': 12},
+            {'start': create_converter.round_convert(2), 'response_time': 11},
             {'start': create_converter.round_convert(5), 'response_time': 8}
         ]
         result = to_dict(response_time.to_all_records(converter=create_converter.get_converter()))
@@ -183,8 +181,9 @@ class TestResponseTimeAll:
 
     def test_drop_case(self, create_converter):
         records_raw = [
-            {'start': 0, 'middle': 4, 'end': 13},
-            {'start': 1, 'middle': 4},
+            {'start': 0, 'middle': 3, 'end': 12},
+            {'start': 1, 'middle': 4, 'end': 13},
+            {'start': 2, 'middle': 4},
             {'start': 5, 'middle': 12, 'end': 13}
         ]
         columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
@@ -193,16 +192,16 @@ class TestResponseTimeAll:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 13},
             {'start': 1, 'response_time': 12},
+            {'start': 2, 'response_time': 11},
             {'start': 5, 'response_time': 8}
         ]
         result = to_dict(response_time.to_all_records())
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 13},
             {'start': create_converter.round_convert(1), 'response_time': 12},
+            {'start': create_converter.round_convert(2), 'response_time': 11},
             {'start': create_converter.round_convert(5), 'response_time': 8}
         ]
         result = to_dict(response_time.to_all_records(converter=create_converter.get_converter()))
@@ -223,7 +222,6 @@ class TestResponseTimeAll:
         response_time = response.to_all_records()
         expect = [
             {'start': 0, 'response_time': 10},
-            {'start': 3, 'response_time': 1},
             {'start': 4, 'response_time': 6},
             {'start': 6, 'response_time': 0}
         ]
@@ -232,7 +230,6 @@ class TestResponseTimeAll:
         response_time = response.to_all_records(converter=create_converter.get_converter())
         expect = [
             {'start': create_converter.round_convert(0), 'response_time': 10},
-            {'start': create_converter.round_convert(3), 'response_time': 1},
             {'start': create_converter.round_convert(4), 'response_time': 6},
             {'start': create_converter.round_convert(6), 'response_time': 0}
         ]
@@ -261,7 +258,6 @@ class TestResponseTimeAll:
             assert str(w[0].message) == warning_message
 
             expect_raw = [
-                {'start': 0, 'response_time': 2},
                 {'start': 3, 'response_time': 1},
                 {'start': 11, 'response_time': 1}
             ]
@@ -269,7 +265,6 @@ class TestResponseTimeAll:
             assert result == expect_raw
 
             expect_raw = [
-                {'start': create_converter.round_convert(0), 'response_time': 2},
                 {'start': create_converter.round_convert(3), 'response_time': 1},
                 {'start': create_converter.round_convert(11), 'response_time': 1}
             ]
@@ -311,7 +306,6 @@ class TestResponseTimeBest:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 2},
             {'start': 3, 'response_time': 1},
             {'start': 11, 'response_time': 1}
         ]
@@ -319,7 +313,6 @@ class TestResponseTimeBest:
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 2},
             {'start': create_converter.round_convert(3), 'response_time': 1},
             {'start': create_converter.round_convert(11), 'response_time': 1}
         ]
@@ -339,7 +332,6 @@ class TestResponseTimeBest:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 2},
             {'start': 3, 'response_time': 3},
             {'start': 11, 'response_time': 5}
         ]
@@ -347,7 +339,6 @@ class TestResponseTimeBest:
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 2},
             {'start': create_converter.round_convert(3), 'response_time': 3},
             {'start': create_converter.round_convert(11), 'response_time': 5}
         ]
@@ -357,9 +348,10 @@ class TestResponseTimeBest:
 
     def test_single_input_multi_output_case(self, create_converter):
         records_raw = [
-            {'start': 0, 'middle': 4, 'end': 5},
-            {'start': 0, 'middle': 4, 'end': 6},
-            {'start': 0, 'middle': 12, 'end': 13}
+            {'start': 0, 'middle': 2, 'end': 4},
+            {'start': 1, 'middle': 4, 'end': 5},
+            {'start': 1, 'middle': 4, 'end': 6},
+            {'start': 1, 'middle': 12, 'end': 13}
         ]
         columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
         records = create_records(records_raw, columns)
@@ -367,13 +359,13 @@ class TestResponseTimeBest:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 5}
+            {'start': 1, 'response_time': 4}
         ]
         result = to_dict(response_time.to_best_case_records())
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 5}
+            {'start': create_converter.round_convert(1), 'response_time': 4}
         ]
         result = to_dict(response_time.to_best_case_records(
             converter=create_converter.get_converter()))
@@ -381,8 +373,9 @@ class TestResponseTimeBest:
 
     def test_multi_input_single_output_case(self, create_converter):
         records_raw = [
-            {'start': 0, 'middle': 4, 'end': 13},
+            {'start': 0, 'middle': 3, 'end': 12},
             {'start': 1, 'middle': 4, 'end': 13},
+            {'start': 2, 'middle': 4, 'end': 13},
             {'start': 5, 'middle': 12, 'end': 13}
         ]
         columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
@@ -417,7 +410,6 @@ class TestResponseTimeBest:
 
         response_time = response.to_best_case_records()
         expect = [
-            {'start': 3, 'response_time': 1},
             {'start': 4, 'response_time': 6},
             {'start': 6, 'response_time': 0}
         ]
@@ -425,7 +417,6 @@ class TestResponseTimeBest:
 
         response_time = response.to_best_case_records(converter=create_converter.get_converter())
         expect = [
-            {'start': create_converter.round_convert(3), 'response_time': 1},
             {'start': create_converter.round_convert(4), 'response_time': 6},
             {'start': create_converter.round_convert(6), 'response_time': 0}
         ]
@@ -454,7 +445,6 @@ class TestResponseTimeBest:
             assert str(w[0].message) == warning_message
 
             expect_raw = [
-                {'start': 0, 'response_time': 2},
                 {'start': 3, 'response_time': 1},
                 {'start': 11, 'response_time': 1},
             ]
@@ -462,7 +452,6 @@ class TestResponseTimeBest:
             assert result == expect_raw
 
             expect_raw = [
-                {'start': create_converter.round_convert(0), 'response_time': 2},
                 {'start': create_converter.round_convert(3), 'response_time': 1},
                 {'start': create_converter.round_convert(11), 'response_time': 1},
             ]
@@ -504,14 +493,12 @@ class TestResponseTimeWorstWithExternalLatency:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 4},
             {'start': 3, 'response_time': 9}
         ]
         result = to_dict(response_time.to_worst_with_external_latency_case_records())
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 4},
             {'start': create_converter.round_convert(3), 'response_time': 9}
         ]
         result = to_dict(response_time.to_worst_with_external_latency_case_records(
@@ -530,14 +517,12 @@ class TestResponseTimeWorstWithExternalLatency:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 6},
             {'start': 3, 'response_time': 13}
         ]
         result = to_dict(response_time.to_worst_with_external_latency_case_records())
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 6},
             {'start': create_converter.round_convert(3), 'response_time': 13}
         ]
         result = to_dict(response_time.to_worst_with_external_latency_case_records(
@@ -546,8 +531,9 @@ class TestResponseTimeWorstWithExternalLatency:
 
     def test_single_input_multi_output_case(self, create_converter):
         records_raw = [
-            {'start': 0, 'middle': 4, 'end': 5},
-            {'start': 0, 'middle': 4, 'end': 6},
+            {'start': 0, 'middle': 2, 'end': 3},
+            {'start': 1, 'middle': 4, 'end': 5},
+            {'start': 1, 'middle': 4, 'end': 6},
             {'start': 3, 'middle': 10, 'end': 11},
             {'start': 3, 'middle': 12, 'end': 13}
         ]
@@ -557,13 +543,13 @@ class TestResponseTimeWorstWithExternalLatency:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 11},
+            {'start': 1, 'response_time': 10},
         ]
         result = to_dict(response_time.to_worst_with_external_latency_case_records())
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 11},
+            {'start': create_converter.round_convert(1), 'response_time': 10},
         ]
         result = to_dict(response_time.to_worst_with_external_latency_case_records(
             converter=create_converter.get_converter()))
@@ -571,8 +557,9 @@ class TestResponseTimeWorstWithExternalLatency:
 
     def test_multi_input_single_output_case(self, create_converter):
         records_raw = [
-            {'start': 0, 'middle': 4, 'end': 13},
+            {'start': 0, 'middle': 3, 'end': 12},
             {'start': 1, 'middle': 4, 'end': 13},
+            {'start': 2, 'middle': 4, 'end': 13},
             {'start': 5, 'middle': 12, 'end': 13}
         ]
         columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
@@ -581,13 +568,13 @@ class TestResponseTimeWorstWithExternalLatency:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 13}
+            {'start': 1, 'response_time': 12}
         ]
         result = to_dict(response_time.to_worst_with_external_latency_case_records())
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 13}
+            {'start': create_converter.round_convert(1), 'response_time': 12}
         ]
         result = to_dict(response_time.to_worst_with_external_latency_case_records(
             converter=create_converter.get_converter()))
@@ -595,8 +582,9 @@ class TestResponseTimeWorstWithExternalLatency:
 
     def test_drop_case(self, create_converter):
         records_raw = [
-            {'start': 0, 'middle': 4, 'end': 8},
-            {'start': 1, 'middle': 4},
+            {'start': 0, 'middle': 3, 'end': 12},
+            {'start': 1, 'middle': 4, 'end': 13},
+            {'start': 2, 'middle': 4},
             {'start': 5, 'middle': 12, 'end': 13}
         ]
         columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
@@ -605,13 +593,13 @@ class TestResponseTimeWorstWithExternalLatency:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 13}
+            {'start': 1, 'response_time': 12}
         ]
         result = to_dict(response_time.to_worst_with_external_latency_case_records())
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 13}
+            {'start': create_converter.round_convert(1), 'response_time': 12}
         ]
         result = to_dict(response_time.to_worst_with_external_latency_case_records(
             converter=create_converter.get_converter()))
@@ -631,8 +619,7 @@ class TestResponseTimeWorstWithExternalLatency:
 
         response_time = response.to_worst_with_external_latency_case_records()
         expect = [
-            {'start': 0, 'response_time': 4},
-            {'start': 3, 'response_time': 7},
+            {'start': 0, 'response_time': 10},
             {'start': 4, 'response_time': 2}
         ]
         assert to_dict(response_time) == expect
@@ -640,8 +627,7 @@ class TestResponseTimeWorstWithExternalLatency:
         response_time = response.to_worst_with_external_latency_case_records(
             converter=create_converter.get_converter())
         expect = [
-            {'start': create_converter.round_convert(0), 'response_time': 4},
-            {'start': create_converter.round_convert(3), 'response_time': 7},
+            {'start': create_converter.round_convert(0), 'response_time': 10},
             {'start': create_converter.round_convert(4), 'response_time': 2}
         ]
         assert to_dict(response_time) == expect
@@ -669,14 +655,12 @@ class TestResponseTimeWorstWithExternalLatency:
             assert str(w[0].message) == warning_message
 
             expect_raw = [
-                {'start': 0, 'response_time': 4},
                 {'start': 3, 'response_time': 9}
             ]
             result = to_dict(response_time.to_worst_with_external_latency_case_records())
             assert result == expect_raw
 
             expect_raw = [
-                {'start': create_converter.round_convert(0), 'response_time': 4},
                 {'start': create_converter.round_convert(3), 'response_time': 9}
             ]
             result = to_dict(response_time.to_worst_with_external_latency_case_records(
@@ -714,7 +698,6 @@ class TestResponseTimeWorst:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 2},
             {'start': 3, 'response_time': 1},
             {'start': 11, 'response_time': 1}
         ]
@@ -722,7 +705,6 @@ class TestResponseTimeWorst:
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 2},
             {'start': create_converter.round_convert(3), 'response_time': 1},
             {'start': create_converter.round_convert(11), 'response_time': 1}
         ]
@@ -742,7 +724,6 @@ class TestResponseTimeWorst:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 2},
             {'start': 3, 'response_time': 3},
             {'start': 11, 'response_time': 5}
         ]
@@ -750,7 +731,6 @@ class TestResponseTimeWorst:
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 2},
             {'start': create_converter.round_convert(3), 'response_time': 3},
             {'start': create_converter.round_convert(11), 'response_time': 5}
         ]
@@ -760,9 +740,10 @@ class TestResponseTimeWorst:
 
     def test_single_input_multi_output_case(self, create_converter):
         records_raw = [
-            {'start': 0, 'middle': 4, 'end': 5},
-            {'start': 0, 'middle': 4, 'end': 6},
-            {'start': 0, 'middle': 12, 'end': 13}
+            {'start': 0, 'middle': 2, 'end': 4},
+            {'start': 1, 'middle': 4, 'end': 5},
+            {'start': 1, 'middle': 4, 'end': 6},
+            {'start': 1, 'middle': 12, 'end': 13}
         ]
         columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
         records = create_records(records_raw, columns)
@@ -770,13 +751,13 @@ class TestResponseTimeWorst:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 5}
+            {'start': 1, 'response_time': 4}
         ]
         result = to_dict(response_time.to_worst_case_records())
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 5}
+            {'start': create_converter.round_convert(1), 'response_time': 4}
         ]
         result = to_dict(response_time.to_worst_case_records(
             converter=create_converter.get_converter()))
@@ -784,8 +765,9 @@ class TestResponseTimeWorst:
 
     def test_multi_input_single_output_case(self, create_converter):
         records_raw = [
-            {'start': 0, 'middle': 4, 'end': 13},
+            {'start': 0, 'middle': 3, 'end': 12},
             {'start': 1, 'middle': 4, 'end': 13},
+            {'start': 2, 'middle': 4, 'end': 13},
             {'start': 5, 'middle': 12, 'end': 13}
         ]
         columns = [ColumnValue('start'), ColumnValue('middle'), ColumnValue('end')]
@@ -794,13 +776,13 @@ class TestResponseTimeWorst:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 13}
+            {'start': 1, 'response_time': 12}
         ]
         result = to_dict(response_time.to_worst_case_records())
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 13}
+            {'start': create_converter.round_convert(1), 'response_time': 12}
         ]
         result = to_dict(response_time.to_worst_case_records(
             converter=create_converter.get_converter()))
@@ -818,14 +800,12 @@ class TestResponseTimeWorst:
         response_time = ResponseTime(records)
 
         expect_raw = [
-            {'start': 0, 'response_time': 8},
             {'start': 1, 'response_time': 12}
         ]
         result = to_dict(response_time.to_worst_case_records())
         assert result == expect_raw
 
         expect_raw = [
-            {'start': create_converter.round_convert(0), 'response_time': 8},
             {'start': create_converter.round_convert(1), 'response_time': 12}
         ]
         result = to_dict(response_time.to_worst_case_records(
@@ -847,7 +827,6 @@ class TestResponseTimeWorst:
         response_time = response.to_worst_case_records()
         expect = [
             {'start': 0, 'response_time': 10},
-            {'start': 3, 'response_time': 1},
             {'start': 6, 'response_time': 0}
         ]
         assert to_dict(response_time) == expect
@@ -855,7 +834,6 @@ class TestResponseTimeWorst:
         response_time = response.to_worst_case_records(converter=create_converter.get_converter())
         expect = [
             {'start': create_converter.round_convert(0), 'response_time': 10},
-            {'start': create_converter.round_convert(3), 'response_time': 1},
             {'start': create_converter.round_convert(6), 'response_time': 0}
         ]
         assert to_dict(response_time) == expect
@@ -883,7 +861,6 @@ class TestResponseTimeWorst:
             assert str(w[0].message) == warning_message
 
             expect_raw = [
-                {'start': 0, 'response_time': 2},
                 {'start': 3, 'response_time': 1},
                 {'start': 11, 'response_time': 1},
             ]
@@ -891,7 +868,6 @@ class TestResponseTimeWorst:
             assert result == expect_raw
 
             expect_raw = [
-                {'start': create_converter.round_convert(0), 'response_time': 2},
                 {'start': create_converter.round_convert(3), 'response_time': 1},
                 {'start': create_converter.round_convert(11), 'response_time': 1},
             ]
@@ -932,7 +908,6 @@ class TestAllStackedBar:
         response_time = ResponseTime(records, columns=self.column_names)
 
         expect_raw = [
-            {'start': 0, 'middle0': 1, 'middle1': 2, 'end': 3},
             {'start': 4, 'middle0': 5, 'middle1': 7, 'end': 8},
             {'start': 6, 'middle0': 7, 'middle1': 8, 'end': 9}
         ]
@@ -951,8 +926,6 @@ class TestAllStackedBar:
         response_time = ResponseTime(records, columns=self.column_names)
 
         expect_raw = [
-            {'start': 0, 'middle0': 1, 'middle1': 3, 'end': 4},
-            {'start': 1, 'middle0': 2, 'middle1': 3, 'end': 4},
             {'start': 2, 'middle0': 3, 'middle1': 5, 'end': 6},
             {'start': 3, 'middle0': 4, 'middle1': 5, 'end': 6}
         ]
@@ -971,8 +944,6 @@ class TestAllStackedBar:
         response_time = ResponseTime(records, columns=self.column_names)
 
         expect_raw = [
-            {'start': 0, 'middle0': 1, 'middle1': 3, 'end': 4},
-            {'start': 1, 'middle0': 2, 'middle1': 3, 'end': 4},
             {'start': 2, 'middle0': 3, 'middle1': 4, 'end': 6},
             {'start': 3, 'middle0': 4, 'middle1': 5, 'end': 6}
         ]


### PR DESCRIPTION
## Description
ignore data flow until first data of output column arrived in Response Time.

<!-- Write a brief description of this PR. -->

## Related links
Jira: https://tier4.atlassian.net/browse/RT2-1430

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
