### PR TITLE
fix: use visible instead of toggleable since bokeh 3.4.0

### DIFF
--- a/src/caret_analyze/plot/visualize_lib/bokeh/util/hover.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/util/hover.py
@@ -18,9 +18,9 @@ from abc import ABCMeta, abstractmethod
 from logging import getLogger
 from typing import Any
 
+from bokeh import __version__ as bokeh_version
 from packaging import version
 
-from bokeh import __version__ as bokeh_version
 from bokeh.models import HoverTool
 
 from .....exceptions import InvalidArgumentError

--- a/src/caret_analyze/plot/visualize_lib/bokeh/util/hover.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/util/hover.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from logging import getLogger
+from packaging import version
 from typing import Any
 
+from bokeh import __version__ as bokeh_version
 from bokeh.models import HoverTool
 
 from .....exceptions import InvalidArgumentError
@@ -153,9 +155,14 @@ class HoverKeysBase(metaclass=ABCMeta):
                 tips_str += f'@{k} <br>'
         tips_str += '</div>'
 
-        return HoverTool(
-            tooltips=tips_str, point_policy='follow_mouse', visible=False, **options
-        )
+        if version.parse(bokeh_version) >= version.parse("3.4.0"):
+            return HoverTool(
+                tooltips=tips_str, point_policy='follow_mouse', visible=False, **options
+            )
+        else:
+            return HoverTool(
+                tooltips=tips_str, point_policy='follow_mouse', toggleable=False, **options
+            )
 
 
 class CallbackSchedBarKeys(HoverKeysBase):

--- a/src/caret_analyze/plot/visualize_lib/bokeh/util/hover.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/util/hover.py
@@ -19,9 +19,9 @@ from logging import getLogger
 from typing import Any
 
 from bokeh import __version__ as bokeh_version
-from packaging import version
-
 from bokeh.models import HoverTool
+
+from packaging import version
 
 from .....exceptions import InvalidArgumentError
 from .....runtime import CallbackBase, Communication, Path, Publisher, Subscription

--- a/src/caret_analyze/plot/visualize_lib/bokeh/util/hover.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/util/hover.py
@@ -154,7 +154,7 @@ class HoverKeysBase(metaclass=ABCMeta):
         tips_str += '</div>'
 
         return HoverTool(
-            tooltips=tips_str, point_policy='follow_mouse', toggleable=False, **options
+            tooltips=tips_str, point_policy='follow_mouse', visible=False, **options
         )
 
 

--- a/src/caret_analyze/plot/visualize_lib/bokeh/util/hover.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/util/hover.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from logging import getLogger
-from packaging import version
 from typing import Any
+
+from packaging import version
 
 from bokeh import __version__ as bokeh_version
 from bokeh.models import HoverTool
@@ -155,7 +156,7 @@ class HoverKeysBase(metaclass=ABCMeta):
                 tips_str += f'@{k} <br>'
         tips_str += '</div>'
 
-        if version.parse(bokeh_version) >= version.parse("3.4.0"):
+        if version.parse(bokeh_version) >= version.parse('3.4.0'):
             return HoverTool(
                 tooltips=tips_str, point_policy='follow_mouse', visible=False, **options
             )


### PR DESCRIPTION
## Description

Use 'visible' instead of 'toggleable' since bokeh 3.4.0

## Related links

[https://tier4.atlassian.net/browse/RT2-1763](https://tier4.atlassian.net/browse/RT2-1763)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
