### PR TITLE
fix: exclude "struct/__init__.py" from test_frake8.py

### DIFF
--- a/src/test/test_flake8.py
+++ b/src/test/test_flake8.py
@@ -19,7 +19,8 @@ import pytest
 @pytest.mark.flake8
 @pytest.mark.linter
 def test_flake8():
-    rc, errors = main_with_errors(argv=[])
+    ignore_files = 'src/caret_analyze/architecture/struct/__init__.py'
+    rc, errors = main_with_errors(argv=[f'--exclude={ignore_files}'])
     assert rc == 0, 'Found %d code style errors / warnings:\n' % len(
         errors
     ) + '\n'.join(errors)


### PR DESCRIPTION
## Description

Exclude struct/__init__.py from test_frake8.py.

## Related links

[https://tier4.atlassian.net/browse/RT2-1985](https://tier4.atlassian.net/browse/RT2-1985)

## Notes for reviewers

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
