### PR TITLE
fix: subscription callback not linked to executor is deleted

### DIFF
--- a/src/caret_analyze/infra/lttng/lttng_info.py
+++ b/src/caret_analyze/infra/lttng/lttng_info.py
@@ -452,7 +452,7 @@ class LttngInfo:
         sub_cbs.drop_column('node_handle')
         sub_cbs.reset_index()
         callback_groups = self._formatted.callback_groups.clone()
-        merge(sub_cbs, callback_groups, 'callback_group_addr',how='inner')
+        merge(sub_cbs, callback_groups, 'callback_group_addr', how='inner')
 
         sub.merge(sub_cbs, ['subscription_handle'], how='left')
 

--- a/src/caret_analyze/infra/lttng/lttng_info.py
+++ b/src/caret_analyze/infra/lttng/lttng_info.py
@@ -451,6 +451,8 @@ class LttngInfo:
         sub_cbs.drop_column('depth')
         sub_cbs.drop_column('node_handle')
         sub_cbs.reset_index()
+        callback_groups = self._formatted.callback_groups.clone()
+        merge(sub_cbs, callback_groups, 'callback_group_addr',how='inner')
 
         sub.merge(sub_cbs, ['subscription_handle'], how='left')
 


### PR DESCRIPTION
## Description


Callbacks not linked to an executor were preventing analysis. Therefore, subscription callbacks not linked to an executor have been set to not display.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
