### PR TITLE
fix: set to 'visible=False' to HoverTool()

### DIFF
--- a/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
@@ -23,9 +23,8 @@ from bokeh.models.renderers import GlyphRenderer
 
 from bokeh.plotting import figure as Figure
 
-from packaging import version
-
 import numpy as np
+from packaging import version
 
 from .callback_scheduling import BokehCallbackSched
 from .message_flow import BokehMessageFlow

--- a/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
@@ -17,10 +17,13 @@ from __future__ import annotations
 from collections.abc import Sequence
 from logging import getLogger
 
+from bokeh import __version__ as bokeh_version
 from bokeh.models import HoverTool
 from bokeh.models.renderers import GlyphRenderer
 
 from bokeh.plotting import figure as Figure
+
+from packaging import version
 
 import numpy as np
 
@@ -223,9 +226,17 @@ class Bokeh(VisualizeLibInterface):
                     top=top, bottom=0, left=bins[i], right=bins[i+1],
                     color=color, alpha=1, line_color='white'
                     )
-                hover = HoverTool(
-                    tooltips=[(x_label, f'{bins[i]}'), ('The number of samples', f'{top}')],
-                    renderers=[quad]
+                if version.parse(bokeh_version) >= version.parse('3.4.0'):
+                    hover = HoverTool(
+                        tooltips=[(x_label, f'{bins[i]}'), ('The number of samples', f'{top}')],
+                        renderers=[quad],
+                        visible=False
+                        )
+                else:
+                    hover = HoverTool(
+                        tooltips=[(x_label, f'{bins[i]}'), ('The number of samples', f'{top}')],
+                        renderers=[quad],
+                        toggleable=False
                     )
                 plot.add_tools(hover)
                 quad_dicts[target_object] = quad_dicts[target_object] + [quad]


### PR DESCRIPTION
## Description

Suppress the display of multiple hover icons when displaying histograms.
![image](https://github.com/user-attachments/assets/aeebf3e2-4b3c-4180-bd35-390d63e2ecb5)

## Related links

[https://tier4.atlassian.net/browse/RT2-1785](https://tier4.atlassian.net/browse/RT2-1785)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
