### PR TITLE
refactor: frequency calculation logic

### DIFF
--- a/src/caret_analyze/record/records_service/frequency.py
+++ b/src/caret_analyze/record/records_service/frequency.py
@@ -139,7 +139,7 @@ class Frequency:
             convert_vector = np.vectorize(converter.convert)
             timestamp_array = np.round(convert_vector(timestamp_array)).astype(np.int64)
 
-        timestamp_array = timestamp_array[timestamp_array >= base_timestamp]        
+        timestamp_array = timestamp_array[timestamp_array >= base_timestamp]
         if len(timestamp_array) == 0:
             return [base_timestamp], [0]
 

--- a/src/caret_analyze/record/records_service/frequency.py
+++ b/src/caret_analyze/record/records_service/frequency.py
@@ -98,9 +98,8 @@ class Frequency:
             - {frequency_column}
 
         """
-        records = self._create_empty_records()
         if not self._target_timestamps:
-            return records
+            return self._create_empty_records()
         
         if base_timestamp is None:
             base_timestamp = self._target_timestamps[0]
@@ -113,21 +112,17 @@ class Frequency:
             until_timestamp,
             converter=converter
         )
+
+        records = self._create_empty_records()
         for ts, freq in zip(timestamp_list, frequency_list):
-            record = {
-                self._target_column: ts,
-                'frequency': freq
-            }
+            record = {self._target_column: ts, 'frequency': freq}
             records.append(record)
 
         return records
 
-    def _create_empty_records(
-        self
-    ) -> RecordsInterface:
-        return RecordsFactory.create_instance(None, columns=[
-            ColumnValue(self._target_column), ColumnValue('frequency')
-        ])
+    def _create_empty_records(self) -> RecordsInterface:
+        columns = [ColumnValue(self._target_column), ColumnValue('frequency')]
+        return RecordsFactory.create_instance(None, columns=columns)
 
     def _get_frequency_with_timestamp(
         self,

--- a/src/caret_analyze/record/records_service/frequency.py
+++ b/src/caret_analyze/record/records_service/frequency.py
@@ -16,12 +16,13 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+import numpy as np
+
 from ..column import ColumnValue
 from ..interface import RecordsInterface
 from ..record_factory import RecordsFactory
 from ...common import ClockConverter
 
-import numpy as np
 
 class Frequency:
 
@@ -100,7 +101,7 @@ class Frequency:
         """
         if not self._target_timestamps:
             return self._create_empty_records()
-        
+
         if base_timestamp is None:
             base_timestamp = self._target_timestamps[0]
         if until_timestamp is None:
@@ -135,7 +136,8 @@ class Frequency:
         if converter:
             base_timestamp = round(converter.convert(base_timestamp))
             until_timestamp = round(converter.convert(until_timestamp))
-            timestamp_array = np.round(np.vectorize(converter.convert)(timestamp_array)).astype(np.int64)
+            convert_vector = np.vectorize(converter.convert)
+            timestamp_array = np.round(convert_vector(timestamp_array)).astype(np.int64)
 
         timestamp_array = timestamp_array[timestamp_array >= base_timestamp]        
         if len(timestamp_array) == 0:
@@ -149,5 +151,5 @@ class Frequency:
 
         interval_start_time_array = np.arange(len(frequency_list)) * interval_ns + base_timestamp
         timestamp_list = interval_start_time_array.tolist()
-  
+
         return timestamp_list, frequency_list


### PR DESCRIPTION
## Description

This PR simplifies the frequency calculation logic by using numpy.

## Related links

## Notes for reviewers

Testing was done by running the existing test suite.
```
~/caret_ws/ros2_caret_ws/src/CARET/caret_analyze/src$ pytest-3 test/record/records_service/test_frequency.py -s
```

For all unit test, there is only 1 failure related to flake8 test. But they are not warnings for `frequency.py`
```
~/caret_ws/ros2_caret_ws/src/CARET/caret_analyze/src$ pytest-3 test
```

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
