### PR TITLE
refactor: abstractproperty is deprecated

### DIFF
--- a/src/caret_analyze/common/summary.py
+++ b/src/caret_analyze/common/summary.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from abc import ABCMeta, abstractproperty
+from abc import ABCMeta, abstractmethod
 from collections import UserDict
 from typing import Any
 
@@ -80,7 +80,8 @@ class Summary(UserDict):
 class Summarizable(metaclass=ABCMeta):
     """Abstract base class that have summary property."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def summary(self) -> Summary:
         """
         Get summary.

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 from collections.abc import Iterable, Iterator, Sequence, Sized
 from datetime import datetime
 from functools import cached_property
@@ -145,7 +145,8 @@ class IterableEvents(Iterable, Sized, metaclass=ABCMeta):
     def __len__(self) -> int:
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def events(self) -> list[dict]:
         pass
 


### PR DESCRIPTION
## Description

`abstractproperty` is deprecated.
Changed to `property` and `abstractmethod`.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
