### PR TITLE
chore: exclude bokeh 3.7 to avoid type hint problems

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,7 @@
 setuptools>=68.2.2
 colorcet
 pandas>=2.1.1
-bokeh>=3,!=3.7.0
+bokeh>=3,<3.7.0
 graphviz
 types-pyyaml
 pydantic>=1.9.0


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

The github release of bokeh 3.7.0 fixes a function problem with type hints in python 3.10. On the other hand, it turns out that the pip-installed bokeh 3.7.0 and 3.7.1 still have the type hinting problem. We will temporarily remove support for bokeh 3.7 and later versions until we can confirm that the problem has been resolved.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
- https://github.com/tier4/caret_analyze/pull/556

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
