### PR TITLE
fix: configuration sim_time converter

### DIFF
--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -862,6 +862,14 @@ class Lttng(InfraBase):
                     system_times_filtered.append(system_time)
                     sim_times_filtered.append(sim_time)
 
+        if (len(system_times_filtered) < 2):
+            logger.warning(
+                'Out-of-range time is used to convert sim_time, '
+                'due to no time data within the operating time of the target object.')
+            # Use all time data
+            system_times_filtered = system_times
+            sim_times_filtered = sim_times
+
         try:
             return ClockConverter.create_from_series(system_times_filtered, sim_times_filtered)
         except InvalidArgumentError:

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -854,8 +854,8 @@ class Lttng(InfraBase):
         records: RecordsInterface = self._source.system_and_sim_times
         system_times = records.get_column_series('system_time')
         sim_times = records.get_column_series('sim_time')
-        system_times_filtered = []
-        sim_times_filtered = []
+        system_times_filtered: list[int] = []
+        sim_times_filtered: list[int] = []
         for system_time, sim_time in zip(system_times, sim_times):
             if system_time is not None and sim_time is not None:
                 if min_ns <= system_time <= max_ns:
@@ -867,8 +867,8 @@ class Lttng(InfraBase):
                 'Out-of-range time is used to convert sim_time, '
                 'due to no time data within the operating time of the target object.')
             # Use all time data
-            system_times_filtered = system_times
-            sim_times_filtered = sim_times
+            system_times_filtered = [t for t in system_times if t is not None]
+            sim_times_filtered = [t for t in system_times if t is not None]
 
         try:
             return ClockConverter.create_from_series(system_times_filtered, sim_times_filtered)

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -868,7 +868,7 @@ class Lttng(InfraBase):
                 'due to no time data within the operating time of the target object.')
             # Use all time data
             system_times_filtered = [t for t in system_times if t is not None]
-            sim_times_filtered = [t for t in system_times if t is not None]
+            sim_times_filtered = [t for t in sim_times if t is not None]
 
         try:
             return ClockConverter.create_from_series(system_times_filtered, sim_times_filtered)

--- a/src/test/infra/lttng/test_latency_definitions.py
+++ b/src/test/infra/lttng/test_latency_definitions.py
@@ -2035,3 +2035,32 @@ class TestSimTimeConverter:
 
         assert converter.convert(0) - 1.0 <= 1e-6
         assert converter.convert(1) - 2.0 <= 1e-6
+
+    def test_converter_compare(
+        self,
+        create_lttng,
+    ):
+        data = Ros2DataModel()
+        # pid, tid = 4, 5
+        data.add_sim_time(100, 200)
+        data.add_sim_time(200, 300)
+        data.add_sim_time(300, 350)
+        data.add_sim_time(400, 400)
+        data.finalize()
+
+        lttng = create_lttng(data)
+        provider = RecordsProviderLttng(lttng)
+        min_ns = 100
+        max_ns = 400
+        converter = provider.get_sim_time_converter(min_ns, max_ns)
+        s100 = converter.convert(100)
+        s300 = converter.convert(300)
+        # out of range
+        min_ns = 201
+        max_ns = 299
+        converter = provider.get_sim_time_converter(min_ns, max_ns)
+        d100 = converter.convert(100)
+        d300 = converter.convert(300)
+
+        assert (s100 == d100)
+        assert (s300 == d300)

--- a/src/test/infra/lttng/test_latency_definitions.py
+++ b/src/test/infra/lttng/test_latency_definitions.py
@@ -2039,6 +2039,7 @@ class TestSimTimeConverter:
     def test_converter_compare(
         self,
         create_lttng,
+        caplog
     ):
         data = Ros2DataModel()
         # pid, tid = 4, 5
@@ -2064,3 +2065,4 @@ class TestSimTimeConverter:
 
         assert (s100 == d100)
         assert (s300 == d300)
+        assert 'Out-of-range time is used to convert sim_time' in caplog.messages[0]


### PR DESCRIPTION
## Description

If there is no time MSG in the processing time of the target object, use all time MSGs to configure the sim_time converter

## Related links

[https://tier4.atlassian.net/browse/RT2-1881](https://tier4.atlassian.net/browse/RT2-1881)

## Notes for reviewers

In caret_report, no warning messages or other logs from caret_analyze are displayed.

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
