### PR TITLE
fix: deploy docs has error because installed griffe>=1.0.0

### DIFF
--- a/mkdocs-requirements.txt
+++ b/mkdocs-requirements.txt
@@ -13,3 +13,4 @@ pymdown-extensions
 python-markdown-math
 mkdocstrings<=0.23
 mkdocstrings[python]
+griffe<1.0.0


### PR DESCRIPTION
## Description

`tag:deploy_docs` is not work, because griffe>=1.0.0 and mkdocstring <=0.23 are not match.
Specified installed version of griffe.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
