### PR TITLE
fix: use default value if no key registration

### DIFF
--- a/src/caret_analyze/infra/lttng/event_counter.py
+++ b/src/caret_analyze/infra/lttng/event_counter.py
@@ -254,7 +254,7 @@ class EventCounter:
                 node_handle_to_node_name.get(row['node_handle'], '-')
             sub_handle_to_topic_name[handler] = row['topic_name']
             rmw_handle_to_node_name[row['rmw_handle']] = \
-                node_handle_to_node_name.get([row['node_handle']], '-')
+                node_handle_to_node_name.get(row['node_handle'], '-')
             rmw_handle_to_topic_name[row['rmw_handle']] = row['topic_name']
 
         for handler, row in data.timer_node_links.df.iterrows():

--- a/src/caret_analyze/infra/lttng/event_counter.py
+++ b/src/caret_analyze/infra/lttng/event_counter.py
@@ -254,7 +254,7 @@ class EventCounter:
                 node_handle_to_node_name.get(row['node_handle'], '-')
             sub_handle_to_topic_name[handler] = row['topic_name']
             rmw_handle_to_node_name[row['rmw_handle']] = \
-                node_handle_to_node_name[row['node_handle']]
+                node_handle_to_node_name.get([row['node_handle']], '-')
             rmw_handle_to_topic_name[row['rmw_handle']] = row['topic_name']
 
         for handler, row in data.timer_node_links.df.iterrows():


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Use default value if no key is registered in `event_counter.py`

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
