### PR TITLE
fix: fixed merge timestamp_key for nodes that get messages by take() on user code

### DIFF
--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1379,9 +1379,11 @@ class NodeRecordsUseLatestMessage:
             f'{self._node_path.publish_topic_name}/rclcpp_publish_timestamp',
         ]
         left_key = sub_records.columns[0]
-        if COLUMN_NAME.RMW_TAKE_TIMESTAMP in columns:
-            columns.remove(COLUMN_NAME.RMW_TAKE_TIMESTAMP)
-            left_key = COLUMN_NAME.RMW_TAKE_TIMESTAMP
+        for column in sub_records.columns:
+            if column.endswith(COLUMN_NAME.RMW_TAKE_TIMESTAMP):
+                columns.remove(column)
+                left_key = column
+                break
 
         pub_sub_records = merge_sequential(
             left_records=sub_records,

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -921,12 +921,10 @@ class RecordsProviderLttng(RuntimeDataProvider):
             columns.append(COLUMN_NAME.RCL_PUBLISH_TIMESTAMP)
         if COLUMN_NAME.DDS_WRITE_TIMESTAMP in records.columns:
             columns.append(COLUMN_NAME.DDS_WRITE_TIMESTAMP)
-        columns.append(COLUMN_NAME.SOURCE_TIMESTAMP)
-
-        sub_records = self._source.sub_records(callback_object, None)
-        is_take_node = len(sub_records) == 0
-        if not is_take_node:
-            columns.append(COLUMN_NAME.CALLBACK_START_TIMESTAMP)
+        columns += [
+            COLUMN_NAME.SOURCE_TIMESTAMP,
+            COLUMN_NAME.CALLBACK_START_TIMESTAMP,
+        ]
 
         self._format(records, columns)
 

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1379,11 +1379,15 @@ class NodeRecordsUseLatestMessage:
             f'{self._node_path.publish_topic_name}/rclcpp_publish_timestamp',
         ]
         left_key = sub_records.columns[0]
-        for column in sub_records.columns:
-            if column.endswith(COLUMN_NAME.RMW_TAKE_TIMESTAMP):
-                columns.remove(column)
-                left_key = column
-                break
+
+        # Set left_key to rmw_take timestamp
+        # if sub_records are obtained by RecordsProviderLttng.subscription_take_records()
+        if is_take_node:
+            for column in sub_records.columns:
+                if column.endswith(COLUMN_NAME.RMW_TAKE_TIMESTAMP):
+                    columns.remove(column)
+                    left_key = column
+                    break
 
         pub_sub_records = merge_sequential(
             left_records=sub_records,

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -163,11 +163,9 @@ class RecordsMerged:
                 right_records)
             right_records.rename_columns(rename_rule)
 
-            # remove columns from included in communications not via callback
-            if is_match_column(right_records.columns[-1], 'callback_start_timestamp') and \
-                    all(x is None for x
-                        in right_records.get_column_series(right_records.columns[-1])):
-                right_records.drop_columns([right_records.columns[-1]])
+            # adjust the columns for the case that the message is not taken by callback
+            if is_match_column(right_records.columns[0], 'source_timestamp'):
+                left_records.drop_columns([left_records.columns[-1]])
 
             if left_records.columns[-1] != right_records.columns[0]:
                 raise InvalidRecordsError('left columns[-1] != right columns[0]')

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -163,6 +163,11 @@ class RecordsMerged:
                 right_records)
             right_records.rename_columns(rename_rule)
 
+            # remove columns from included in communications not via callback
+            if is_match_column(right_records.columns[-1], 'callback_start_timestamp') and \
+                    all(x is None for x in right_records.get_column_series(right_records.columns[-1])):
+                right_records.drop_columns([right_records.columns[-1]])
+
             if left_records.columns[-1] != right_records.columns[0]:
                 raise InvalidRecordsError('left columns[-1] != right columns[0]')
 

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -165,7 +165,8 @@ class RecordsMerged:
 
             # remove columns from included in communications not via callback
             if is_match_column(right_records.columns[-1], 'callback_start_timestamp') and \
-                    all(x is None for x in right_records.get_column_series(right_records.columns[-1])):
+                    all(x is None for x
+                        in right_records.get_column_series(right_records.columns[-1])):
                 right_records.drop_columns([right_records.columns[-1]])
 
             if left_records.columns[-1] != right_records.columns[0]:

--- a/src/test/infra/lttng/test_latency_definitions.py
+++ b/src/test/infra/lttng/test_latency_definitions.py
@@ -1381,6 +1381,7 @@ class TestCommunicationRecords:
             columns=[
                 f'{communication.topic_name}/rclcpp_publish_timestamp',
                 f'{communication.topic_name}/source_timestamp',
+                f'{callback.callback_name}/callback_start_timestamp',
             ],
             dtype='Int64'
         )

--- a/src/test/infra/lttng/test_records_provider_lttng.py
+++ b/src/test/infra/lttng/test_records_provider_lttng.py
@@ -608,18 +608,18 @@ class TestNodeRecordsUseLatestMessage:
         take_records_data = [
             RecordCppImpl({
                 f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 1,
-                COLUMN_NAME.RMW_TAKE_TIMESTAMP: 2,
+                f'{topic_name_1}/{COLUMN_NAME.RMW_TAKE_TIMESTAMP}': 2,
             }),
             RecordCppImpl({
                 f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}': 6,
-                COLUMN_NAME.RMW_TAKE_TIMESTAMP: 7,
+                f'{topic_name_1}/{COLUMN_NAME.RMW_TAKE_TIMESTAMP}': 7,
             }),
         ]
         take_records = RecordsCppImpl(
             take_records_data,
             [
                 ColumnValue(f'{topic_name_1}/{COLUMN_NAME.SOURCE_TIMESTAMP}'),
-                ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
+                ColumnValue(f'{topic_name_1}/{COLUMN_NAME.RMW_TAKE_TIMESTAMP}'),
             ]
         )
 

--- a/src/test/runtime/test_path.py
+++ b/src/test/runtime/test_path.py
@@ -596,6 +596,7 @@ class TestRecordsMerged:
                     ColumnValue(f'{topic0}/rcl_publish_timestamp'),
                     ColumnValue(f'{topic0}/dds_write_timestamp'),
                     ColumnValue(f'{topic0}/source_timestamp'),
+                    ColumnValue(f'{topic0}/callback_start_timestamp'),
                 ]
             )
         )


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Fixed merge method for nodes that get messages by take() on user code.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

- [TIERIV INTERNAL LINK](https://tier4.atlassian.net/browse/RT2-2081)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
