### PR TITLE
fix: exclude 3.7.0 from bokeh installation

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,7 @@
 setuptools>=68.2.2
 colorcet
 pandas>=2.1.1
-bokeh>=3
+bokeh>=3,!=3.7.0
 graphviz
 types-pyyaml
 pydantic>=1.9.0


### PR DESCRIPTION
## Description

bokeh 3.7.0 has been released, but type checking does not pass in the python 3.10 environment. For this reason, the installation of 3.7.0 is excluded.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

[https://tier4.atlassian.net/browse/RT2-2235](https://tier4.atlassian.net/browse/RT2-2235)

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
