### PR TITLE
fix: updated legend count check

### DIFF
--- a/src/caret_analyze/plot/visualize_lib/bokeh/util/legend.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/util/legend.py
@@ -100,7 +100,7 @@ class LegendManager:
 
         legends: list[Legend] = []
         for i in range(0, len(self._legend_items)+separate_num, separate_num):
-            if not full_legends and i >= max_legends:
+            if not full_legends and i >= max_legends and len(self._legend_items) > i:
                 logger.warning(
                     f'The maximum number of legends drawn by default is {max_legends}. '
                     'If you want all legends to be displayed, '


### PR DESCRIPTION
## Description

Only one legend is displayed, despite the warning that the maximum number of legends (20) has been exceeded.

![image](https://github.com/user-attachments/assets/ea3033cf-247e-4364-ac6b-80d300a1a488)


## Related links

[https://tier4.atlassian.net/browse/RT2-1791](https://tier4.atlassian.net/browse/RT2-1791)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
