### PR TITLE
refactor: `type check decorator`

### DIFF
--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -38,8 +38,8 @@ try:
 
         Parameters
         ----------
-        signature: Signature
-            Signature of target function.
+        annotations: dict[str, Any]
+            Dict of annotations of target function.
         args: tuple[Any, ...]
             Arguments of target function.
         kwargs: dict[str, Any]
@@ -58,7 +58,7 @@ try:
 
         Returns
         -------
-        str
+        Any
             The argument which validation error occurs.
 
         """
@@ -87,17 +87,17 @@ try:
 
         Parameters
         ----------
-        e: ValidationError
-            ValidationError instance has one or more ErrorDict instances.
-            Example of ErrorDict structure is as follows.
-            (i) Build-in type case:
-                {'type': 'type_error.<EXPECT_TYPE>', ...}
+        given_arg_loc: tuple
+            (i) Not iterable type case
+                ('<ARGUMENT_NAME>,')
 
-            (ii) Custom class type case:
-                {'type': 'type_error.arbitrary_type',
-                'ctx': {'expected_arbitrary_type': '<EXPECT_TYPE>'}, ...}
-        signature: Signature
-            Signature of target function.
+            (ii) Iterable type except for dict case
+                ('<ARGUMENT_NAME>', '<INDEX>')
+
+            (ii) Dict case
+                ('<ARGUMENT_NAME>', '<KEY>')
+        annotations: dict[str, Any]
+            Dict of annotations of target function.
 
         Returns
         -------
@@ -184,17 +184,6 @@ try:
 
             (ii) Dict case
                 ('<ARGUMENT_NAME>', '<KEY>')
-        error_type: str
-            (i) Dict case
-                'DictArg'
-
-            (ii) Iterable type except for dict case
-                'IterableArg'
-
-            (iii) Not iterable type case
-                other
-        varargs: None | str
-            The name of the variable length argument if the function has one, otherwise None.
 
         Returns
         -------

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from collections.abc import Collection, Sequence
 from functools import wraps
-from inspect import getfullargspec, get_annotations
+from inspect import get_annotations, getfullargspec
 from logging import getLogger
 from re import findall
 from typing import Any

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -66,10 +66,9 @@ try:
         given_arg: Any = None
 
         # Check kwargs
-        for k, v in kwargs.items():
-            if k == arg_name:
-                given_arg = v
-                break
+        if arg_name in kwargs:
+            given_arg = kwargs.get(arg_name)
+
         if given_arg is None:
             # Check args
             given_arg_idx = list(annotations.keys()).index(arg_name)

--- a/src/caret_analyze/common/type_check_decorator.py
+++ b/src/caret_analyze/common/type_check_decorator.py
@@ -31,7 +31,7 @@ try:
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
         given_arg_loc: tuple,
-        varargs: None | str
+        varargs_name: None | str
     ) -> Any:
         """
         Get an argument which validation error occurs.
@@ -53,7 +53,7 @@ try:
 
             (ii) Dict case
                 ('<ARGUMENT_NAME>', '<KEY>')
-        varargs: None | str
+        varargs_name: None | str
             The name of the variable length argument if the function has one, otherwise None.
 
         Returns
@@ -74,7 +74,7 @@ try:
             given_arg_idx = list(annotations.keys()).index(arg_name)
 
             # for variable length arguments
-            if arg_name == varargs:
+            if arg_name == varargs_name:
                 given_arg = args[given_arg_idx:]
             else:
                 given_arg = args[given_arg_idx]
@@ -252,16 +252,18 @@ try:
             try:
                 # Checks whether the arguments of a given func have variable length arguments
                 arg_spec = getfullargspec(func)
+                varargs_name = arg_spec.varargs
                 arg_len = len(arg_spec.args)
-                if arg_spec.varargs is not None:
+
+                if varargs_name is not None:
                     args = args[:arg_len] + _parse_collection_or_unpack(args[arg_len:])
                 return validate_arguments_wrapper(*args, **kwargs)
+
             except ValidationError as e:
                 loc_tuple = e.errors()[0]['loc']
                 annotations = get_annotations(func)
 
-                given_arg = _get_given_arg(annotations, args, kwargs,
-                                           loc_tuple, arg_spec.varargs)
+                given_arg = _get_given_arg(annotations, args, kwargs, loc_tuple, varargs_name)
                 expected_types = _get_expected_types(loc_tuple, annotations)
                 given_arg_loc_str = _get_given_arg_loc_str(loc_tuple, given_arg)
                 given_arg_type = _get_given_arg_type(given_arg, loc_tuple)


### PR DESCRIPTION
## Description
code maintenance of `type_check_decorator` is conducted.

The changes are as follows:
- The annotation information can be getted by `get_annotations()` without get all `signature`. #[4283e74](https://github.com/tier4/caret_analyze/pull/489/commits/4283e74c1e98881b0e21fdd9060a9c49ec5d70bf)
- Simplify code by using `dict.get()` to get dict elements. #[4bded45](https://github.com/tier4/caret_analyze/pull/489/commits/4bded45b0e4d2d9924ea778513e357d39751d855)
- Variable-length arguments do not fall under `e.title==IterableArg`, so determine whether the argument is iterable without using `e.title`. #[0af9f5d](https://github.com/tier4/caret_analyze/pull/489/commits/0af9f5d391b1e8ed2ae9552316226b3317039fc6)

<!-- Write a brief description of this PR. -->
![image](https://github.com/tier4/caret_analyze/assets/48247817/30dbff0f-996f-468e-a73e-a062bf02a384)


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
