### PR TITLE
fix: mypy1.11 error `untyped-overrides`

### DIFF
--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -31,7 +31,7 @@ from ..common import Summarizable, Summary, type_check_decorator, Util
 from ..exceptions import InvalidArgumentError, ItemNotFoundError, UnsupportedTypeError
 from ..value_objects import (CallbackGroupStructValue, CallbackStructValue,
                              CommunicationStructValue, DiffNode, ExecutorStructValue,
-                             NodePathStructValue, NodeStructValue, PathStructValue,
+                             NodePathStructValue, NodeStructValue, NodeValue, PathStructValue,
                              PublisherStructValue, ServiceStructValue, SubscriptionStructValue)
 
 logger = logging.getLogger(__name__)
@@ -762,13 +762,13 @@ class AssignContextReader(ArchitectureReader):
     def get_message_contexts(self, _) -> Sequence[dict]:
         return self._contexts
 
-    def get_callback_groups(self):
+    def get_callback_groups(self, node: NodeValue):
         pass
 
     def get_executors(self):
         pass
 
-    def get_node_names_and_cb_symbols(self):
+    def get_node_names_and_cb_symbols(self, callback_group_id: str):
         pass
 
     def get_nodes(self):
@@ -777,28 +777,28 @@ class AssignContextReader(ArchitectureReader):
     def get_paths(self):
         pass
 
-    def get_publishers(self):
+    def get_publishers(self, node: NodeValue):
         pass
 
-    def get_service_callbacks(self):
+    def get_service_callbacks(self, node: NodeValue):
         pass
 
-    def get_services(self):
+    def get_services(self, node: NodeValue):
         pass
 
-    def get_subscription_callbacks(self):
+    def get_subscription_callbacks(self, node: NodeValue):
         pass
 
-    def get_subscriptions(self):
+    def get_subscriptions(self, node: NodeValue):
         pass
 
-    def get_timer_callbacks(self):
+    def get_timer_callbacks(self, node: NodeValue):
         pass
 
-    def get_timers(self):
+    def get_timers(self, node: NodeValue):
         pass
 
-    def get_variable_passings(self):
+    def get_variable_passings(self, node: NodeValue):
         pass
 
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,5 +5,5 @@ bokeh>=3
 graphviz
 types-pyyaml
 pydantic>=1.9.0
-mypy>1, <1.11.0
+mypy>1
 multimethod>=1.10


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
In mypy 1.11, untyped-overrides are now more strictly checked.
Fixing the problems pointed out and updating the ci mypy version.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

- [TIERⅣ INTERNAL LINK](https://tier4.atlassian.net/browse/RT2-1752)
- [mypy/CHANGELOG.md at master · python/mypy](https://github.com/python/mypy/blob/master/CHANGELOG.md#stricter-checks-for-untyped-overrides)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
