### PR TITLE
fix: temporary workaround for the issue where typeguard 2.2.2 is installed

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -32,7 +32,6 @@ jobs:
           # cSpell:ignore typeguard
           if dpkg -l | grep -q python3-typeguard; then
             sudo apt remove -y python3-typeguard
-            pip install typeguard
           fi
 
       - name: Get package list

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -29,6 +29,7 @@ jobs:
       - name: Install dependent packages
         run: |
           python3 -m pip install -r src/requirements.txt
+          # cSpell:ignore typeguard
           if dpkg -l | grep -q python3-typeguard; then
             sudo apt remove -y python3-typeguard
             pip install typeguard

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -27,7 +27,12 @@ jobs:
           rosdep update
           rosdep install -i --skip-keys "caret_analyze_cpp_impl" --from-paths . -y --rosdistro humble
       - name: Install dependent packages
-        run: python3 -m pip install -r src/requirements.txt
+        run: |
+          python3 -m pip install -r src/requirements.txt
+          if dpkg -l | grep -q python3-typeguard; then
+            sudo apt remove -y python3-typeguard
+            pip install typeguard
+          fi
 
       - name: Get package list
         run: |


### PR DESCRIPTION
## Description

On the current Docker image, python3-typeguard=2.2.2 is installed. Since this version causes inconsistencies, we are applying a temporary workaround to reinstall typeguard.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
