### PR TITLE
fix: error occurs when multiple types of input are given to create frequency timeseries plot

### DIFF
--- a/src/caret_analyze/plot/visualize_lib/bokeh/timeseries.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/timeseries.py
@@ -83,19 +83,26 @@ class BokehTimeSeries:
         # Draw lines
         color_selector = ColorSelectorFactory.create_instance(coloring_rule='unique')
         legend_manager = LegendManager()
-        if converter:
-            line_source = \
-                LineSource(legend_manager, target_objects[0], frame_min_convert, self._xaxis_type)
-        else:
-            line_source = \
-                LineSource(legend_manager, target_objects[0], frame_min, self._xaxis_type)
-        fig.add_tools(line_source.create_hover())
+
+        num = 0
         for to, timeseries in zip(target_objects, timeseries_records_list):
+            if converter:
+                line_source = \
+                    LineSource(legend_manager, target_objects[num],
+                               frame_min_convert, self._xaxis_type)
+            else:
+                line_source = \
+                    LineSource(legend_manager, target_objects[num], frame_min, self._xaxis_type)
+            num = num + 1
+
             renderer = fig.line(
                 'x', 'y',
                 source=line_source.generate(to, timeseries),
                 color=color_selector.get_color()
             )
+            hover = line_source.create_hover()
+            hover.renderers = [renderer]
+            fig.add_tools(hover)
             legend_manager.add_legend(to, renderer)
 
         # Draw legends

--- a/src/caret_analyze/plot/visualize_lib/bokeh/timeseries.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/timeseries.py
@@ -84,25 +84,21 @@ class BokehTimeSeries:
         color_selector = ColorSelectorFactory.create_instance(coloring_rule='unique')
         legend_manager = LegendManager()
 
-        num = 0
         for to, timeseries in zip(target_objects, timeseries_records_list):
             if converter:
                 line_source = \
-                    LineSource(legend_manager, target_objects[num],
+                    LineSource(legend_manager, to,
                                frame_min_convert, self._xaxis_type)
             else:
                 line_source = \
-                    LineSource(legend_manager, target_objects[num], frame_min, self._xaxis_type)
-            num = num + 1
+                    LineSource(legend_manager, to, frame_min, self._xaxis_type)
 
             renderer = fig.line(
                 'x', 'y',
                 source=line_source.generate(to, timeseries),
                 color=color_selector.get_color()
             )
-            hover = line_source.create_hover()
-            hover.renderers = [renderer]
-            fig.add_tools(hover)
+            fig.add_tools(line_source.create_hover({'renderers': [renderer]}))
             legend_manager.add_legend(to, renderer)
 
         # Draw legends


### PR DESCRIPTION
## Description

An error occurs when multiple types of input are given to create_frequency_timeseries_plot().

## Related links

https://tier4.atlassian.net/browse/RT2-2126

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
