### PR TITLE
refactor: replace logger.warn() to logger.warning()

### DIFF
--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -291,7 +291,7 @@ class NodeValuesLoaded():
         try:
             self._validate(nodes)
         except InvalidReaderError as e:
-            logger.warn(e)
+            logger.warning(e)
 
         nodes = self._remove_duplicated(nodes)
 
@@ -306,7 +306,7 @@ class NodeValuesLoaded():
                 self._cb_loaded.append(cb_loaded)
                 self._cbg_loaded.append(cbg_loaded)
             except Error as e:
-                logger.warn(f'Failed to load node. node_name = {node.node_name}, {e}')
+                logger.warning(f'Failed to load node. node_name = {node.node_name}, {e}')
 
         nodes_struct = sorted(nodes_struct, key=lambda x: x.node_name)
         self._data = nodes_struct
@@ -833,7 +833,7 @@ class SubscriptionsLoaded:
         try:
             self._validate(subscription_values)
         except InvalidReaderError as e:
-            logger.warn(e)
+            logger.warning(e)
 
         subscription_values = self._remove_duplicated(subscription_values)
 
@@ -905,7 +905,7 @@ class ServicesLoaded:
         try:
             self._validate(services_values)
         except InvalidReaderError as e:
-            logger.warn(e)
+            logger.warning(e)
 
         services_values = self._remove_duplicated(services_values)
 
@@ -978,7 +978,7 @@ class TimersLoaded:
         try:
             self._validate(timer_values)
         except InvalidReaderError as e:
-            logger.warn(e)
+            logger.warning(e)
 
         timer_values = self._remove_duplicated(timer_values)
 
@@ -1129,7 +1129,7 @@ class CallbackGroupsLoaded():
                 duplicated_names.add(cbg_name)
                 self._data[cbg.callback_group_id] = cbg_struct
             except InvalidReaderError as e:
-                logger.warn(e)
+                logger.warning(e)
 
     @staticmethod
     def _validate_name(name: str, names: set[str]):
@@ -1387,7 +1387,7 @@ class ExecutorValuesLoaded():
         try:
             self._validate(exec_vals)
         except InvalidReaderError as e:
-            logger.warn(e)
+            logger.warning(e)
         exec_vals = self._remove_duplicated(exec_vals)
 
         num_digit = Util.num_digit(len(exec_vals))
@@ -1497,7 +1497,7 @@ class PathValuesLoaded():
         try:
             self._validate(path_values)
         except InvalidReaderError as e:
-            logger.warn(e)
+            logger.warning(e)
 
         path_values = self._remove_duplicated(path_values)
 
@@ -1615,7 +1615,7 @@ class CallbackPathSearched():
                 paths += searched_paths
 
             if skip_count:
-                logger.warn(
+                logger.warning(
                     f'{node.node_name} '
                     f'contains callbacks whose construction_order are greater than '
                     f'{max_callback_construction_order}. '

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -232,7 +232,7 @@ class RecordsMerged:
                     )
                 else:
                     msg = 'Empty records are not merged.'
-                    logger.warn(msg)
+                    logger.warning(msg)
             else:
                 msg = 'Since the path cannot be extended, '
                 msg += 'the merge process for the last callback record is skipped.'

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -157,7 +157,7 @@ class RecordsMerged:
                     logger.info(msg)
                 else:
                     msg = 'Detected dummy_records before merging end_records. merge terminated.'
-                    logger.warn(msg)
+                    logger.warning(msg)
                 break
             rename_rule = column_merger.append_columns_and_return_rename_rule(
                 right_records)
@@ -231,7 +231,7 @@ class RecordsMerged:
                 msg = 'include_last_callback argument is ignored '
                 msg += 'because last node receive messages '
                 msg += 'by `take` method instead of subscription callback.'
-                logger.warn(msg)
+                logger.warning(msg)
 
         logger.info('Finished merging path records.')
         left_records.sort(first_column)

--- a/src/package.xml
+++ b/src/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>caret_analyze</name>
-  <version>0.5.10</version>
+  <version>0.5.11</version>
   <description>CARET's tools for analyzing trace results</description>
   <maintainer email="yamasaki@isp.co.jp">ymski</maintainer>
   <maintainer email="uetsuki@isp.co.jp">isp-uetsuki</maintainer>

--- a/src/test/architecture/test_architecture_loader.py
+++ b/src/test/architecture/test_architecture_loader.py
@@ -1199,7 +1199,7 @@ class TestCallbacksLoaded:
         with pytest.raises(InvalidReaderError) as e:
             CallbacksLoaded(reader_mock, node)
 
-        logger.warn(e)
+        logger.warning(e)
         assert 'Duplicated callback id.' in caplog.messages[0]
 
     def test_duplicated_callback_name_cl(self, mocker, caplog):
@@ -1236,7 +1236,7 @@ class TestCallbacksLoaded:
         with pytest.raises(InvalidReaderError) as e:
             CallbacksLoaded(reader_mock, node)
 
-        logger.warn(e)
+        logger.warning(e)
         assert 'Duplicated callback names.' in caplog.messages[0]
 
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

logger.warn() will be deprecated and cause warning message.
Therefore it has been replaced with logger.warning()

I run `pytest-3 test` and confirmed that the following messages disappeared.
```
src/test/architecture/test_architecture_loader.py::TestSubscriptionsLoaded::test_duplicated_subscription_name
  /home/takahisaishikawa/caret_ws/ros2_caret_ws/src/CARET/caret_analyze/src/caret_analyze/architecture/architecture_loaded.py:836: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    logger.warn(e)
```

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
