### PR TITLE
fix: setuptools version specification to requirements.txt

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-setuptools>=68.2.2
+setuptools>=68.2.2,<72.0.0
 colorcet
 pandas>=2.1.1
 bokeh>=3


### PR DESCRIPTION
## Description

Add the setuptools version specification to requirements.txt.

## Related links

[https://tier4.atlassian.net/browse/RT2-1858](https://tier4.atlassian.net/browse/RT2-1858)

## Notes for reviewers

If setuptools is already installed with privileges, you may need to run sudo pip uninstall setuptools multiple times to install the version specified in requirements.txt.

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
