### PR TITLE
fix: changed arguments for get_timer

### DIFF
--- a/src/caret_analyze/value_objects/node.py
+++ b/src/caret_analyze/value_objects/node.py
@@ -535,7 +535,7 @@ class NodeStructValue(ValueObject, Summarizable):
 
     def get_timer(
         self,
-        timer_period: str,
+        timer_period: int,
         construction_order: int | None
     ) -> TimerStructValue:
         """
@@ -543,7 +543,7 @@ class NodeStructValue(ValueObject, Summarizable):
 
         Parameters
         ----------
-        timer_period: str
+        timer_period: int
             Timer period to get.
         construction_order : int | None
             Construction order to get.
@@ -561,11 +561,11 @@ class NodeStructValue(ValueObject, Summarizable):
         """
         try:
             def is_target_timer(timer: TimerStructValue):
-                timer_node_name_match = timer.node_name == timer_period
+                timer_period_match = timer.period_ns == timer_period
                 construction_order_match = True
                 if construction_order is not None:
                     construction_order_match = timer.construction_order == construction_order
-                return timer_node_name_match and construction_order_match
+                return timer_period_match and construction_order_match
 
             return Util.find_one(is_target_timer, self._timers)
         except ItemNotFoundError:

--- a/src/test/value_objects/test_node_struct_value.py
+++ b/src/test/value_objects/test_node_struct_value.py
@@ -36,7 +36,7 @@ class TestNodeStructValue:
         mocker.patch.object(service_info_mock, 'construction_order', 1)
 
         timer_info_mock = mocker.Mock(spec=TimerStructValue)
-        mocker.patch.object(timer_info_mock, 'node_name', 'node_name')
+        mocker.patch.object(timer_info_mock, 'period_ns', 1001)
         mocker.patch.object(timer_info_mock, 'construction_order', 1)
 
         node_pub_mock1 = mocker.Mock(spec=NodePathStructValue)
@@ -85,9 +85,9 @@ class TestNodeStructValue:
         with pytest.raises(ItemNotFoundError):
             node_info.get_service('service_name', 0)
 
-        node = node_info.get_timer('node_name', None)
+        node = node_info.get_timer(1001, None)
         assert node == timer_info_mock
-        node = node_info.get_timer('node_name', 1)
+        node = node_info.get_timer(1001, 1)
         assert node == timer_info_mock
         with pytest.raises(ItemNotFoundError):
-            node_info.get_timer('node_name', 0)
+            node_info.get_timer(1001, 0)


### PR DESCRIPTION
## Description

Changed arguments for get_timer

## Related links

https://tier4.atlassian.net/browse/RT2-1506

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
