### PR TITLE
feat: merge using the source timestamp

### DIFF
--- a/src/caret_analyze/infra/lttng/event_counter.py
+++ b/src/caret_analyze/infra/lttng/event_counter.py
@@ -241,6 +241,9 @@ class EventCounter:
             sub_handle_to_node_name[handler] = \
                 node_handle_to_node_name.get(row['node_handle'], '-')
             sub_handle_to_topic_name[handler] = row['topic_name']
+            rmw_handle_to_node_name[row['rmw_handle']] = \
+                node_handle_to_node_name[row['node_handle']]
+            rmw_handle_to_topic_name[row['rmw_handle']] = row['topic_name']
 
         for handler, row in data.timer_node_links.df.iterrows():
             timer_handle_to_node_name[handler] = \
@@ -258,11 +261,6 @@ class EventCounter:
             elif handler in timer_handle_to_node_name:
                 timer_cb_to_node_name[row['callback_object']] = \
                     timer_handle_to_node_name.get(handler, '-')
-
-        for handler, row in data.subscriptions.df.iterrows():
-            rmw_handle_to_node_name[row['rmw_handle']] = \
-                node_handle_to_node_name[row['node_handle']]
-            rmw_handle_to_topic_name[row['rmw_handle']] = row['topic_name']
 
         tilde_pub_to_topic_name: dict[int, str] = {}
         tilde_pub_to_node_name: dict[int, str] = {}

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -90,7 +90,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
             - [topic_name]/rcl_publish_timestamp (Optional)
             - [topic_name]/dds_publish_timestamp (Optional)
             - [topic_name]/source_timestamp (for inter-proc)
-            - [callback_name]/callback_start_timestamps
+            - [callback_name]/callback_start_timestamp
 
         """
         assert comm_val.subscribe_callback_name is not None

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -236,7 +236,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         # get rmw_records, which relates to callback_object
         rmw_records: RecordsInterface
         if rmw_handle is not None:
-            rmw_records = self._source._grouped_rmw_records[rmw_handle]
+            rmw_records = self._source._grouped_rmw_records[rmw_handle].clone()
         else:
             rmw_records = RecordsFactory.create_instance(
                 None,
@@ -254,6 +254,9 @@ class RecordsProviderLttng(RuntimeDataProvider):
         drop_columns = list(set(columns) - {'source_timestamp', 'rmw_take_timestamp'})
         rmw_records.drop_columns(drop_columns)
 
+        # reindex
+        rmw_records.reindex(['source_timestamp', 'rmw_take_timestamp'])
+
         # add prefix to columns; e.g. [topic_name]/source_timestamp
         if callback is not None:
             self._rename_column(
@@ -262,6 +265,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
                 subscription.topic_name,
                 None
             )
+
         return rmw_records
 
     def _subscribe_records(

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -227,8 +227,6 @@ class RecordsProviderLttng(RuntimeDataProvider):
         if callback is not None:
             callback_objects = self._helper.get_subscription_callback_objects(callback)
 
-        # callback_objects[0]: inter, callback_objects[1]: intra
-        # subscription -> take implementation must be use inter-process communication
         data_model_srv = DataModelService(self._lttng.data)
 
         rmw_handle = data_model_srv._get_rmw_handle_from_callback_object(callback_objects[0])

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -222,10 +222,6 @@ class RecordsProviderLttng(RuntimeDataProvider):
             - [topic_name]/source_timestamp
             - [topic_name]/rmw_take
 
-        Raises
-        ------
-        InvalidArgumentError
-
         """
         callback = subscription.callback
         if callback is not None:

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -238,15 +238,14 @@ class RecordsProviderLttng(RuntimeDataProvider):
         if rmw_handle is not None:
             rmw_records = self._source._grouped_rmw_records[rmw_handle]
         else:
-             rmw_records = \
-                RecordsFactory.create_instance(
-                    None,
-                    columns = [
-                        ColumnValue(COLUMN_NAME.TID),
-                        ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
-                        ColumnValue(COLUMN_NAME.RMW_SUBSCRIPTION_HANDLE),
-                        ColumnValue(COLUMN_NAME.MESSAGE),
-                        ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP)
+            rmw_records = RecordsFactory.create_instance(
+                None,
+                columns=[
+                    ColumnValue(COLUMN_NAME.TID),
+                    ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
+                    ColumnValue(COLUMN_NAME.RMW_SUBSCRIPTION_HANDLE),
+                    ColumnValue(COLUMN_NAME.MESSAGE),
+                    ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP)
                     ]
                 )
 

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -234,10 +234,11 @@ class RecordsProviderLttng(RuntimeDataProvider):
             rmw_handle = None
 
         # get rmw_records, which relates to callback_object
+        rmw_records: RecordsInterface
         if rmw_handle is not None:
             rmw_records = self._source._grouped_rmw_records[rmw_handle]
         else:
-            rmw_records: RecordsInterface = \
+             rmw_records = \
                 RecordsFactory.create_instance(
                     None,
                     columns = [

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -833,6 +833,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
             Columns
 
             - [topic_name]/rclcpp_publish_timestamp
+            - [topic_name]/source_timestamp
             - [callback_name]/callback_start_timestamp
 
         """

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1315,8 +1315,6 @@ class NodeRecordsUseLatestMessage:
         is_take_node = len(sub_records) == 0
         if is_take_node:
             sub_records = self._provider.subscription_take_records(self._node_path.subscription)
-            # TODO: Currently, pub_records and sub_records are being joined by source_timestamp.
-            # If possible, use rmw_take as the key.
         pub_records = self._provider.publish_records(self._node_path.publisher)
 
         columns = [

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -68,6 +68,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         self._lttng = lttng
         self._source = FilteredRecordsSource(lttng)
         self._helper = RecordsProviderLttngHelper(lttng)
+        self._srv = DataModelService(lttng.data)
 
     def communication_records(
         self,
@@ -227,9 +228,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         if callback is not None:
             callback_objects = self._helper.get_subscription_callback_objects(callback)
 
-        data_model_srv = DataModelService(self._lttng.data)
-
-        rmw_handle = data_model_srv._get_rmw_handle_from_callback_object(callback_objects[0])
+        rmw_handle = self._srv._get_rmw_handle_from_callback_object(callback_objects[0])
 
         # get rmw_records, which relates to callback_object
         rmw_records = self._source._grouped_rmw_records[rmw_handle]

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -206,8 +206,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         Provide subscription records.
 
         This method is implemented for a node with a specific subscription usage.
-        When subscribe a message,
-        use this function when you get the message
+        Use this function when you get the message
         using 'subscription->take' at any arbitrary timing
         instead of using 'subscription_callback'.
 

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -21,6 +21,7 @@ from logging import getLogger
 from .bridge import LttngBridge
 from .column_names import COLUMN_NAME
 from .lttng import Lttng
+from .ros2_tracing.data_model_service import DataModelService
 from .value_objects import (PublisherValueLttng,
                             SubscriptionCallbackValueLttng,
                             TimerCallbackValueLttng)
@@ -229,6 +230,9 @@ class RecordsProviderLttng(RuntimeDataProvider):
         sub = self._lttng.data.map_callback_to_sub[callback_objects[0]]
         sub_handle = self._lttng.data.map_sub_to_sub_handle[sub]
         rmw_handle = self._lttng.data.map_sub_handle_to_rmw_handle[sub_handle]
+        data_model_srv = DataModelService(self._lttng.data)
+
+        rmw_handle = data_model_srv._get_rmw_handle_from_callback_object(callback_objects[0])
 
         # get rmw_records, which relates to callback_object
         rmw_records = self._source._grouped_rmw_records[rmw_handle]

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -203,6 +203,11 @@ class RecordsProviderLttng(RuntimeDataProvider):
     ) -> RecordsInterface:
         """
         Provide subscription records.
+        This method is implemented for a node with a specific subscription usage.
+        When subscribe a message,
+        use this function when you get the message
+        using 'subscription->take' at any arbitrary timing
+        instead of using 'subscription_callback'.
 
         Parameters
         ----------

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1328,7 +1328,6 @@ class NodeRecordsUseLatestMessage:
         )
 
         drop_columns = list(set(pub_sub_records.columns) - set(columns))
-        drop_columns += [s for s in pub_sub_records.columns if s.endswith('callback_start')]
         pub_sub_records.drop_columns(drop_columns)
         pub_sub_records.reindex(columns)
         return pub_sub_records

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1325,16 +1325,16 @@ class NodeRecordsUseLatestMessage:
                 columns += [ColumnValue(column)]
 
             records_data = []
-            tmp_timestamp = 0
+            latest_timestamp = 0
 
             for record in records.data:
                 source_timestamp = record.data[source_column]
                 if source_timestamp == 0:
                     record_dict = record.data
-                    record_dict[source_column] = tmp_timestamp
+                    record_dict[source_column] = latest_timestamp
                     records_data.append(record_dict)
                 else:
-                    tmp_timestamp = source_timestamp
+                    latest_timestamp = source_timestamp
                     records_data.append(record.data)
 
             new_records = RecordsFactory.create_instance(

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -221,7 +221,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
             Columns
 
             - [topic_name]/source_timestamp
-            - [topic_name]/rmw_take_timestamp
+            - rmw_take_timestamp
 
         """
         callback = subscription.callback

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -204,6 +204,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
     ) -> RecordsInterface:
         """
         Provide subscription records.
+
         This method is implemented for a node with a specific subscription usage.
         When subscribe a message,
         use this function when you get the message

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -843,7 +843,6 @@ class RecordsProviderLttng(RuntimeDataProvider):
             Columns
 
             - [topic_name]/rclcpp_publish_timestamp
-            - [topic_name]/source_timestamp
             - [callback_name]/callback_start_timestamp
 
         """

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -227,9 +227,6 @@ class RecordsProviderLttng(RuntimeDataProvider):
 
         # callback_objects[0]: inter, callback_objects[1]: intra
         # subscription -> take implementation must be use inter-process communication
-        sub = self._lttng.data.map_callback_to_sub[callback_objects[0]]
-        sub_handle = self._lttng.data.map_sub_to_sub_handle[sub]
-        rmw_handle = self._lttng.data.map_sub_handle_to_rmw_handle[sub_handle]
         data_model_srv = DataModelService(self._lttng.data)
 
         rmw_handle = data_model_srv._get_rmw_handle_from_callback_object(callback_objects[0])

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1314,15 +1314,15 @@ class NodeRecordsUseLatestMessage:
             *sub_records.columns,
             f'{self._node_path.publish_topic_name}/rclcpp_publish_timestamp',
         ]
-        left_key_index = 0
+        left_key = sub_records.columns[0]
         if 'rmw_take_timestamp' in columns:
             columns.remove('rmw_take_timestamp')
-            left_key_index = -1
+            left_key = 'rmw_take_timestamp'
 
         pub_sub_records = merge_sequential(
             left_records=sub_records,
             right_records=pub_records,
-            left_stamp_key=sub_records.columns[left_key_index],
+            left_stamp_key=left_key,
             right_stamp_key=pub_records.columns[0],
             join_left_key=None,
             join_right_key=None,

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -89,7 +89,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
             - [topic_name]/rclcpp_publish_timestamp
             - [topic_name]/rcl_publish_timestamp (Optional)
             - [topic_name]/dds_publish_timestamp (Optional)
-            - [topic_name]/source_timestamp (for inter-proc)
+            - [topic_name]/source_timestamp (only inter process)
             - [callback_name]/callback_start_timestamp
 
         """

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -874,6 +874,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
             - [topic_name]/rclcpp_publish_timestamp
             - [topic_name]/rcl_publish_timestamp (Optional)
             - [topic_name]/dds_write_timestamp (Optional)
+            - [topic_name]/source_timestamp
             - [callback_name_name]/callback_start_timestamp
 
         """

--- a/src/caret_analyze/infra/lttng/records_source.py
+++ b/src/caret_analyze/infra/lttng/records_source.py
@@ -404,6 +404,20 @@ class RecordsSource():
 
     @cached_property
     def rmw_take_records(self) -> RecordsInterface:
+        """
+        Compose rmw_take records.
+
+        Returns
+        -------
+        RecordsInterface
+            columns:
+            - tid
+            - rmw_take_timestamp
+            - rmw_subscription_handle
+            - message
+            - source_timestamp
+
+        """
         rmw_take_records = self._data.rmw_take_instances.clone()
         return rmw_take_records
 

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model.py
@@ -32,7 +32,6 @@ class Ros2DataModel():
         # Objects (one-time events, usually when something is created)
         self.map_callback_to_sub: dict[int, int] = {}
         self.map_sub_to_sub_handle: dict[int, int] = {}
-        self.map_sub_handle_to_rmw_handle: dict[int, int] = {}
 
         self._contexts = TracePointIntermediateData(
             ['context_handle', 'timestamp', 'pid'])
@@ -309,7 +308,7 @@ class Ros2DataModel():
             'depth': depth,
         }
         self._subscriptions.append(record)
-        self.map_sub_handle_to_rmw_handle[handle] = rmw_handle
+        # self.map_sub_handle_to_rmw_handle[handle] = rmw_handle
 
     def add_rclcpp_subscription(
         self, subscription_pointer, timestamp, subscription_handle

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model.py
@@ -209,10 +209,10 @@ class Ros2DataModel():
             None,
             columns=[
                 ColumnValue('tid'),
+                ColumnValue('source_timestamp'),
                 ColumnValue('rmw_take_timestamp'),
                 ColumnValue('rmw_subscription_handle'),
-                ColumnValue('message'),
-                ColumnValue('source_timestamp')
+                ColumnValue('message')
             ]
         )
         self.dispatch_intra_process_subscription_callback_instances = \

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model.py
@@ -209,10 +209,10 @@ class Ros2DataModel():
             None,
             columns=[
                 ColumnValue('tid'),
-                ColumnValue('source_timestamp'),
                 ColumnValue('rmw_take_timestamp'),
                 ColumnValue('rmw_subscription_handle'),
-                ColumnValue('message')
+                ColumnValue('message'),
+                ColumnValue('source_timestamp')
             ]
         )
         self.dispatch_intra_process_subscription_callback_instances = \

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model.py
@@ -30,8 +30,6 @@ class Ros2DataModel():
     def __init__(self) -> None:
         """Create a Ros2DataModel."""
         # Objects (one-time events, usually when something is created)
-        self.map_callback_to_sub: dict[int, int] = {}
-        self.map_sub_to_sub_handle: dict[int, int] = {}
 
         self._contexts = TracePointIntermediateData(
             ['context_handle', 'timestamp', 'pid'])
@@ -308,7 +306,6 @@ class Ros2DataModel():
             'depth': depth,
         }
         self._subscriptions.append(record)
-        # self.map_sub_handle_to_rmw_handle[handle] = rmw_handle
 
     def add_rclcpp_subscription(
         self, subscription_pointer, timestamp, subscription_handle
@@ -319,7 +316,6 @@ class Ros2DataModel():
             'subscription_handle': subscription_handle,
         }
         self._subscription_objects.append(record)
-        self.map_sub_to_sub_handle[subscription_pointer] = subscription_handle
 
     def add_service(self, handle, timestamp, node_handle, rmw_handle, service_name) -> None:
         record = {

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model.py
@@ -30,7 +30,6 @@ class Ros2DataModel():
     def __init__(self) -> None:
         """Create a Ros2DataModel."""
         # Objects (one-time events, usually when something is created)
-
         self._contexts = TracePointIntermediateData(
             ['context_handle', 'timestamp', 'pid'])
         self._nodes = TracePointIntermediateData(

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -194,10 +194,7 @@ class DataModelService:
                 sub_handle = self._get_sub_handle_from_sub(sub)
             if sub_handle is not None:
                 rmw_handle = self._get_rmw_handle_from_sub_handle(sub_handle)
-            if rmw_handle is not None:
                 return rmw_handle
-            else:
-                return None
         except KeyError:
             return None
 
@@ -211,8 +208,11 @@ class DataModelService:
             sub = target_df[target_df['callback_object'] == cb_addr]['reference'].values
             if len(sub) == 1:
                 return sub[0]
+            elif len(sub) == 0:
+                msg = f'There is no subscription id that corresponds to callback_addr:{cb_addr}.'
+                raise InvalidArgumentError(msg)
             else:
-                msg = f'Duplicated subscription id. {sub}. Use first subscription only.'
+                msg = f'Duplicated subscription id: [{sub}] that corresponds to callback_addr:{cb_addr}'
                 raise InvalidArgumentError(msg)
         except KeyError:
             return None
@@ -232,8 +232,11 @@ class DataModelService:
                 ].values
             if len(sub_handle) == 1:
                 return sub_handle[0]
+            elif len(sub_handle) == 0:
+                msg = f'There is no subscription_handle that corresponds to subscription id: {subscription}.'
+                raise InvalidArgumentError(msg)
             else:
-                msg = f'Duplicated subscription_handle. {sub_handle}. Use first subscription_handle only.'
+                msg = f'Duplicated subscription_handle: [{sub_handle}] that corresponds to subscription id: {subscription}.'
                 raise InvalidArgumentError(msg)
         except KeyError:
             return None
@@ -250,8 +253,11 @@ class DataModelService:
                 ]['rmw_handle'].values
             if len(rmw_handle) == 1:
                 return rmw_handle[0]
+            elif len(rmw_handle) == 0:
+                msg = f'There is no rmw_handle that corresponds to subscription_handle: {subscription_handle}.'
+                raise InvalidArgumentError(msg)
             else:
-                msg = f'Duplicated rmw_handle. {rmw_handle}. Use first rmw_handle only.'
+                msg = f'Duplicated rmw_handle: [{rmw_handle}] that corresponds to subscription_handle: {subscription_handle}.'
                 raise InvalidArgumentError('len(rmw_handle) != 1')
         except KeyError:
             return None

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -209,10 +209,10 @@ class DataModelService:
             if len(sub) == 1:
                 return sub[0]
             elif len(sub) == 0:
-                msg = f'There is no subscription id that corresponds to callback_addr: {cb_addr}.'
+                msg = f'There is no subscription  that corresponds to callback_addr: {cb_addr}.'
                 raise InvalidArgumentError(msg)
             else:
-                msg = f'Duplicated subscription id: [{sub}] \
+                msg = f'Duplicated subscription : [{sub}] \
                     that corresponds to callback_addr: {cb_addr}'
                 raise InvalidArgumentError(msg)
         except KeyError:
@@ -235,11 +235,11 @@ class DataModelService:
                 return sub_handle[0]
             elif len(sub_handle) == 0:
                 msg = f'There is no subscription_handle that \
-                    corresponds to subscription id: {subscription}.'
+                    corresponds to subscription : {subscription}.'
                 raise InvalidArgumentError(msg)
             else:
                 msg = f'Duplicated subscription_handle: [{sub_handle}] that \
-                    corresponds to subscription id: {subscription}.'
+                    corresponds to subscription : {subscription}.'
                 raise InvalidArgumentError(msg)
         except KeyError:
             return None

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -183,17 +183,6 @@ class DataModelService:
         except KeyError:
             return [None]
 
-    def _get_rmw_handle_from_callback_object(
-        self,
-        cb_addr: int
-    ) -> list[str | None]:
-        try:
-            target_df = self._ensure_dataframe(
-                self._data.subscriptions.df.loc[cb_addr, :])
-            return target_df['rmw_handle'].values()[0]
-        except KeyError:
-            return [None]
-
     @staticmethod
     def _ensure_dataframe(
         dataframe_or_series: pd.DataFrame | pd.Series

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -188,9 +188,43 @@ class DataModelService:
         cb_addr: int
     ) -> list[str | None]:
         try:
+            sub = self._get_sub_from_callback_object(cb_addr)
+            sub_handle = self._get_sub_handle_from_sub(sub)
+            rmw_handle = self._get_rmw_handle_from_sub_handle(sub_handle)
+            return rmw_handle
+        except KeyError:
+            return [None]
+
+    def _get_sub_from_callback_object(
+        self,
+        cb_addr: int
+    ) -> str | None:
+        try:
             target_df = self._ensure_dataframe(
-                self._data.subscriptions.df.loc[cb_addr, :])
-            return target_df['rmw_handle'].values()[0]
+                self._data.callback_objects.df.reset_index()[['reference', 'callback_object']])
+            return target_df[target_df['callback_object']==cb_addr]['reference'].values[0]
+        except KeyError:
+            return [None]
+
+    def _get_sub_handle_from_sub(
+        self,
+        subscription: int
+    ) -> str | None:
+        try:
+            target_df = self._ensure_dataframe(
+                self._data.subscription_objects.df.reset_index()[['subscription', 'subscription_handle']])
+            return target_df[target_df['subscription']==subscription]['subscription_handle'].values[0]
+        except KeyError:
+            return [None]
+
+    def _get_rmw_handle_from_sub_handle(
+        self,
+        subscription_handle: int
+    ) -> str | None:
+        try:
+            target_df = self._ensure_dataframe(
+                self._data.subscriptions.df.reset_index()[['subscription_handle', 'rmw_handle']])
+            return target_df[target_df['subscription_handle']==subscription_handle]['rmw_handle'].values[0]
         except KeyError:
             return [None]
 

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -194,7 +194,7 @@ class DataModelService:
                 sub_handle = self._get_sub_handle_from_sub(sub)
             if sub_handle is not None:
                 rmw_handle = self._get_rmw_handle_from_sub_handle(sub_handle)
-                return rmw_handle
+            return rmw_handle
         except KeyError:
             return None
 

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -209,10 +209,11 @@ class DataModelService:
             if len(sub) == 1:
                 return sub[0]
             elif len(sub) == 0:
-                msg = f'There is no subscription id that corresponds to callback_addr:{cb_addr}.'
+                msg = f'There is no subscription id that corresponds to callback_addr: {cb_addr}.'
                 raise InvalidArgumentError(msg)
             else:
-                msg = f'Duplicated subscription id: [{sub}] that corresponds to callback_addr:{cb_addr}'
+                msg = f'Duplicated subscription id: [{sub}] \
+                    that corresponds to callback_addr: {cb_addr}'
                 raise InvalidArgumentError(msg)
         except KeyError:
             return None
@@ -233,10 +234,12 @@ class DataModelService:
             if len(sub_handle) == 1:
                 return sub_handle[0]
             elif len(sub_handle) == 0:
-                msg = f'There is no subscription_handle that corresponds to subscription id: {subscription}.'
+                msg = f'There is no subscription_handle that \
+                    corresponds to subscription id: {subscription}.'
                 raise InvalidArgumentError(msg)
             else:
-                msg = f'Duplicated subscription_handle: [{sub_handle}] that corresponds to subscription id: {subscription}.'
+                msg = f'Duplicated subscription_handle: [{sub_handle}] that \
+                    corresponds to subscription id: {subscription}.'
                 raise InvalidArgumentError(msg)
         except KeyError:
             return None
@@ -254,10 +257,12 @@ class DataModelService:
             if len(rmw_handle) == 1:
                 return rmw_handle[0]
             elif len(rmw_handle) == 0:
-                msg = f'There is no rmw_handle that corresponds to subscription_handle: {subscription_handle}.'
+                msg = f'There is no rmw_handle that \
+                    corresponds to subscription_handle: {subscription_handle}.'
                 raise InvalidArgumentError(msg)
             else:
-                msg = f'Duplicated rmw_handle: [{rmw_handle}] that corresponds to subscription_handle: {subscription_handle}.'
+                msg = f'Duplicated rmw_handle: [{rmw_handle}] that \
+                    corresponds to subscription_handle: {subscription_handle}.'
                 raise InvalidArgumentError('len(rmw_handle) != 1')
         except KeyError:
             return None

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -202,7 +202,7 @@ class DataModelService:
         try:
             target_df = self._ensure_dataframe(
                 self._data.callback_objects.df.reset_index()[['reference', 'callback_object']])
-            return target_df[target_df['callback_object']==cb_addr]['reference'].values[0]
+            return target_df[target_df['callback_object'] == cb_addr]['reference'].values[0]
         except KeyError:
             return [None]
 
@@ -212,8 +212,13 @@ class DataModelService:
     ) -> str | None:
         try:
             target_df = self._ensure_dataframe(
-                self._data.subscription_objects.df.reset_index()[['subscription', 'subscription_handle']])
-            return target_df[target_df['subscription']==subscription]['subscription_handle'].values[0]
+                self._data.subscription_objects.df.reset_index()[
+                        ['subscription', 'subscription_handle']
+                    ]
+                )
+            return target_df[target_df['subscription'] == subscription][
+                    'subscription_handle'
+                ].values[0]
         except KeyError:
             return [None]
 
@@ -224,7 +229,9 @@ class DataModelService:
         try:
             target_df = self._ensure_dataframe(
                 self._data.subscriptions.df.reset_index()[['subscription_handle', 'rmw_handle']])
-            return target_df[target_df['subscription_handle']==subscription_handle]['rmw_handle'].values[0]
+            return target_df[
+                    target_df['subscription_handle'] == subscription_handle
+                ]['rmw_handle'].values[0]
         except KeyError:
             return [None]
 

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -22,6 +22,7 @@ from logging import getLogger, Logger
 import pandas as pd
 
 from .data_model import Ros2DataModel
+from ....exceptions import InvalidArgumentError
 
 
 logger = getLogger(__name__)
@@ -202,7 +203,11 @@ class DataModelService:
         try:
             target_df = self._ensure_dataframe(
                 self._data.callback_objects.df.reset_index()[['reference', 'callback_object']])
-            return target_df[target_df['callback_object'] == cb_addr]['reference'].values[0]
+            sub = target_df[target_df['callback_object'] == cb_addr]['reference'].values
+            if len(sub) == 1:
+                return sub[0]
+            else:
+                raise InvalidArgumentError('len(sub) != 1')
         except KeyError:
             return [None]
 
@@ -216,9 +221,13 @@ class DataModelService:
                         ['subscription', 'subscription_handle']
                     ]
                 )
-            return target_df[target_df['subscription'] == subscription][
+            sub_handle = target_df[target_df['subscription'] == subscription][
                     'subscription_handle'
-                ].values[0]
+                ].values
+            if len(sub_handle) == 1:
+                return sub_handle[0]
+            else:
+                raise InvalidArgumentError('len(sub_handle) != 1')
         except KeyError:
             return [None]
 
@@ -229,9 +238,13 @@ class DataModelService:
         try:
             target_df = self._ensure_dataframe(
                 self._data.subscriptions.df.reset_index()[['subscription_handle', 'rmw_handle']])
-            return target_df[
-                    target_df['subscription_handle'] == subscription_handle
-                ]['rmw_handle'].values[0]
+            rmw_handle = target_df[
+                target_df['subscription_handle'] == subscription_handle
+                ]['rmw_handle'].values
+            if len(rmw_handle) == 1:
+                return rmw_handle[0]
+            else:
+                raise InvalidArgumentError('len(rmw_handle) != 1')
         except KeyError:
             return [None]
 

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -183,6 +183,17 @@ class DataModelService:
         except KeyError:
             return [None]
 
+    def _get_rmw_handle_from_callback_object(
+        self,
+        cb_addr: int
+    ) -> list[str | None]:
+        try:
+            target_df = self._ensure_dataframe(
+                self._data.subscriptions.df.loc[cb_addr, :])
+            return target_df['rmw_handle'].values()[0]
+        except KeyError:
+            return [None]
+
     @staticmethod
     def _ensure_dataframe(
         dataframe_or_series: pd.DataFrame | pd.Series

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -187,19 +187,24 @@ class DataModelService:
     def _get_rmw_handle_from_callback_object(
         self,
         cb_addr: int
-    ) -> list[str | None]:
+    ) -> int | None:
         try:
             sub = self._get_sub_from_callback_object(cb_addr)
-            sub_handle = self._get_sub_handle_from_sub(sub)
-            rmw_handle = self._get_rmw_handle_from_sub_handle(sub_handle)
-            return rmw_handle
+            if sub is not None:
+                sub_handle = self._get_sub_handle_from_sub(sub)
+            if sub_handle is not None:
+                rmw_handle = self._get_rmw_handle_from_sub_handle(sub_handle)
+            if rmw_handle is not None:
+                return rmw_handle
+            else:
+                return None
         except KeyError:
-            return [None]
+            return None
 
     def _get_sub_from_callback_object(
         self,
         cb_addr: int
-    ) -> str | None:
+    ) -> int | None:
         try:
             target_df = self._ensure_dataframe(
                 self._data.callback_objects.df.reset_index()[['reference', 'callback_object']])
@@ -209,12 +214,12 @@ class DataModelService:
             else:
                 raise InvalidArgumentError('len(sub) != 1')
         except KeyError:
-            return [None]
+            return None
 
     def _get_sub_handle_from_sub(
         self,
         subscription: int
-    ) -> str | None:
+    ) -> int | None:
         try:
             target_df = self._ensure_dataframe(
                 self._data.subscription_objects.df.reset_index()[
@@ -229,12 +234,12 @@ class DataModelService:
             else:
                 raise InvalidArgumentError('len(sub_handle) != 1')
         except KeyError:
-            return [None]
+            return None
 
     def _get_rmw_handle_from_sub_handle(
         self,
         subscription_handle: int
-    ) -> str | None:
+    ) -> int | None:
         try:
             target_df = self._ensure_dataframe(
                 self._data.subscriptions.df.reset_index()[['subscription_handle', 'rmw_handle']])
@@ -246,7 +251,7 @@ class DataModelService:
             else:
                 raise InvalidArgumentError('len(rmw_handle) != 1')
         except KeyError:
-            return [None]
+            return None
 
     @staticmethod
     def _ensure_dataframe(

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -212,7 +212,8 @@ class DataModelService:
             if len(sub) == 1:
                 return sub[0]
             else:
-                raise InvalidArgumentError('len(sub) != 1')
+                msg = f'Duplicated subscription id. {sub}. Use first subscription only.'
+                raise InvalidArgumentError(msg)
         except KeyError:
             return None
 
@@ -232,7 +233,8 @@ class DataModelService:
             if len(sub_handle) == 1:
                 return sub_handle[0]
             else:
-                raise InvalidArgumentError('len(sub_handle) != 1')
+                msg = f'Duplicated subscription_handle. {sub_handle}. Use first subscription_handle only.'
+                raise InvalidArgumentError(msg)
         except KeyError:
             return None
 
@@ -249,6 +251,7 @@ class DataModelService:
             if len(rmw_handle) == 1:
                 return rmw_handle[0]
             else:
+                msg = f'Duplicated rmw_handle. {rmw_handle}. Use first rmw_handle only.'
                 raise InvalidArgumentError('len(rmw_handle) != 1')
         except KeyError:
             return None

--- a/src/caret_analyze/infra/lttng/ros2_tracing/processor.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/processor.py
@@ -500,7 +500,7 @@ class Ros2Handler():
             self._remapper.callback_remapper.register_and_get_object_id(callback_object, event)
         self.data.add_callback_object(
             subscription_pointer, timestamp, callback_object)
-        self.data.map_callback_to_sub[callback_object] = subscription_pointer
+        # self.data.map_callback_to_sub[callback_object] = subscription_pointer
 
     def _handle_rcl_service_init(
         self,

--- a/src/caret_analyze/infra/lttng/ros2_tracing/processor.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/processor.py
@@ -500,7 +500,6 @@ class Ros2Handler():
             self._remapper.callback_remapper.register_and_get_object_id(callback_object, event)
         self.data.add_callback_object(
             subscription_pointer, timestamp, callback_object)
-        # self.data.map_callback_to_sub[callback_object] = subscription_pointer
 
     def _handle_rcl_service_init(
         self,

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -157,12 +157,10 @@ class RecordsMerged:
                 right_records)
             right_records.rename_columns(rename_rule)
 
+            if 'source_timestamp' in right_records.columns[0]:
+                left_records.drop_columns([left_records.columns[-1]])
             if left_records.columns[-1] != right_records.columns[0]:
-                # If right_records[0] is source_timestamp
-                if left_records.columns[-2] == right_records.columns[0]:
-                    left_records.drop_columns([left_records.columns[-1]])
-                else:
-                    raise InvalidRecordsError('left columns[-1] != right columns[0]')
+                raise InvalidRecordsError('left columns[-1] != right columns[0]')
 
             left_stamp_key = left_records.columns[-1]
             right_stamp_key = right_records.columns[0]

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -223,7 +223,7 @@ class RecordsMerged:
                 )
             else:
                 msg = 'last_callback is None. Use last_callback = False'
-                msg += 'last Node is implemented using method of Explicitly take message by User'
+                msg += 'last Node is implemented using method of explicitly take message by User'
                 logger.warn(msg)
 
         logger.info('Finished merging path records.')

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -223,7 +223,7 @@ class RecordsMerged:
                 )
             else:
                 msg = 'last_callback is None. Use last_callback = False'
-                msg += 'last Node is implemented using method of explicitly take message by User'
+                msg += 'last Node is implemented using method of explicitly take message by user'
                 logger.warn(msg)
 
         logger.info('Finished merging path records.')

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -223,6 +223,7 @@ class RecordsMerged:
                 )
             else:
                 msg = 'last_callback is None. Use last_callback = False'
+                msg += 'last Node is implemented using subscription -> take'
                 logger.warn(msg)
 
         logger.info('Finished merging path records.')

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -222,7 +222,7 @@ class RecordsMerged:
                     how='left'
                 )
             else:
-                msg = 'last_callback is None. Use last_callback = False'
+                msg = 'last_callback is None. Use last_callback = False\n'
                 msg += 'last Node is implemented using method of explicitly take message by user'
                 logger.warn(msg)
 

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -223,7 +223,7 @@ class RecordsMerged:
                 )
             else:
                 msg = 'last_callback is None. Use last_callback = False'
-                msg += 'last Node is implemented using subscription -> take'
+                msg += 'last Node is implemented using method of Explicitly take message by User'
                 logger.warn(msg)
 
         logger.info('Finished merging path records.')

--- a/src/test/infra/lttng/test_lttng.py
+++ b/src/test/infra/lttng/test_lttng.py
@@ -265,6 +265,30 @@ class TestLttng:
                             records_mock)
         assert lttng.compose_callback_records() == records_mock
 
+    def test_compose_rmw_take_records(self, mocker):
+        data_mock = mocker.Mock(spec=Ros2DataModel)
+        mocker.patch.object(Lttng, '_parse_lttng_data',
+                            return_value=(data_mock, {}, 0, 1))
+
+        lttng_info_mock = mocker.Mock(spec=LttngInfo)
+        mocker.patch('caret_analyze.infra.lttng.lttng.LttngInfo',
+                     return_value=lttng_info_mock)
+
+        records_source_mock = mocker.Mock(spec=RecordsSource)
+        mocker.patch('caret_analyze.infra.lttng.lttng.RecordsSource',
+                     return_value=records_source_mock)
+        counter_mock = mocker.Mock(spec=EventCounter)
+        mocker.patch('caret_analyze.infra.lttng.lttng.EventCounter',
+                     return_value=counter_mock)
+
+        lttng = Lttng('trace_dir')
+
+        records_mock = mocker.Mock(spec=RecordsInterface)
+        mocker.patch.object(records_mock, 'clone', return_value=records_mock)
+        mocker.patch.object(records_source_mock, 'rmw_take_records',
+                            records_mock)
+        assert lttng.compose_rmw_take_records() == records_mock
+
     def test_singleton_disabled(self, mocker):
         data = Ros2DataModel()
         data.finalize()

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -610,19 +610,19 @@ class TestNodeRecordsUseLatestMessage:
         take_records_data: list[RecordInterface]
         take_records_data = [
             RecordCppImpl({
-                COLUMN_NAME.RMW_TAKE_TIMESTAMP: 2,
                 f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 1,
+                COLUMN_NAME.RMW_TAKE_TIMESTAMP: 2,
             }),
             RecordCppImpl({
-                COLUMN_NAME.RMW_TAKE_TIMESTAMP: 6,
-                f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 7,
+                f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 6,
+                COLUMN_NAME.RMW_TAKE_TIMESTAMP: 7,
             }),
         ]
         take_records = RecordsCppImpl(
             take_records_data,
             [
-                ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
                 ColumnValue(f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
+                ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
             ]
         )
 
@@ -669,7 +669,7 @@ class TestNodeRecordsUseLatestMessage:
                 f'{topic_name_2}/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 2,
             }),
             RecordCppImpl({
-                f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 7,
+                f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 6,
                 f'{topic_name_2}/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 8,
             }),
         ]
@@ -714,19 +714,19 @@ class TestNodeRecordsUseLatestMessage:
         take_records_data: list[RecordInterface]
         take_records_data = [
             RecordCppImpl({
-                COLUMN_NAME.RMW_TAKE_TIMESTAMP: 2,
                 f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 1,
+                COLUMN_NAME.RMW_TAKE_TIMESTAMP: 2,
             }),
             RecordCppImpl({
-                COLUMN_NAME.RMW_TAKE_TIMESTAMP: 7,
                 f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 0,
+                COLUMN_NAME.RMW_TAKE_TIMESTAMP: 7,
             }),
         ]
         take_records = RecordsCppImpl(
             take_records_data,
             [
-                ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
                 ColumnValue(f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
+                ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
             ]
         )
 
@@ -786,6 +786,7 @@ class TestNodeRecordsUseLatestMessage:
         )
 
         assert records.equals(expect_records)
+
 
 class TestNodeRecordsCallbackChain:
 

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -165,7 +165,7 @@ class TestRecordsProviderLttng:
             ]
         )
 
-        records.equals(expected)
+        assert records.equals(expected)
 
     def test_node_records_callback_chain(self, mocker):
         lttng_mock = mocker.Mock(spec=Lttng)

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -582,7 +582,7 @@ class TestNodeRecordsUseLatestMessage:
                 f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'
                 )
             })
-        records.equals(expect_records)
+        assert records.equals(expect_records)
 
     # When node is implemented with subscription->take
     def test_data_has_not_callback_start(self, mocker):

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -98,9 +98,9 @@ class TestRecordsProviderLttng:
 
         lttng_mock = mocker.Mock(spec=Lttng)
 
-        ros2datamodel_mock = mocker.Mock(spec=Ros2DataModel)
+        data_model_mock = mocker.Mock(spec=Ros2DataModel)
 
-        lttng_mock.data = ros2datamodel_mock
+        lttng_mock.data = data_model_mock
 
         helper_mock = mocker.Mock(spec=RecordsProviderLttngHelper)
         mocker.patch('caret_analyze.infra.lttng.records_provider_lttng.RecordsProviderLttngHelper',

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -129,10 +129,10 @@ class TestRecordsProviderLttng:
                 RecordCppImpl(
                     {
                         COLUMN_NAME.TID: 2,
-                        COLUMN_NAME.RMW_TAKE_TIMESTAMP: 3,
+                        COLUMN_NAME.RMW_TAKE_TIMESTAMP: 6,
                         COLUMN_NAME.RMW_SUBSCRIPTION_HANDLE: 4,
                         COLUMN_NAME.MESSAGE: 5,
-                        COLUMN_NAME.SOURCE_TIMESTAMP: 6,
+                        COLUMN_NAME.SOURCE_TIMESTAMP: 3,
                     },
                 )
             ],
@@ -144,8 +144,7 @@ class TestRecordsProviderLttng:
                 ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
             ]
         )
-        mocker.patch.object(source_mock, '_grouped_rmw_records',
-                            return_value={4: records_mock})
+        mocker.patch.object(source_mock, '_grouped_rmw_records', {4: records_mock})
 
         subscription_mock = mocker.Mock(spec=SubscriptionStructValue)
         provider = RecordsProviderLttng(lttng_mock)
@@ -155,14 +154,14 @@ class TestRecordsProviderLttng:
             [
                 RecordCppImpl(
                     {
-                        COLUMN_NAME.RMW_TAKE_TIMESTAMP: 3,
-                        COLUMN_NAME.SOURCE_TIMESTAMP: 6,
+                        COLUMN_NAME.SOURCE_TIMESTAMP: 3,
+                        COLUMN_NAME.RMW_TAKE_TIMESTAMP: 6,
                     },
                 )
             ],
             [
+                ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
                 ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
-                ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP)
             ]
         )
 

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -124,7 +124,7 @@ class TestRecordsProviderLttng:
         mocker.patch('caret_analyze.infra.lttng.records_provider_lttng.FilteredRecordsSource',
                      return_value=source_mock)
 
-        records_mock = RecordsCppImpl(
+        rmw_records = RecordsCppImpl(
             [
                 RecordCppImpl(
                     {
@@ -144,7 +144,7 @@ class TestRecordsProviderLttng:
                 ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
             ]
         )
-        mocker.patch.object(source_mock, '_grouped_rmw_records', {4: records_mock})
+        mocker.patch.object(source_mock, '_grouped_rmw_records', {4: rmw_records})
 
         subscription_mock = mocker.Mock(spec=SubscriptionStructValue)
         provider = RecordsProviderLttng(lttng_mock)

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -107,12 +107,14 @@ class TestRecordsProviderLttng:
                      return_value=helper_mock)
 
         callback_objects = (1, None)
-        mocker.patch.object(helper_mock, 'get_subscription_callback_objects', return_value=callback_objects)
+        mocker.patch.object(helper_mock, 'get_subscription_callback_objects',
+                            return_value=callback_objects)
 
         data_model_srv_mock = mocker.Mock(spec=DataModelService)
-        mocker.patch('caret_analyze.infra.lttng.records_provider_lttng.DataModelService', \
-            return_value=data_model_srv_mock)
-        mocker.patch.object(data_model_srv_mock, '_get_rmw_handle_from_callback_object', return_value=0)
+        mocker.patch('caret_analyze.infra.lttng.records_provider_lttng.DataModelService',
+                     return_value=data_model_srv_mock)
+        mocker.patch.object(data_model_srv_mock,
+                            '_get_rmw_handle_from_callback_object', return_value=0)
 
         source_mock = mocker.Mock(spec=FilteredRecordsSource)
         mocker.patch('caret_analyze.infra.lttng.records_provider_lttng.FilteredRecordsSource',
@@ -122,20 +124,20 @@ class TestRecordsProviderLttng:
             [
                 RecordCppImpl(
                     {
-                    COLUMN_NAME.TID: 2,
-                    COLUMN_NAME.RMW_TAKE_TIMESTAMP: 3,
-                    COLUMN_NAME.RMW_SUBSCRIPTION_HANDLE: 4,
-                    COLUMN_NAME.MESSAGE: 5,
-                    COLUMN_NAME.SOURCE_TIMESTAMP: 6,
+                        COLUMN_NAME.TID: 2,
+                        COLUMN_NAME.RMW_TAKE_TIMESTAMP: 3,
+                        COLUMN_NAME.RMW_SUBSCRIPTION_HANDLE: 4,
+                        COLUMN_NAME.MESSAGE: 5,
+                        COLUMN_NAME.SOURCE_TIMESTAMP: 6,
                     },
                 )
             ],
             [
-            ColumnValue(COLUMN_NAME.TID),
-            ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
-            ColumnValue(COLUMN_NAME.RMW_SUBSCRIPTION_HANDLE),
-            ColumnValue(COLUMN_NAME.MESSAGE),
-            ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
+                ColumnValue(COLUMN_NAME.TID),
+                ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
+                ColumnValue(COLUMN_NAME.RMW_SUBSCRIPTION_HANDLE),
+                ColumnValue(COLUMN_NAME.MESSAGE),
+                ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
             ]
         )
         source_mock._grouped_rmw_records = [records_mock, ]
@@ -148,7 +150,7 @@ class TestRecordsProviderLttng:
             [
                 RecordCppImpl(
                     {
-                    COLUMN_NAME.SOURCE_TIMESTAMP: 6,
+                        COLUMN_NAME.SOURCE_TIMESTAMP: 6,
                     },
                 )
             ],
@@ -458,7 +460,9 @@ class TestRecordsProviderLttngHelper:
         pub_handles = helper.get_publisher_handles(pub_info_mock)
         assert pub_handles == [pub_handle]
 
+
 class TestNodeRecordsUseLatestMessage:
+
     def test_data_normal_flow(self, mocker):
         provider_mock = mocker.Mock(spec=RecordsProviderLttng)
         node_path_mock = mocker.Mock(spec=NodePathStructValue)
@@ -510,16 +514,18 @@ class TestNodeRecordsUseLatestMessage:
         pub_records = RecordsCppImpl(
             pub_records_data,
             [
-            ColumnValue(COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP),
-            ColumnValue(COLUMN_NAME.RCL_PUBLISH_TIMESTAMP),
-            ColumnValue(COLUMN_NAME.DDS_WRITE_TIMESTAMP),
-            ColumnValue(COLUMN_NAME.MESSAGE_TIMESTAMP),
-            ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
+                ColumnValue(COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP),
+                ColumnValue(COLUMN_NAME.RCL_PUBLISH_TIMESTAMP),
+                ColumnValue(COLUMN_NAME.DDS_WRITE_TIMESTAMP),
+                ColumnValue(COLUMN_NAME.MESSAGE_TIMESTAMP),
+                ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
             ]
         )
         pub_records.rename_columns({
-            COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: \
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'})
+            COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: (
+                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'
+                )
+            })
 
         mocker.patch.object(provider_mock, 'publish_records', return_value=pub_records)
         mocker.patch.object(node_path_mock, 'publish_topic_name', '')
@@ -548,8 +554,10 @@ class TestNodeRecordsUseLatestMessage:
             ]
         )
         expect_records.rename_columns({
-            COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: \
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'})
+            COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: (
+                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'
+                )
+            })
         records.equals(expect_records)
 
     # When node is implemented with subscription->take
@@ -592,7 +600,7 @@ class TestNodeRecordsUseLatestMessage:
             ]
         )
 
-        mocker.patch.object(provider_mock,'subscription_take_records', return_value=take_records)
+        mocker.patch.object(provider_mock, 'subscription_take_records', return_value=take_records)
 
         records_data: list[RecordInterface]
         pub_records_data = [
@@ -615,16 +623,18 @@ class TestNodeRecordsUseLatestMessage:
         pub_records = RecordsCppImpl(
             pub_records_data,
             [
-            ColumnValue(COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP),
-            ColumnValue(COLUMN_NAME.RCL_PUBLISH_TIMESTAMP),
-            ColumnValue(COLUMN_NAME.DDS_WRITE_TIMESTAMP),
-            ColumnValue(COLUMN_NAME.MESSAGE_TIMESTAMP),
-            ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
+                ColumnValue(COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP),
+                ColumnValue(COLUMN_NAME.RCL_PUBLISH_TIMESTAMP),
+                ColumnValue(COLUMN_NAME.DDS_WRITE_TIMESTAMP),
+                ColumnValue(COLUMN_NAME.MESSAGE_TIMESTAMP),
+                ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
             ]
         )
         pub_records.rename_columns({
-            COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: \
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'})
+            COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: (
+                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'
+                )
+            })
 
         mocker.patch.object(provider_mock, 'publish_records', return_value=pub_records)
         mocker.patch.object(node_path_mock, 'publish_topic_name', '')
@@ -650,9 +660,12 @@ class TestNodeRecordsUseLatestMessage:
             ]
         )
         expect_records.rename_columns({
-            COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: \
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'})
+            COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: (
+                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'
+            )
+        })
         records.equals(expect_records)
+
 
 class TestNodeRecordsCallbackChain:
 

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -87,8 +87,6 @@ class TestRecordsProviderLttng:
     # When node is implemented with subscription->take.
     def test_subscription_take_records(self, mocker):
 
-        records_mock = mocker.Mock(spec=RecordsInterface)
-
         def _rename_column(records, callback_name, topic_name, node_name):
             return records
         mocker.patch.object(

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -118,7 +118,7 @@ class TestRecordsProviderLttng:
         mocker.patch('caret_analyze.infra.lttng.records_provider_lttng.DataModelService',
                      return_value=data_model_srv_mock)
         mocker.patch.object(data_model_srv_mock,
-                            '_get_rmw_handle_from_callback_object', return_value=0)
+                            '_get_rmw_handle_from_callback_object', return_value=4)
 
         source_mock = mocker.Mock(spec=FilteredRecordsSource)
         mocker.patch('caret_analyze.infra.lttng.records_provider_lttng.FilteredRecordsSource',
@@ -145,7 +145,7 @@ class TestRecordsProviderLttng:
             ]
         )
         mocker.patch.object(source_mock, '_grouped_rmw_records',
-                            return_value={0: records_mock})
+                            return_value={4: records_mock})
 
         subscription_mock = mocker.Mock(spec=SubscriptionStructValue)
         provider = RecordsProviderLttng(lttng_mock)

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -84,6 +84,7 @@ class TestRecordsProviderLttng:
 
         assert records == records_mock
 
+    # When node is implemented with subscription->take.
     def test_subscription_take_records(self, mocker):
 
         records_mock = mocker.Mock(spec=RecordsInterface)
@@ -153,11 +154,15 @@ class TestRecordsProviderLttng:
             [
                 RecordCppImpl(
                     {
+                        COLUMN_NAME.RMW_TAKE_TIMESTAMP: 3,
                         COLUMN_NAME.SOURCE_TIMESTAMP: 6,
                     },
                 )
             ],
-            [ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP), ]
+            [
+                ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
+                ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP)
+            ]
         )
 
         records.equals(expected)

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -492,6 +492,10 @@ class TestNodeRecordsUseLatestMessage:
         provider_mock = mocker.Mock(spec=RecordsProviderLttng)
         node_path_mock = mocker.Mock(spec=NodePathStructValue)
 
+        callback_name = 'callback'
+        topic_name_1 = 'topic_1'
+        topic_name_2 = 'topic_2'
+
         use_latest_message = mocker.Mock(spec=UseLatestMessage)
         mocker.patch.object(node_path_mock, 'message_context', use_latest_message)
 
@@ -502,19 +506,19 @@ class TestNodeRecordsUseLatestMessage:
         records_data: list[RecordInterface]
         records_data = [
             RecordCppImpl({
-                f'00/{COLUMN_NAME.SOURCE_TIMESTAMP}': 1,
-                f'0/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}': 2,
+                f'{callback_name}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 1,
+                f'{topic_name_1}/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}': 2,
             }),
             RecordCppImpl({
-                f'00/{COLUMN_NAME.SOURCE_TIMESTAMP}': 6,
-                f'0/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}': 7,
+                f'{callback_name}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 6,
+                f'{topic_name_1}/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}': 7,
             }),
         ]
         sub_records = RecordsCppImpl(
             records_data,
             [
-                ColumnValue(f'00/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
-                ColumnValue(f'0/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}'),
+                ColumnValue(f'{callback_name}/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_1}/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}'),
             ]
         )
         mocker.patch.object(provider_mock, 'subscribe_records', return_value=sub_records)
@@ -522,55 +526,55 @@ class TestNodeRecordsUseLatestMessage:
         records_data: list[RecordInterface]
         pub_records_data = [
             RecordCppImpl({
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 3,
-                f'1/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}': 4,
-                f'1/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}': 5,
-                f'1/{COLUMN_NAME.MESSAGE_TIMESTAMP}': 6,
-                f'1/{COLUMN_NAME.SOURCE_TIMESTAMP}': 7,
+                f'{topic_name_2}/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 3,
+                f'{topic_name_2}/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}': 4,
+                f'{topic_name_2}/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}': 5,
+                f'{topic_name_2}/{COLUMN_NAME.MESSAGE_TIMESTAMP}': 6,
+                f'{topic_name_2}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 7,
             }),
             RecordCppImpl({
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 8,
-                f'1/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}': 9,
-                f'1/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}': 10,
-                f'1/{COLUMN_NAME.MESSAGE_TIMESTAMP}': 11,
-                f'1/{COLUMN_NAME.SOURCE_TIMESTAMP}': 12,
+                f'{topic_name_2}/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 8,
+                f'{topic_name_2}/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}': 9,
+                f'{topic_name_2}/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}': 10,
+                f'{topic_name_2}/{COLUMN_NAME.MESSAGE_TIMESTAMP}': 11,
+                f'{topic_name_2}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 12,
             }),
         ]
         pub_records = RecordsCppImpl(
             pub_records_data,
             [
-                ColumnValue(f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'),
-                ColumnValue(f'1/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}'),
-                ColumnValue(f'1/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}'),
-                ColumnValue(f'1/{COLUMN_NAME.MESSAGE_TIMESTAMP}'),
-                ColumnValue(f'1/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_2}/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_2}/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_2}/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_2}/{COLUMN_NAME.MESSAGE_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_2}/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
             ]
         )
 
         mocker.patch.object(provider_mock, 'publish_records', return_value=pub_records)
-        mocker.patch.object(node_path_mock, 'publish_topic_name', '')
+        mocker.patch.object(node_path_mock, 'publish_topic_name', topic_name_2)
 
         node_records = NodeRecordsUseLatestMessage(provider_mock, node_path_mock)
         records = node_records.to_records()
 
         expect_data = [
             RecordCppImpl({
-                f'00/{COLUMN_NAME.SOURCE_TIMESTAMP}': 1,
-                f'0/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}': 2,
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 3,
+                f'{callback_name}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 1,
+                f'{topic_name_1}/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}': 2,
+                f'{topic_name_2}/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 3,
             }),
             RecordCppImpl({
-                f'00/{COLUMN_NAME.SOURCE_TIMESTAMP}': 6,
-                f'0/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}': 7,
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 8,
+                f'{callback_name}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 6,
+                f'{topic_name_1}/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}': 7,
+                f'{topic_name_2}/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 8,
             }),
         ]
         expect_records = RecordsCppImpl(
             expect_data,
             [
-                ColumnValue(f'00/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
-                ColumnValue(f'0/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}'),
-                ColumnValue(f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'),
+                ColumnValue(f'{callback_name}/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_1}/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_2}/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'),
             ]
         )
 
@@ -580,6 +584,9 @@ class TestNodeRecordsUseLatestMessage:
     def test_data_has_not_callback_start(self, mocker):
         provider_mock = mocker.Mock(spec=RecordsProviderLttng)
         node_path_mock = mocker.Mock(spec=NodePathStructValue)
+
+        topic_name_1 = 'topic_1'
+        topic_name_2 = 'topic_2'
 
         use_latest_message = mocker.Mock(spec=UseLatestMessage)
         mocker.patch.object(node_path_mock, 'message_context', use_latest_message)
@@ -603,19 +610,19 @@ class TestNodeRecordsUseLatestMessage:
         take_records_data: list[RecordInterface]
         take_records_data = [
             RecordCppImpl({
-                COLUMN_NAME.RMW_TAKE_TIMESTAMP: 0,
-                f'0/{COLUMN_NAME.SOURCE_TIMESTAMP}': 1,
+                COLUMN_NAME.RMW_TAKE_TIMESTAMP: 2,
+                f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 1,
             }),
             RecordCppImpl({
                 COLUMN_NAME.RMW_TAKE_TIMESTAMP: 6,
-                f'0/{COLUMN_NAME.SOURCE_TIMESTAMP}': 7,
+                f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 7,
             }),
         ]
         take_records = RecordsCppImpl(
             take_records_data,
             [
                 ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
-                ColumnValue(f'0/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
             ]
         )
 
@@ -624,53 +631,53 @@ class TestNodeRecordsUseLatestMessage:
         records_data: list[RecordInterface]
         pub_records_data = [
             RecordCppImpl({
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 2,
-                f'/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}': 3,
-                f'/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}': 4,
-                f'/{COLUMN_NAME.MESSAGE_TIMESTAMP}': 5,
-                f'/{COLUMN_NAME.SOURCE_TIMESTAMP}': 6,
+                f'{topic_name_2}/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 2,
+                f'{topic_name_2}/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}': 3,
+                f'{topic_name_2}/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}': 4,
+                f'{topic_name_2}/{COLUMN_NAME.MESSAGE_TIMESTAMP}': 5,
+                f'{topic_name_2}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 6,
             }),
             RecordCppImpl({
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 8,
-                f'/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}': 9,
-                f'/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}': 10,
-                f'/{COLUMN_NAME.MESSAGE_TIMESTAMP}': 11,
-                f'/{COLUMN_NAME.SOURCE_TIMESTAMP}': 12,
+                f'{topic_name_2}/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 8,
+                f'{topic_name_2}/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}': 9,
+                f'{topic_name_2}/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}': 10,
+                f'{topic_name_2}/{COLUMN_NAME.MESSAGE_TIMESTAMP}': 11,
+                f'{topic_name_2}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 12,
             }),
         ]
 
         pub_records = RecordsCppImpl(
             pub_records_data,
             [
-                ColumnValue(f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'),
-                ColumnValue(f'/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}'),
-                ColumnValue(f'/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}'),
-                ColumnValue(f'/{COLUMN_NAME.MESSAGE_TIMESTAMP}'),
-                ColumnValue(f'/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_2}/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_2}/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_2}/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_2}/{COLUMN_NAME.MESSAGE_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_2}/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
             ]
         )
 
         mocker.patch.object(provider_mock, 'publish_records', return_value=pub_records)
-        mocker.patch.object(node_path_mock, 'publish_topic_name', '')
+        mocker.patch.object(node_path_mock, 'publish_topic_name', topic_name_2)
 
         node_records = NodeRecordsUseLatestMessage(provider_mock, node_path_mock)
         records = node_records.to_records()
 
         expect_data = [
             RecordCppImpl({
-                f'0/{COLUMN_NAME.SOURCE_TIMESTAMP}': 1,
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 2,
+                f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 1,
+                f'{topic_name_2}/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 2,
             }),
             RecordCppImpl({
-                f'0/{COLUMN_NAME.SOURCE_TIMESTAMP}': 7,
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 8,
+                f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 7,
+                f'{topic_name_2}/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 8,
             }),
         ]
         expect_records = RecordsCppImpl(
             expect_data,
             [
-                ColumnValue(f'0/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
-                ColumnValue(f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
+                ColumnValue(f'{topic_name_2}/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'),
             ]
         )
 

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -144,7 +144,7 @@ class TestRecordsProviderLttng:
                 ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
             ]
         )
-        source_mock._grouped_rmw_records = [records_mock, ]
+        mocker.patch.object(source_mock, '_grouped_rmw_records', return_value=records_mock)
 
         subscription_mock = mocker.Mock(spec=SubscriptionStructValue)
         provider = RecordsProviderLttng(lttng_mock)

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -691,7 +691,7 @@ class TestNodeRecordsUseLatestMessage:
                 f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'
             )
         })
-        records.equals(expect_records)
+        assert records.equals(expect_records)
 
 
 class TestNodeRecordsCallbackChain:

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -501,19 +501,19 @@ class TestNodeRecordsUseLatestMessage:
         records_data: list[RecordInterface]
         records_data = [
             RecordCppImpl({
-                COLUMN_NAME.CALLBACK_START_TIMESTAMP: 1,
-                COLUMN_NAME.SOURCE_TIMESTAMP: 2,
+                f'00/{COLUMN_NAME.SOURCE_TIMESTAMP}': 1,
+                f'0/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}': 2,
             }),
             RecordCppImpl({
-                COLUMN_NAME.CALLBACK_START_TIMESTAMP: 6,
-                COLUMN_NAME.SOURCE_TIMESTAMP: 7,
+                f'00/{COLUMN_NAME.SOURCE_TIMESTAMP}': 6,
+                f'0/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}': 7,
             }),
         ]
         sub_records = RecordsCppImpl(
             records_data,
             [
-                ColumnValue(COLUMN_NAME.CALLBACK_START_TIMESTAMP),
-                ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
+                ColumnValue(f'00/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
+                ColumnValue(f'0/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}'),
             ]
         )
         mocker.patch.object(provider_mock, 'subscribe_records', return_value=sub_records)
@@ -521,35 +521,30 @@ class TestNodeRecordsUseLatestMessage:
         records_data: list[RecordInterface]
         pub_records_data = [
             RecordCppImpl({
-                COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: 3,
-                COLUMN_NAME.RCL_PUBLISH_TIMESTAMP: 4,
-                COLUMN_NAME.DDS_WRITE_TIMESTAMP: 5,
-                COLUMN_NAME.MESSAGE_TIMESTAMP: 6,
-                COLUMN_NAME.SOURCE_TIMESTAMP: 7,
+                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 3,
+                f'1/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}': 4,
+                f'1/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}': 5,
+                f'1/{COLUMN_NAME.MESSAGE_TIMESTAMP}': 6,
+                f'1/{COLUMN_NAME.SOURCE_TIMESTAMP}': 7,
             }),
             RecordCppImpl({
-                COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: 8,
-                COLUMN_NAME.RCL_PUBLISH_TIMESTAMP: 9,
-                COLUMN_NAME.DDS_WRITE_TIMESTAMP: 10,
-                COLUMN_NAME.MESSAGE_TIMESTAMP: 11,
-                COLUMN_NAME.SOURCE_TIMESTAMP: 12,
+                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 8,
+                f'1/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}': 9,
+                f'1/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}': 10,
+                f'1/{COLUMN_NAME.MESSAGE_TIMESTAMP}': 11,
+                f'1/{COLUMN_NAME.SOURCE_TIMESTAMP}': 12,
             }),
         ]
         pub_records = RecordsCppImpl(
             pub_records_data,
             [
-                ColumnValue(COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP),
-                ColumnValue(COLUMN_NAME.RCL_PUBLISH_TIMESTAMP),
-                ColumnValue(COLUMN_NAME.DDS_WRITE_TIMESTAMP),
-                ColumnValue(COLUMN_NAME.MESSAGE_TIMESTAMP),
-                ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
+                ColumnValue(f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'),
+                ColumnValue(f'1/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}'),
+                ColumnValue(f'1/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}'),
+                ColumnValue(f'1/{COLUMN_NAME.MESSAGE_TIMESTAMP}'),
+                ColumnValue(f'1/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
             ]
         )
-        pub_records.rename_columns({
-            COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: (
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'
-                )
-            })
 
         mocker.patch.object(provider_mock, 'publish_records', return_value=pub_records)
         mocker.patch.object(node_path_mock, 'publish_topic_name', '')
@@ -559,29 +554,25 @@ class TestNodeRecordsUseLatestMessage:
 
         expect_data = [
             RecordCppImpl({
-                COLUMN_NAME.CALLBACK_START_TIMESTAMP: 1,
-                COLUMN_NAME.SOURCE_TIMESTAMP: 2,
-                COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: 3,
+                f'00/{COLUMN_NAME.SOURCE_TIMESTAMP}': 1,
+                f'0/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}': 2,
+                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 3,
             }),
             RecordCppImpl({
-                COLUMN_NAME.CALLBACK_START_TIMESTAMP: 6,
-                COLUMN_NAME.SOURCE_TIMESTAMP: 7,
-                COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: 8,
+                f'00/{COLUMN_NAME.SOURCE_TIMESTAMP}': 6,
+                f'0/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}': 7,
+                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 8,
             }),
         ]
         expect_records = RecordsCppImpl(
             expect_data,
             [
-                ColumnValue(COLUMN_NAME.CALLBACK_START_TIMESTAMP),
-                ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
-                ColumnValue(COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP),
+                ColumnValue(f'00/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
+                ColumnValue(f'0/{COLUMN_NAME.CALLBACK_START_TIMESTAMP}'),
+                ColumnValue(f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'),
             ]
         )
-        expect_records.rename_columns({
-            COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: (
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'
-                )
-            })
+
         assert records.equals(expect_records)
 
     # When node is implemented with subscription->take
@@ -612,18 +603,18 @@ class TestNodeRecordsUseLatestMessage:
         take_records_data = [
             RecordCppImpl({
                 COLUMN_NAME.RMW_TAKE_TIMESTAMP: 0,
-                COLUMN_NAME.SOURCE_TIMESTAMP: 1,
+                f'0/{COLUMN_NAME.SOURCE_TIMESTAMP}': 1,
             }),
             RecordCppImpl({
                 COLUMN_NAME.RMW_TAKE_TIMESTAMP: 6,
-                COLUMN_NAME.SOURCE_TIMESTAMP: 7,
+                f'0/{COLUMN_NAME.SOURCE_TIMESTAMP}': 7,
             }),
         ]
         take_records = RecordsCppImpl(
             take_records_data,
             [
                 ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
-                ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
+                ColumnValue(f'0/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
             ]
         )
 
@@ -632,36 +623,36 @@ class TestNodeRecordsUseLatestMessage:
         records_data: list[RecordInterface]
         pub_records_data = [
             RecordCppImpl({
-                COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: 2,
-                COLUMN_NAME.RCL_PUBLISH_TIMESTAMP: 3,
-                COLUMN_NAME.DDS_WRITE_TIMESTAMP: 4,
-                COLUMN_NAME.MESSAGE_TIMESTAMP: 5,
-                COLUMN_NAME.SOURCE_TIMESTAMP: 6,
+                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 2,
+                f'/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}': 3,
+                f'/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}': 4,
+                f'/{COLUMN_NAME.MESSAGE_TIMESTAMP}': 5,
+                f'/{COLUMN_NAME.SOURCE_TIMESTAMP}': 6,
             }),
             RecordCppImpl({
-                COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: 8,
-                COLUMN_NAME.RCL_PUBLISH_TIMESTAMP: 9,
-                COLUMN_NAME.DDS_WRITE_TIMESTAMP: 10,
-                COLUMN_NAME.MESSAGE_TIMESTAMP: 11,
-                COLUMN_NAME.SOURCE_TIMESTAMP: 12,
+                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 8,
+                f'/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}': 9,
+                f'/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}': 10,
+                f'/{COLUMN_NAME.MESSAGE_TIMESTAMP}': 11,
+                f'/{COLUMN_NAME.SOURCE_TIMESTAMP}': 12,
             }),
         ]
 
         pub_records = RecordsCppImpl(
             pub_records_data,
             [
-                ColumnValue(COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP),
-                ColumnValue(COLUMN_NAME.RCL_PUBLISH_TIMESTAMP),
-                ColumnValue(COLUMN_NAME.DDS_WRITE_TIMESTAMP),
-                ColumnValue(COLUMN_NAME.MESSAGE_TIMESTAMP),
-                ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
+                ColumnValue(f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'),
+                ColumnValue(f'/{COLUMN_NAME.RCL_PUBLISH_TIMESTAMP}'),
+                ColumnValue(f'/{COLUMN_NAME.DDS_WRITE_TIMESTAMP}'),
+                ColumnValue(f'/{COLUMN_NAME.MESSAGE_TIMESTAMP}'),
+                ColumnValue(f'/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
             ]
         )
-        pub_records.rename_columns({
-            COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: (
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'
-                )
-            })
+        # pub_records.rename_columns({
+        #     COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: (
+        #         f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'
+        #         )
+        #     })
 
         mocker.patch.object(provider_mock, 'publish_records', return_value=pub_records)
         mocker.patch.object(node_path_mock, 'publish_topic_name', '')
@@ -671,26 +662,26 @@ class TestNodeRecordsUseLatestMessage:
 
         expect_data = [
             RecordCppImpl({
-                COLUMN_NAME.SOURCE_TIMESTAMP: 1,
-                COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: 2,
+                f'0/{COLUMN_NAME.SOURCE_TIMESTAMP}': 1,
+                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 2,
             }),
             RecordCppImpl({
-                COLUMN_NAME.SOURCE_TIMESTAMP: 7,
-                COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: 8,
+                f'0/{COLUMN_NAME.SOURCE_TIMESTAMP}': 7,
+                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}': 8,
             }),
         ]
         expect_records = RecordsCppImpl(
             expect_data,
             [
-                ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
-                ColumnValue(COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP),
+                ColumnValue(f'0/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
+                ColumnValue(f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'),
             ]
         )
-        expect_records.rename_columns({
-            COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: (
-                f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'
-            )
-        })
+        # expect_records.rename_columns({
+        #     COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: (
+        #         f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'
+        #     )
+        # })
         assert records.equals(expect_records)
 
 

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -648,11 +648,6 @@ class TestNodeRecordsUseLatestMessage:
                 ColumnValue(f'/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
             ]
         )
-        # pub_records.rename_columns({
-        #     COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: (
-        #         f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'
-        #         )
-        #     })
 
         mocker.patch.object(provider_mock, 'publish_records', return_value=pub_records)
         mocker.patch.object(node_path_mock, 'publish_topic_name', '')
@@ -677,11 +672,7 @@ class TestNodeRecordsUseLatestMessage:
                 ColumnValue(f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'),
             ]
         )
-        # expect_records.rename_columns({
-        #     COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP: (
-        #         f'/{COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP}'
-        #     )
-        # })
+
         assert records.equals(expect_records)
 
 

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -144,7 +144,8 @@ class TestRecordsProviderLttng:
                 ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
             ]
         )
-        mocker.patch.object(source_mock, '_grouped_rmw_records', return_value=records_mock)
+        mocker.patch.object(source_mock, '_grouped_rmw_records',
+                            return_value={0: records_mock})
 
         subscription_mock = mocker.Mock(spec=SubscriptionStructValue)
         provider = RecordsProviderLttng(lttng_mock)

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -63,6 +63,9 @@ class TestRecordsProviderLttng:
 
         lttng_mock = mocker.Mock(spec=Lttng)
 
+        data_model_mock = mocker.Mock(spec=Ros2DataModel)
+        lttng_mock.data = data_model_mock
+
         helper_mock = mocker.Mock(spec=RecordsProviderLttngHelper)
         mocker.patch('caret_analyze.infra.lttng.records_provider_lttng.RecordsProviderLttngHelper',
                      return_value=helper_mock)
@@ -161,6 +164,8 @@ class TestRecordsProviderLttng:
 
     def test_node_records_callback_chain(self, mocker):
         lttng_mock = mocker.Mock(spec=Lttng)
+        data_model_mock = mocker.Mock(spec=Ros2DataModel)
+        lttng_mock.data = data_model_mock
         node_path_info_mock = mocker.Mock(spec=NodePathStructValue)
         records_mock = mocker.Mock(spec=RecordsInterface)
 
@@ -181,6 +186,8 @@ class TestRecordsProviderLttng:
 
     def test_node_records_inherit_timestamp(self, mocker):
         lttng_mock = mocker.Mock(spec=Lttng)
+        data_model_mock = mocker.Mock(spec=Ros2DataModel)
+        lttng_mock.data = data_model_mock
         node_path_info_mock = mocker.Mock(spec=NodePathStructValue)
         records_mock = mocker.Mock(spec=RecordsInterface)
 
@@ -205,6 +212,8 @@ class TestRecordsProviderLttng:
 
     def test_get_publish_records(self, mocker):
         lttng_mock = mocker.Mock(spec=Lttng)
+        data_model_mock = mocker.Mock(spec=Ros2DataModel)
+        lttng_mock.data = data_model_mock
 
         pub_handle = 6
 
@@ -245,6 +254,8 @@ class TestRecordsProviderLttng:
 
     def test_get_rmw_impl(self, mocker):
         lttng_mock = mocker.Mock(spec=Lttng)
+        data_model_mock = mocker.Mock(spec=Ros2DataModel)
+        lttng_mock.data = data_model_mock
         mocker.patch.object(
             lttng_mock, 'get_rmw_impl', return_value='rmw')
         provider = RecordsProviderLttng(lttng_mock)
@@ -253,6 +264,8 @@ class TestRecordsProviderLttng:
 
     def test_intra_proc_comm_records(self, mocker):
         lttng_mock = mocker.Mock(spec=Lttng)
+        data_model_mock = mocker.Mock(spec=Ros2DataModel)
+        lttng_mock.data = data_model_mock
 
         comm_mock = mocker.Mock(spec=CommunicationStructValue)
         pub_mock = mocker.Mock(spec=PublisherStructValue)
@@ -300,6 +313,8 @@ class TestRecordsProviderLttng:
 
     def test_is_intra_process_communication(self, mocker):
         lttng_mock = mocker.Mock(spec=Lttng)
+        data_model_mock = mocker.Mock(spec=Ros2DataModel)
+        lttng_mock.data = data_model_mock
         provider = RecordsProviderLttng(lttng_mock)
         comm_info_mock = mocker.Mock(spec=Lttng)
 
@@ -326,6 +341,8 @@ class TestRecordsProviderLttng:
             RecordsProviderLttng, '_format', side_effect=_format)
 
         lttng_mock = mocker.Mock(spec=Lttng)
+        data_model_mock = mocker.Mock(spec=Ros2DataModel)
+        lttng_mock.data = data_model_mock
 
         helper_mock = mocker.Mock(spec=RecordsProviderLttngHelper)
         mocker.patch('caret_analyze.infra.lttng.records_provider_lttng.RecordsProviderLttngHelper',
@@ -360,6 +377,8 @@ class TestRecordsProviderLttng:
             RecordsProviderLttng, '_format', side_effect=_format)
 
         lttng_mock = mocker.Mock(spec=Lttng)
+        data_model_mock = mocker.Mock(spec=Ros2DataModel)
+        lttng_mock.data = data_model_mock
 
         helper_mock = mocker.Mock(spec=RecordsProviderLttngHelper)
         mocker.patch('caret_analyze.infra.lttng.records_provider_lttng.RecordsProviderLttngHelper',

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -611,15 +611,18 @@ class TestNodeRecordsUseLatestMessage:
         take_records_data: list[RecordInterface]
         take_records_data = [
             RecordCppImpl({
+                COLUMN_NAME.RMW_TAKE_TIMESTAMP: 0,
                 COLUMN_NAME.SOURCE_TIMESTAMP: 1,
             }),
             RecordCppImpl({
+                COLUMN_NAME.RMW_TAKE_TIMESTAMP: 6,
                 COLUMN_NAME.SOURCE_TIMESTAMP: 7,
             }),
         ]
         take_records = RecordsCppImpl(
             take_records_data,
             [
+                ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
                 ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
             ]
         )

--- a/src/test/runtime/test_application.py
+++ b/src/test/runtime/test_application.py
@@ -16,6 +16,7 @@
 from caret_analyze.architecture.architecture import Architecture
 from caret_analyze.exceptions import ItemNotFoundError
 from caret_analyze.infra.lttng import Lttng
+from caret_analyze.infra.lttng.ros2_tracing.data_model import Ros2DataModel
 from caret_analyze.runtime.application import Application
 from caret_analyze.runtime.callback import CallbackBase
 from caret_analyze.runtime.communication import Communication
@@ -41,6 +42,8 @@ class TestApplication:
         mocker.patch(
             'caret_analyze.runtime.application.RuntimeLoaded', return_value=assigned_mock)
         records_provider_mock = mocker.Mock(spec=Lttng)
+        data_model_mock = mocker.Mock(spec=Ros2DataModel)
+        records_provider_mock.data = data_model_mock
         app = Application(arch_mock, records_provider_mock)
 
         assert len(app.paths) == 0
@@ -65,6 +68,8 @@ class TestApplication:
         # define mocks
         arch_mock = mocker.Mock(spec=Architecture)
         records_provider_mock = mocker.Mock(spec=Lttng)
+        data_model_mock = mocker.Mock(spec=Ros2DataModel)
+        records_provider_mock.data = data_model_mock
 
         node_mock = mocker.Mock(spec=Node)
         executor_mock = mocker.Mock(spec=Executor)
@@ -168,6 +173,8 @@ class TestApplication:
         # define mocks
         arch_mock = mocker.Mock(spec=Architecture)
         records_provider_mock = mocker.Mock(spec=Lttng)
+        data_model_mock = mocker.Mock(spec=Ros2DataModel)
+        records_provider_mock.data = data_model_mock
 
         # node_mock = mocker.Mock(spec=Node)
         node_mock = mocker.Mock(spec=Node)

--- a/src/test/runtime/test_path.py
+++ b/src/test/runtime/test_path.py
@@ -657,10 +657,94 @@ class TestRecordsMerged:
 
         assert records.equals(expected)
 
+    def test_take_imple_case_include_first_callback(self, mocker):
+        node_path =mocker.Mock(spec=NodePath)
+        mocker.patch.object(
+            node_path, 'to_records',
+            return_value=RecordsCppImpl()
+        )
+        mocker.patch.object(
+            node_path, 'to_path_beginning_records',
+            return_value=RecordsCppImpl(
+                [
+                    RecordCppImpl({
+                        'callback_start_timestamp': 0,
+                        'rclcpp_publish_timestamp': 1,
+                    }),
+                ],
+                [
+                    ColumnValue('callback_start_timestamp'),
+                    ColumnValue('rclcpp_publish_timestamp'),
+                ]
+            )
+        )
 
+        comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(
+            comm_path, 'to_records',
+            return_value=RecordsCppImpl(
+                [
+                    RecordCppImpl({
+                        'rclcpp_publish_timestamp': 1,
+                        'rcl_publish_timestamp': 2,
+                        'dds_write_timestamp': 3,
+                        'source_timestamp': 4,
+                        'callback_start_timestamp': 5
+                    }),
+                ],
+                [
+                    ColumnValue('rclcpp_publish_timestamp'),
+                    ColumnValue('rcl_publish_timestamp'),
+                    ColumnValue('dds_write_timestamp'),
+                    ColumnValue('source_timestamp'),
+                    ColumnValue('callback_start_timestamp'),
+                ]
+            )
+        )
 
+        merger_mock = mocker.Mock(spec=ColumnMerger)
+        mocker.patch('caret_analyze.runtime.path.ColumnMerger',
+                     return_value=merger_mock)
 
+        def append_columns_and_return_rename_rule(records):
+            if merger_mock.append_columns_and_return_rename_rule.call_count == 1:
+                return {
+                        'callback_start_timestamp': 'callback_start_timestamp/0',
+                        'rclcpp_publish_timestamp': 'rclcpp_publish_timestamp/0',
+                }
+            if merger_mock.append_columns_and_return_rename_rule.call_count == 2:
+                return {
+                        'rclcpp_publish_timestamp': 'rclcpp_publish_timestamp/0',
+                        'rcl_publish_timestamp': 'rcl_publish_timestamp/0',
+                        'dds_write_timestamp': 'dds_write_timestamp/0',
+                        'source_timestamp': 'source_timestamp/0',
+                        'callback_start_timestamp': 'callback_start_timestamp/1',
+                        }
+        mocker.patch.object(
+            merger_mock, 'append_columns_and_return_rename_rule',
+            side_effect=append_columns_and_return_rename_rule)
 
+        merged = RecordsMerged([node_path, comm_path], include_first_callback=True)
+        records = merged.data
 
+        expected = RecordsCppImpl(
+            [
+                RecordCppImpl({
+                    'callback_start_timestamp/0': 0,
+                    'rclcpp_publish_timestamp/0': 1,
+                    'rcl_publish_timestamp/0': 2,
+                    'dds_write_timestamp/0': 3,
+                    'callback_start_timestamp/1': 5,
 
+                }),
+            ],
+            [
+                ColumnValue('callback_start_timestamp/0'),
+                ColumnValue('rclcpp_publish_timestamp/0'),
+                ColumnValue('rcl_publish_timestamp/0'),
+                ColumnValue('dds_write_timestamp/0'),
+                ColumnValue('callback_start_timestamp/1'),
+            ]
+        )
 
+        assert records.equals(expected)

--- a/src/test/runtime/test_path.py
+++ b/src/test/runtime/test_path.py
@@ -657,7 +657,7 @@ class TestRecordsMerged:
 
         assert records.equals(expected)
 
-    def test_take_imple_case_include_first_callback(self, mocker):
+    def test_take_impl_case_include_first_callback(self, mocker):
         node_path =mocker.Mock(spec=NodePath)
         mocker.patch.object(
             node_path, 'to_records',

--- a/src/test/runtime/test_path.py
+++ b/src/test/runtime/test_path.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from logging import WARNING
+
 from caret_analyze.exceptions import InvalidArgumentError
 from caret_analyze.infra import RecordsProvider
 from caret_analyze.record.column import ColumnValue
@@ -748,3 +750,70 @@ class TestRecordsMerged:
         )
 
         assert records.equals(expected)
+
+    def test_take_impl_case_include_last_callback(self, mocker, caplog):
+        comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(
+            comm_path, 'to_records',
+            return_value=RecordsCppImpl(
+                [
+                    RecordCppImpl({
+                        'rclcpp_publish_timestamp': 1,
+                        'rcl_publish_timestamp': 2,
+                        'dds_write_timestamp': 3,
+                        'source_timestamp': 4,
+                    }),
+                ],
+                [
+                    ColumnValue('rclcpp_publish_timestamp'),
+                    ColumnValue('rcl_publish_timestamp'),
+                    ColumnValue('dds_write_timestamp'),
+                    ColumnValue('source_timestamp'),
+                    ColumnValue('callback_start_timestamp'),
+                ]
+            )
+        )
+
+        node_path = mocker.Mock(spec=NodePath)
+        mocker.patch.object(
+            node_path, 'to_records',
+            return_value=RecordsCppImpl()
+        )
+        mocker.patch.object(
+            node_path, 'to_path_end_records',
+            return_value=RecordsCppImpl(
+                [],
+                [
+                    ColumnValue('callback_start_timestamp'),
+                    ColumnValue('callback_end_timestamp'),
+                ]
+            )
+        )
+
+        merger_mock = mocker.Mock(spec=ColumnMerger)
+        mocker.patch('caret_analyze.runtime.path.ColumnMerger',
+                     return_value=merger_mock)
+
+        def append_columns_and_return_rename_rule(records):
+            if merger_mock.append_columns_and_return_rename_rule.call_count == 1:
+                return {
+                        'rclcpp_publish_timestamp': 'rclcpp_publish_timestamp/0',
+                        'rcl_publish_timestamp': 'rcl_publish_timestamp/0',
+                        'dds_write_timestamp': 'dds_write_timestamp/0',
+                        'source_timestamp': 'source_timestamp/0',
+                        'callback_start_timestamp': 'callback_start_timestamp/1',
+                        }
+            if merger_mock.append_columns_and_return_rename_rule.call_count == 2:
+                return {
+                        'callback_start_timestamp': 'callback_start_timestamp/1',
+                        'callback_end_timestamp': 'callback_end_timestamp/1',
+                }
+        mocker.patch.object(
+            merger_mock, 'append_columns_and_return_rename_rule',
+            side_effect=append_columns_and_return_rename_rule)
+
+        with caplog.at_level(WARNING):
+            RecordsMerged([comm_path, node_path], include_last_callback=True)
+            msg = 'last_callback is None. Use last_callback = False\n'
+            msg += 'last Node is implemented using method of explicitly take message by user'
+            assert caplog.messages[0] == msg

--- a/src/test/runtime/test_path.py
+++ b/src/test/runtime/test_path.py
@@ -658,7 +658,7 @@ class TestRecordsMerged:
         assert records.equals(expected)
 
     def test_take_impl_case_include_first_callback(self, mocker):
-        node_path =mocker.Mock(spec=NodePath)
+        node_path = mocker.Mock(spec=NodePath)
         mocker.patch.object(
             node_path, 'to_records',
             return_value=RecordsCppImpl()


### PR DESCRIPTION
## Description

Adapted the implementation to support calling subscription->take at the intended timing to retrieve the message, rather than using subscription_callback. In this case, modified the code to merge records based on source_timestamp.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
