### PR TITLE
refactor: class to edit message_context

### DIFF
--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -31,7 +31,7 @@ from ..common import Summarizable, Summary, type_check_decorator, Util
 from ..exceptions import InvalidArgumentError, ItemNotFoundError, UnsupportedTypeError
 from ..value_objects import (CallbackGroupStructValue, CallbackStructValue,
                              CommunicationStructValue, DiffNode, ExecutorStructValue,
-                             NodePathStructValue, NodeStructValue, NodeValue, PathStructValue,
+                             NodePathStructValue, NodeStructValue, PathStructValue,
                              PublisherStructValue, ServiceStructValue, SubscriptionStructValue)
 
 logger = logging.getLogger(__name__)

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -398,7 +398,7 @@ class Architecture(Summarizable):
         node.update_node_path(
             NodeValuesLoaded._search_node_paths(
                                 node,
-                                context_updater.get_message_contexts(node),
+                                context_updater.get_message_contexts(),
                                 self._max_callback_construction_order_on_path_searching)
                             )
 
@@ -428,7 +428,7 @@ class Architecture(Summarizable):
         node.update_node_path(
             NodeValuesLoaded._search_node_paths(
                                 node,
-                                ContextUpdater(node).get_message_contexts(node),
+                                ContextUpdater(node).get_message_contexts(),
                                 self._max_callback_construction_order_on_path_searching)
                             )
 
@@ -454,7 +454,7 @@ class Architecture(Summarizable):
         node.update_node_path(
             NodeValuesLoaded._search_node_paths(
                                 node,
-                                ContextUpdater(node).get_message_contexts(node),
+                                ContextUpdater(node).get_message_contexts(),
                                 self._max_callback_construction_order_on_path_searching)
                             )
 
@@ -484,7 +484,7 @@ class Architecture(Summarizable):
         node.update_node_path(
             NodeValuesLoaded._search_node_paths(
                                 node,
-                                ContextUpdater(node).get_message_contexts(node),
+                                ContextUpdater(node).get_message_contexts(),
                                 self._max_callback_construction_order_on_path_searching)
                             )
 
@@ -524,7 +524,7 @@ class Architecture(Summarizable):
             node.update_node_path(
                 NodeValuesLoaded._search_node_paths(
                                     node,
-                                    context_updater.get_message_contexts(node),
+                                    context_updater.get_message_contexts(),
                                     self._max_callback_construction_order_on_path_searching)
                                 )
 
@@ -762,7 +762,7 @@ class ContextUpdater:
                                              'callback_chain')
         ]
 
-    def get_message_contexts(self, _) -> Sequence[dict]:
+    def get_message_contexts(self) -> Sequence[dict]:
         return self._contexts
 
 

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -23,7 +23,7 @@ from .architecture_reader_factory import ArchitectureReaderFactory
 from .combine_path import CombinePath
 from .graph_search import NodePathSearcher
 
-from .reader_interface import ArchitectureReader, IGNORE_TOPICS
+from .reader_interface import IGNORE_TOPICS
 from .struct import (CallbackStruct, CommunicationStruct, ExecutorStruct,
                      NodePathStruct, NodeStruct, PathStruct,
                      ServiceCallbackStruct, SubscriptionCallbackStruct, TimerCallbackStruct)
@@ -389,13 +389,16 @@ class Architecture(Summarizable):
         if subscribe_topic_name not in node.subscribe_topic_names:
             raise ItemNotFoundError('{sub_topic_name} is not found in {node_name}')
 
-        context_reader = AssignContextReader(node)
-        context_reader.update_message_context(context_type,
-                                              subscribe_topic_name, publish_topic_name)
+        context_updater = ContextUpdater(node)
+        context_updater.update_message_context(
+                                        context_type,
+                                        subscribe_topic_name,
+                                        publish_topic_name
+                                    )
         node.update_node_path(
             NodeValuesLoaded._search_node_paths(
                                 node,
-                                context_reader,
+                                context_updater.get_message_contexts(node),
                                 self._max_callback_construction_order_on_path_searching)
                             )
 
@@ -425,7 +428,7 @@ class Architecture(Summarizable):
         node.update_node_path(
             NodeValuesLoaded._search_node_paths(
                                 node,
-                                AssignContextReader(node),
+                                ContextUpdater(node).get_message_contexts(node),
                                 self._max_callback_construction_order_on_path_searching)
                             )
 
@@ -451,7 +454,7 @@ class Architecture(Summarizable):
         node.update_node_path(
             NodeValuesLoaded._search_node_paths(
                                 node,
-                                AssignContextReader(node),
+                                ContextUpdater(node).get_message_contexts(node),
                                 self._max_callback_construction_order_on_path_searching)
                             )
 
@@ -481,7 +484,7 @@ class Architecture(Summarizable):
         node.update_node_path(
             NodeValuesLoaded._search_node_paths(
                                 node,
-                                AssignContextReader(node),
+                                ContextUpdater(node).get_message_contexts(node),
                                 self._max_callback_construction_order_on_path_searching)
                             )
 
@@ -510,10 +513,10 @@ class Architecture(Summarizable):
             Util.find_one(lambda x: x.callback_name == callback_name_write, self.callbacks)
 
         if callback_read.publish_topics:
-            context_reader = AssignContextReader(node)
+            context_updater = ContextUpdater(node)
             for publish_topic in callback_read.publish_topics:
                 if callback_write.subscribe_topic_name and publish_topic is not None:
-                    context_reader.remove_callback_chain(
+                    context_updater.remove_callback_chain(
                         callback_write.subscribe_topic_name,
                         callback_write.construction_order,
                         publish_topic.topic_name,
@@ -521,7 +524,7 @@ class Architecture(Summarizable):
             node.update_node_path(
                 NodeValuesLoaded._search_node_paths(
                                     node,
-                                    context_reader,
+                                    context_updater.get_message_contexts(node),
                                     self._max_callback_construction_order_on_path_searching)
                                 )
 
@@ -709,8 +712,8 @@ class Architecture(Summarizable):
         return DiffNode(left_node, right_node).diff_node_subs()
 
 
-class AssignContextReader(ArchitectureReader):
-    """MessageContext of NodeStruct implemented version of ArchitectureReader."""
+class ContextUpdater:
+    """MessageContext updater of NodeStruct."""
 
     def __init__(self, node: NodeStruct) -> None:
         contexts = [path.message_context for path in node.paths]
@@ -761,45 +764,6 @@ class AssignContextReader(ArchitectureReader):
 
     def get_message_contexts(self, _) -> Sequence[dict]:
         return self._contexts
-
-    def get_callback_groups(self, node: NodeValue):
-        pass
-
-    def get_executors(self):
-        pass
-
-    def get_node_names_and_cb_symbols(self, callback_group_id: str):
-        pass
-
-    def get_nodes(self):
-        pass
-
-    def get_paths(self):
-        pass
-
-    def get_publishers(self, node: NodeValue):
-        pass
-
-    def get_service_callbacks(self, node: NodeValue):
-        pass
-
-    def get_services(self, node: NodeValue):
-        pass
-
-    def get_subscription_callbacks(self, node: NodeValue):
-        pass
-
-    def get_subscriptions(self, node: NodeValue):
-        pass
-
-    def get_timer_callbacks(self, node: NodeValue):
-        pass
-
-    def get_timers(self, node: NodeValue):
-        pass
-
-    def get_variable_passings(self, node: NodeValue):
-        pass
 
 
 # NOTE: DiffArchitecture may be changed when it is refactored.

--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -484,7 +484,7 @@ class NodeValuesLoaded():
             node_paths = \
                     NodeValuesLoaded._search_node_paths(
                         node_struct,
-                        reader,
+                        reader.get_message_contexts(node),
                         max_callback_construction_order_on_path_searching
                     )
             node_path_added = NodeStruct(
@@ -506,7 +506,7 @@ class NodeValuesLoaded():
     @staticmethod
     def _search_node_paths(
         node: NodeStruct,
-        reader: ArchitectureReader,
+        contexts: Sequence[dict],
         max_callback_construction_order: int
     ) -> list[NodePathStruct]:
 
@@ -587,7 +587,7 @@ class NodeValuesLoaded():
                 )
 
         message_contexts: list[MessageContextStruct] = []
-        message_contexts += list(MessageContextsLoaded(reader, node, node_paths).data)
+        message_contexts += list(MessageContextsLoaded(contexts, node, node_paths).data)
 
         # assign message context to each node paths
         node_paths = NodeValuesLoaded._message_context_assigned(
@@ -641,14 +641,13 @@ class NodeValuesLoaded():
 class MessageContextsLoaded:
     def __init__(
         self,
-        reader: ArchitectureReader,
+        context_dicts: Sequence[dict],
         node: NodeStruct,
         node_paths: Sequence[NodePathStruct]
     ) -> None:
         self._data: list[MessageContextStruct]
         data: list[MessageContextStruct] = []
 
-        context_dicts = reader.get_message_contexts(NodeValue(node.node_name, None))
         pub_sub_pairs: list[tuple[str | None, str | None]] = []
         for context_dict in context_dicts:
             try:

--- a/src/caret_analyze/architecture/util.py
+++ b/src/caret_analyze/architecture/util.py
@@ -41,7 +41,7 @@ def check_procedure(
 
     paths = NodeValuesLoaded._search_node_paths(
                                 node,
-                                reader,
+                                reader.get_message_contexts(node),
                                 app_arch._max_callback_construction_order_on_path_searching
                             )
 


### PR DESCRIPTION
## Description

AssignContextReader is a class that inherits from ArchitectureReader, but it implements almost none of ArchitectureReader's functions, making the code difficult to understand.
Delete the AssignContextReader class and change the implementation to be more in line with the actual situation.

## Related links

[https://tier4.atlassian.net/browse/RT2-1845](https://tier4.atlassian.net/browse/RT2-1845)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
