### PR TITLE
fix: subscription take

### DIFF
--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -922,7 +922,11 @@ class RecordsProviderLttng(RuntimeDataProvider):
         if COLUMN_NAME.DDS_WRITE_TIMESTAMP in records.columns:
             columns.append(COLUMN_NAME.DDS_WRITE_TIMESTAMP)
         columns.append(COLUMN_NAME.SOURCE_TIMESTAMP)
-        columns.append(COLUMN_NAME.CALLBACK_START_TIMESTAMP)
+
+        sub_records = self._source.sub_records(callback_object, None)
+        is_take_node = len(sub_records) == 0
+        if not is_take_node:
+            columns.append(COLUMN_NAME.CALLBACK_START_TIMESTAMP)
 
         self._format(records, columns)
 
@@ -981,6 +985,10 @@ class RecordsProviderLttng(RuntimeDataProvider):
         if COLUMN_NAME.SOURCE_TIMESTAMP in records.columns:
             rename_dict[COLUMN_NAME.SOURCE_TIMESTAMP] = \
                 f'{topic_name}/{COLUMN_NAME.SOURCE_TIMESTAMP}'
+
+        if COLUMN_NAME.RMW_TAKE_TIMESTAMP in records.columns:
+            rename_dict[COLUMN_NAME.RMW_TAKE_TIMESTAMP] =\
+                f'{topic_name}/{COLUMN_NAME.RMW_TAKE_TIMESTAMP}'
 
         if COLUMN_NAME.TILDE_SUBSCRIBE_TIMESTAMP in records.columns:
             rename_dict[COLUMN_NAME.TILDE_SUBSCRIBE_TIMESTAMP] = \

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -123,17 +123,11 @@ class RecordsMerged:
     ) -> RecordsInterface:
         logger.info('Started merging path records.')
 
-        def is_source_timestamp_column(column: str) -> bool:
+        def is_match_column(column: str, target_name: str) -> bool:
             last_slash_index = column.rfind('/')
             if last_slash_index >= 0:
                 column = column[:last_slash_index]
-            return column.endswith('source_timestamp')
-
-        def is_rmw_take_column(column):
-            last_slash_index = column.rfind('/')
-            if last_slash_index >= 0:
-                column = column[:last_slash_index]
-            return column.endswith('rmw_take_timestamp')
+            return column.endswith(target_name)
 
         column_merger = ColumnMerger()
         if include_first_callback and isinstance(targets[0], NodePath):
@@ -214,39 +208,46 @@ class RecordsMerged:
                 )
 
         if include_last_callback and isinstance(targets[-1], NodePath):
-            right_records = targets[-1].to_path_end_records()
+            if not is_match_column(left_records.columns[-1], 'source_timestamp'):
+                right_records = targets[-1].to_path_end_records()
 
-            rename_rule = column_merger.append_columns_and_return_rename_rule(right_records)
-            right_records.rename_columns(rename_rule)
-            if len(right_records.data) and (left_records.columns[-1] != right_records.columns[0]):
-                raise InvalidRecordsError('left columns[-1] != right columns[0]')
-            if len(right_records.data) != 0:
-                left_records = merge(
-                    left_records=left_records,
-                    right_records=right_records,
-                    join_left_key=left_records.columns[-1],
-                    join_right_key=right_records.columns[0],
-                    columns=Columns.from_str(
-                        left_records.columns + right_records.columns
-                    ).column_names,
-                    how='left'
-                )
+                rename_rule = column_merger.append_columns_and_return_rename_rule(right_records)
+                right_records.rename_columns(rename_rule)
+                if left_records.columns[-1] != right_records.columns[0]:
+                    raise InvalidRecordsError('left columns[-1] != right columns[0]')
+                if len(right_records.data) != 0:
+                    left_records = merge(
+                        left_records=left_records,
+                        right_records=right_records,
+                        join_left_key=left_records.columns[-1],
+                        join_right_key=right_records.columns[0],
+                        columns=Columns.from_str(
+                            left_records.columns + right_records.columns
+                        ).column_names,
+                        how='left'
+                    )
+                else:
+                    msg = 'Empty records are not merged.'
+                    logger.warn(msg)
             else:
-                msg = 'If include_last_callback is True, '
-                msg += 'there are no records to merge.'
-                msg += 'It may be an exception in nature.'
+                msg = 'If the last record is a take implementation, '
+                msg += 'the path cannot be extended, so the merge process is skipped.'
                 logger.warn(msg)
 
         logger.info('Finished merging path records.')
         left_records.sort(first_column)
 
         # search drop columns, which contain 'source_timestamp'
-        source_columns = \
-            [column for column in left_records.columns if is_source_timestamp_column(column)]
+        source_columns = [
+            column for column in left_records.columns
+            if is_match_column(column, 'source_timestamp')
+        ]
         left_records.drop_columns(source_columns)
 
-        rmw_take_column = \
-            [column for column in left_records.columns if is_rmw_take_column(column)]
+        rmw_take_column = [
+            column for column in left_records.columns
+            if is_match_column(column, 'rmw_take_timestamp')
+        ]
         left_records.drop_columns(rmw_take_column)
 
         return left_records

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -163,8 +163,6 @@ class RecordsMerged:
                 right_records)
             right_records.rename_columns(rename_rule)
 
-            if is_source_timestamp_column(right_records.columns[0]):
-                left_records.drop_columns([left_records.columns[-1]])
             if left_records.columns[-1] != right_records.columns[0]:
                 raise InvalidRecordsError('left columns[-1] != right columns[0]')
 
@@ -209,7 +207,9 @@ class RecordsMerged:
                     how='left'
                 )
 
-        if include_last_callback and isinstance(targets[-1], NodePath):
+        if include_last_callback and \
+            isinstance(targets[-1], NodePath) and \
+            len(targets[-1].to_records().data):
             right_records = targets[-1].to_path_end_records()
 
             rename_rule = column_merger.append_columns_and_return_rename_rule(right_records)

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -207,16 +207,12 @@ class RecordsMerged:
                     how='left'
                 )
 
-        if (
-            include_last_callback
-            and isinstance(targets[-1], NodePath)
-            and len(targets[-1].to_records().data)
-        ):
+        if include_last_callback and isinstance(targets[-1], NodePath):
             right_records = targets[-1].to_path_end_records()
 
             rename_rule = column_merger.append_columns_and_return_rename_rule(right_records)
             right_records.rename_columns(rename_rule)
-            if left_records.columns[-1] != right_records.columns[0]:
+            if len(right_records.data) and (left_records.columns[-1] != right_records.columns[0]):
                 raise InvalidRecordsError('left columns[-1] != right columns[0]')
             if len(right_records.data) != 0:
                 left_records = merge(
@@ -230,9 +226,9 @@ class RecordsMerged:
                     how='left'
                 )
             else:
-                msg = 'include_last_callback argument is ignored '
-                msg += 'because last node receive messages '
-                msg += 'by `take` method instead of subscription callback.'
+                msg = 'If include_last_callback is True, '
+                msg += 'there are no records to merge.'
+                msg += 'It may be an exception in nature.'
                 logger.warn(msg)
 
         logger.info('Finished merging path records.')

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -247,7 +247,6 @@ class RecordsMerged:
         
         rmw_take_column = \
             [column for column in left_records.columns if is_rmw_take_column(column)]
-        # if show rmw_take_timestamp in messageflow, comment out following line.
         left_records.drop_columns(rmw_take_column)
 
         return left_records

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -129,6 +129,12 @@ class RecordsMerged:
                 column = column[:last_slash_index]
             return column.endswith('source_timestamp')
 
+        def is_rmw_take_column(column):
+            last_slash_index = column.rfind('/')
+            if last_slash_index >= 0:
+                column = column[:last_slash_index]
+            return column.endswith('rmw_take_timestamp')
+
         column_merger = ColumnMerger()
         if include_first_callback and isinstance(targets[0], NodePath):
             first_element = targets[0].to_path_beginning_records()
@@ -238,6 +244,11 @@ class RecordsMerged:
         source_columns = \
             [column for column in left_records.columns if is_source_timestamp_column(column)]
         left_records.drop_columns(source_columns)
+        
+        rmw_take_column = \
+            [column for column in left_records.columns if is_rmw_take_column(column)]
+        # if show rmw_take_timestamp in messageflow, comment out following line.
+        left_records.drop_columns(rmw_take_column)
 
         return left_records
 

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -207,9 +207,11 @@ class RecordsMerged:
                     how='left'
                 )
 
-        if include_last_callback and \
-            isinstance(targets[-1], NodePath) and \
-            len(targets[-1].to_records().data):
+        if (
+            include_last_callback
+            and isinstance(targets[-1], NodePath)
+            and len(targets[-1].to_records().data)
+        ):
             right_records = targets[-1].to_path_end_records()
 
             rename_rule = column_merger.append_columns_and_return_rename_rule(right_records)

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -230,8 +230,8 @@ class RecordsMerged:
                     msg = 'Empty records are not merged.'
                     logger.warn(msg)
             else:
-                msg = 'If the last record is a take implementation, '
-                msg += 'the path cannot be extended, so the merge process is skipped.'
+                msg = 'Since the path cannot be extended, '
+                msg += 'the merge process for the last callback record is skipped.'
                 logger.warn(msg)
 
         logger.info('Finished merging path records.')

--- a/src/test/infra/lttng/test_latency_definitions.py
+++ b/src/test/infra/lttng/test_latency_definitions.py
@@ -1381,7 +1381,6 @@ class TestCommunicationRecords:
             columns=[
                 f'{communication.topic_name}/rclcpp_publish_timestamp',
                 f'{communication.topic_name}/source_timestamp',
-                f'{callback.callback_name}/callback_start_timestamp',
             ],
             dtype='Int64'
         )

--- a/src/test/runtime/test_path.py
+++ b/src/test/runtime/test_path.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from logging import WARNING
+
 from caret_analyze.exceptions import InvalidArgumentError
 from caret_analyze.infra import RecordsProvider
 from caret_analyze.record.column import ColumnValue
@@ -798,7 +800,7 @@ class TestRecordsMerged:
             return_value=RecordsCppImpl(
                 [],
                 [
-                    ColumnValue(f'{topic1}/source_timestamp'),
+                    ColumnValue(f'{topic1}/callback_start_timestamp'),
                     ColumnValue(f'{topic1}/callback_end_timestamp'),
                 ]
             )
@@ -848,3 +850,8 @@ class TestRecordsMerged:
         )
 
         assert records.equals(expected)
+
+        caplog.set_level(WARNING)
+        expect = 'Since the path cannot be extended, '
+        expect += 'the merge process for the last callback record is skipped.'
+        assert expect in caplog.text

--- a/src/test/runtime/test_path.py
+++ b/src/test/runtime/test_path.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from logging import WARNING
-
 from caret_analyze.exceptions import InvalidArgumentError
 from caret_analyze.infra import RecordsProvider
 from caret_analyze.record.column import ColumnValue

--- a/src/test/runtime/test_path.py
+++ b/src/test/runtime/test_path.py
@@ -822,9 +822,7 @@ class TestRecordsMerged:
                         }
             if merger_mock.append_columns_and_return_rename_rule.call_count == 2:
                 return {
-                        f'{topic1}/source_timestamp': (
-                            f'{topic1}/source_timestamp/0'
-                        ),
+                        f'{topic1}/source_timestamp': f'{topic1}/source_timestamp/0',
                         f'{topic1}/callback_end_timestamp': f'{topic1}/callback_end_timestamp/0',
                         }
         mocker.patch.object(

--- a/src/test/runtime/test_path.py
+++ b/src/test/runtime/test_path.py
@@ -624,19 +624,15 @@ class TestRecordsMerged:
         def append_columns_and_return_rename_rule(records):
             if merger_mock.append_columns_and_return_rename_rule.call_count == 1:
                 return {
-                        f'{topic0}/rclcpp_publish_timestamp': (
-                            f'{topic0}/rclcpp_publish_timestamp/0'
-                        ),
-                        f'{topic0}/rcl_publish_timestamp': f'{topic0}/rcl_publish_timestamp/0',
-                        f'{topic0}/dds_write_timestamp': f'{topic0}/dds_write_timestamp/0',
-                        f'{topic0}/source_timestamp': f'{topic0}/source_timestamp/0',
-                        }
+                    f'{topic0}/rclcpp_publish_timestamp': f'{topic0}/rclcpp_publish_timestamp/0',
+                    f'{topic0}/rcl_publish_timestamp': f'{topic0}/rcl_publish_timestamp/0',
+                    f'{topic0}/dds_write_timestamp': f'{topic0}/dds_write_timestamp/0',
+                    f'{topic0}/source_timestamp': f'{topic0}/source_timestamp/0',
+                }
             if merger_mock.append_columns_and_return_rename_rule.call_count == 2:
                 return {
-                        f'{topic0}/source_timestamp': f'{topic0}/source_timestamp/0',
-                        f'{topic1}/rclcpp_publish_timestamp': (
-                            f'{topic1}/rclcpp_publish_timestamp/0'
-                        ),
+                    f'{topic0}/source_timestamp': f'{topic0}/source_timestamp/0',
+                    f'{topic1}/rclcpp_publish_timestamp': f'{topic1}/rclcpp_publish_timestamp/0',
                 }
         mocker.patch.object(
             merger_mock, 'append_columns_and_return_rename_rule',
@@ -718,25 +714,17 @@ class TestRecordsMerged:
         def append_columns_and_return_rename_rule(records):
             if merger_mock.append_columns_and_return_rename_rule.call_count == 1:
                 return {
-                        f'{topic0}/callback_start_timestamp': (
-                            f'{topic0}/callback_start_timestamp/0'
-                        ),
-                        f'{topic0}/rclcpp_publish_timestamp': (
-                            f'{topic0}/rclcpp_publish_timestamp/0'
-                        ),
+                    f'{topic0}/callback_start_timestamp': f'{topic0}/callback_start_timestamp/0',
+                    f'{topic0}/rclcpp_publish_timestamp': f'{topic0}/rclcpp_publish_timestamp/0',
                 }
             if merger_mock.append_columns_and_return_rename_rule.call_count == 2:
                 return {
-                        f'{topic0}/rclcpp_publish_timestamp': (
-                            f'{topic0}/rclcpp_publish_timestamp/0'
-                        ),
-                        f'{topic0}/rcl_publish_timestamp': f'{topic0}/rcl_publish_timestamp/0',
-                        f'{topic0}/dds_write_timestamp': f'{topic0}/dds_write_timestamp/0',
-                        f'{topic0}/source_timestamp': f'{topic0}/source_timestamp/0',
-                        f'{topic1}/callback_start_timestamp': (
-                            f'{topic1}/callback_start_timestamp/0'
-                        ),
-                        }
+                    f'{topic0}/rclcpp_publish_timestamp': f'{topic0}/rclcpp_publish_timestamp/0',
+                    f'{topic0}/rcl_publish_timestamp': f'{topic0}/rcl_publish_timestamp/0',
+                    f'{topic0}/dds_write_timestamp': f'{topic0}/dds_write_timestamp/0',
+                    f'{topic0}/source_timestamp': f'{topic0}/source_timestamp/0',
+                    f'{topic1}/callback_start_timestamp': f'{topic1}/callback_start_timestamp/0',
+                }
         mocker.patch.object(
             merger_mock, 'append_columns_and_return_rename_rule',
             side_effect=append_columns_and_return_rename_rule)
@@ -813,19 +801,16 @@ class TestRecordsMerged:
         def append_columns_and_return_rename_rule(records):
             if merger_mock.append_columns_and_return_rename_rule.call_count == 1:
                 return {
-                        f'{topic0}/rclcpp_publish_timestamp': (
-                            f'{topic0}/rclcpp_publish_timestamp/0'
-                        ),
-                        f'{topic0}/rcl_publish_timestamp': f'{topic0}/rcl_publish_timestamp/0',
-                        f'{topic0}/dds_write_timestamp': f'{topic0}/dds_write_timestamp/0',
-                        f'{topic0}/source_timestamp': f'{topic0}/source_timestamp/0',
-                        }
+                    f'{topic0}/rclcpp_publish_timestamp': f'{topic0}/rclcpp_publish_timestamp/0',
+                    f'{topic0}/rcl_publish_timestamp': f'{topic0}/rcl_publish_timestamp/0',
+                    f'{topic0}/dds_write_timestamp': f'{topic0}/dds_write_timestamp/0',
+                    f'{topic0}/source_timestamp': f'{topic0}/source_timestamp/0',
+                }
             if merger_mock.append_columns_and_return_rename_rule.call_count == 2:
                 return {
-                        f'{topic1}/callback_start_timestamp':
-                        f'{topic1}/callback_start_timestamp/0',
-                        f'{topic1}/callback_end_timestamp': f'{topic1}/callback_end_timestamp/0',
-                        }
+                    f'{topic1}/callback_start_timestamp': f'{topic1}/callback_start_timestamp/0',
+                    f'{topic1}/callback_end_timestamp': f'{topic1}/callback_end_timestamp/0',
+                }
         mocker.patch.object(
             merger_mock, 'append_columns_and_return_rename_rule',
             side_effect=append_columns_and_return_rename_rule)

--- a/src/test/runtime/test_path.py
+++ b/src/test/runtime/test_path.py
@@ -839,8 +839,6 @@ class TestRecordsMerged:
         merged = RecordsMerged([comm_path, node_path], include_last_callback=True)
         records = merged.data
 
-        df = records.to_dataframe()
-
         expected = RecordsCppImpl(
             [
                 RecordCppImpl({

--- a/src/test/runtime/test_path.py
+++ b/src/test/runtime/test_path.py
@@ -822,7 +822,9 @@ class TestRecordsMerged:
                         }
             if merger_mock.append_columns_and_return_rename_rule.call_count == 2:
                 return {
-                        f'{topic1}/source_timestamp': f'{topic1}/source_timestamp/0',
+                        f'{topic1}/callback_start_timestamp': (
+                            f'{topic1}/callback_start_timestamp/0'
+                        ),
                         f'{topic1}/callback_end_timestamp': f'{topic1}/callback_end_timestamp/0',
                         }
         mocker.patch.object(

--- a/src/test/runtime/test_path.py
+++ b/src/test/runtime/test_path.py
@@ -777,7 +777,6 @@ class TestRecordsMerged:
                         f'{topic0}/rcl_publish_timestamp': 2,
                         f'{topic0}/dds_write_timestamp': 3,
                         f'{topic0}/source_timestamp': 4,
-                        f'{topic1}/callback_start_timestamp': 5
                     }),
                 ],
                 [
@@ -785,7 +784,6 @@ class TestRecordsMerged:
                     ColumnValue(f'{topic0}/rcl_publish_timestamp'),
                     ColumnValue(f'{topic0}/dds_write_timestamp'),
                     ColumnValue(f'{topic0}/source_timestamp'),
-                    ColumnValue(f'{topic1}/callback_start_timestamp'),
                 ]
             )
         )
@@ -800,7 +798,7 @@ class TestRecordsMerged:
             return_value=RecordsCppImpl(
                 [],
                 [
-                    ColumnValue(f'{topic1}/callback_start_timestamp'),
+                    ColumnValue(f'{topic1}/source_timestamp'),
                     ColumnValue(f'{topic1}/callback_end_timestamp'),
                 ]
             )
@@ -819,14 +817,11 @@ class TestRecordsMerged:
                         f'{topic0}/rcl_publish_timestamp': f'{topic0}/rcl_publish_timestamp/0',
                         f'{topic0}/dds_write_timestamp': f'{topic0}/dds_write_timestamp/0',
                         f'{topic0}/source_timestamp': f'{topic0}/source_timestamp/0',
-                        f'{topic1}/callback_start_timestamp': (
-                            f'{topic1}/callback_start_timestamp/0'
-                        ),
                         }
             if merger_mock.append_columns_and_return_rename_rule.call_count == 2:
                 return {
-                        f'{topic1}/callback_start_timestamp': (
-                            f'{topic1}/callback_start_timestamp/0'
+                        f'{topic1}/source_timestamp': (
+                            f'{topic1}/source_timestamp/0'
                         ),
                         f'{topic1}/callback_end_timestamp': f'{topic1}/callback_end_timestamp/0',
                         }
@@ -843,15 +838,12 @@ class TestRecordsMerged:
                     f'{topic0}/rclcpp_publish_timestamp/0': 1,
                     f'{topic0}/rcl_publish_timestamp/0': 2,
                     f'{topic0}/dds_write_timestamp/0': 3,
-                    f'{topic1}/callback_start_timestamp/0': 5,
-
                 }),
             ],
             [
                 ColumnValue(f'{topic0}/rclcpp_publish_timestamp/0'),
                 ColumnValue(f'{topic0}/rcl_publish_timestamp/0'),
                 ColumnValue(f'{topic0}/dds_write_timestamp/0'),
-                ColumnValue(f'{topic1}/callback_start_timestamp/0'),
             ]
         )
 

--- a/src/test/runtime/test_path.py
+++ b/src/test/runtime/test_path.py
@@ -822,9 +822,8 @@ class TestRecordsMerged:
                         }
             if merger_mock.append_columns_and_return_rename_rule.call_count == 2:
                 return {
-                        f'{topic1}/callback_start_timestamp': (
-                            f'{topic1}/callback_start_timestamp/0'
-                        ),
+                        f'{topic1}/callback_start_timestamp':
+                        f'{topic1}/callback_start_timestamp/0',
                         f'{topic1}/callback_end_timestamp': f'{topic1}/callback_end_timestamp/0',
                         }
         mocker.patch.object(


### PR DESCRIPTION
## Description

Modify the following two points
* If all callback_start_timestamp columns are empty in the Communication just before take implementation, remove them.
* rmw_take with topic name qualification.

## Related links

[https://tier4.atlassian.net/browse/RT2-1838](https://tier4.atlassian.net/browse/RT2-1838)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
