### PR TITLE
fix: setuptools version

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-setuptools>=68.2.2,<72.0.0
+setuptools>=68.2.2
 colorcet
 pandas>=2.1.1
 bokeh>=3


### PR DESCRIPTION
## Description

Revert the setuptools version specification back to the previous setuptools>=68.2.2.

## Related links

[https://tier4.atlassian.net/browse/RT2-1951](https://tier4.atlassian.net/browse/RT2-1951)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
