### PR TITLE
refactor: plot frequency timeseries

### DIFF
--- a/src/caret_analyze/plot/timeseries/frequency_timeseries.py
+++ b/src/caret_analyze/plot/timeseries/frequency_timeseries.py
@@ -20,7 +20,7 @@ import pandas as pd
 
 from ..metrics_base import MetricsBase
 from ..util import get_clock_converter
-from ...common import ClockConverter, Util
+from ...common import Util
 from ...record import Frequency, RecordsInterface
 from ...runtime import CallbackBase, Communication, Publisher, Subscription
 
@@ -99,7 +99,7 @@ class FrequencyTimeSeries(MetricsBase):
             return []
         if isinstance(self._target_objects[0], CallbackBase) is False:
             target_type = type(self._target_objects[0])
-            raise TypeError(f"Invalid type of target object: {target_type}")
+            raise TypeError(f'Invalid type of target object: {target_type}')
 
         timeseries_records_list: list[RecordsInterface] = [
             obj.to_records() for obj in self._target_objects

--- a/src/caret_analyze/plot/timeseries/frequency_timeseries.py
+++ b/src/caret_analyze/plot/timeseries/frequency_timeseries.py
@@ -106,7 +106,7 @@ class FrequencyTimeSeries(MetricsBase):
         ]
         columns = timeseries_records_list[0].columns
 
-        def row_filter_communication(record: RecordsInterface) -> bool:
+        def row_filter_communication(record) -> bool:
             """Return True only if communication is established."""
             comm_start_column = columns[0]
             comm_end_column = columns[1]

--- a/src/caret_analyze/plot/timeseries/frequency_timeseries.py
+++ b/src/caret_analyze/plot/timeseries/frequency_timeseries.py
@@ -95,28 +95,31 @@ class FrequencyTimeSeries(MetricsBase):
             Frequency records list of all target objects.
 
         """
-        if self._target_objects and isinstance(self._target_objects[0], Communication):
-            columns = self._target_objects[0].to_records().columns
-            start_column = columns[0]
-            end_column = columns[1]
-
-            def row_filter_communication(record) -> bool:
-                """Return True only if communication is established."""
-                comm_start_column = start_column
-                comm_end_column = end_column
-                if (record.data.get(comm_start_column) is not None
-                        and record.data.get(comm_end_column) is not None):
-                    return True
-                else:
-                    return False
+        if len(self._target_objects) == 0:
+            return []
+        if isinstance(self._target_objects[0], CallbackBase) is False:
+            target_type = type(self._target_objects[0])
+            raise TypeError(f"Invalid type of target object: {target_type}")
 
         timeseries_records_list: list[RecordsInterface] = [
-            _.to_records() for _ in self._target_objects
+            obj.to_records() for obj in self._target_objects
         ]
+        columns = timeseries_records_list[0].columns
 
-        converter: ClockConverter | None = None
+        def row_filter_communication(record: RecordsInterface) -> bool:
+            """Return True only if communication is established."""
+            comm_start_column = columns[0]
+            comm_end_column = columns[1]
+            if record.data.get(comm_start_column) is None:
+                return False
+            if record.data.get(comm_end_column) is None:
+                return False
+            return True
+
         if xaxis_type == 'sim_time':
             converter = get_clock_converter(self._target_objects)
+        else:
+            converter = None
 
         min_time, max_time = self._get_timestamp_range(timeseries_records_list)
 
@@ -127,10 +130,12 @@ class FrequencyTimeSeries(MetricsBase):
                 row_filter=row_filter_communication
                 if isinstance(records, Communication) else None
             )
-            frequency_timeseries_list.append(frequency.to_records(
-                base_timestamp=min_time, until_timestamp=max_time,
+            frequency_record = frequency.to_records(
+                base_timestamp=min_time,
+                until_timestamp=max_time,
                 converter=converter
-            ))
+            )
+            frequency_timeseries_list.append(frequency_record)
 
         return frequency_timeseries_list
 

--- a/src/test/plot/timeseries/test_frequency_timeseries.py
+++ b/src/test/plot/timeseries/test_frequency_timeseries.py
@@ -15,6 +15,8 @@
 from caret_analyze.plot.timeseries.frequency_timeseries import FrequencyTimeSeries
 from caret_analyze.record import ColumnValue
 from caret_analyze.record.record_factory import RecordFactory, RecordsFactory
+from caret_analyze.runtime.callback import CallbackBase
+import pandas as pd
 
 
 def create_expect_records(records_raw):
@@ -29,7 +31,7 @@ def create_expect_records(records_raw):
     return records
 
 
-class TestFrequencyTimeSeries:
+class TestGetTimestampRange:
 
     def test_get_timestamp_range_normal(self, mocker):
         records0 = create_expect_records([
@@ -90,3 +92,45 @@ class TestFrequencyTimeSeries:
 
         assert min_ts == 0
         assert max_ts == 1
+
+
+
+def create_sample_record(record_raw_list: list[dict]) -> RecordsFactory:
+    records = RecordsFactory.create_instance()
+    columns = [ColumnValue(key) for key in record_raw_list[0].keys()]
+    for column in columns:
+        records.append_column(column, [])
+
+    for record_raw in record_raw_list:
+        record = RecordFactory.create_instance(record_raw)
+        records.append(record)
+    return records
+
+
+class TestFrequencyTimeSeries:
+    def test_sample_record_to_dataframe(self, mocker):
+        records = create_sample_record([
+                {'timestamp': 1, 'some_data': 2},
+                {'timestamp': 2, 'some_data': 3}
+        ])
+        except_freq_df = pd.DataFrame(
+            data=[
+                {'timestamp [ns]': 1, 'frequency [Hz]': 2}
+            ]
+        )
+
+        cb_mock = mocker.Mock(spec=CallbackBase)
+        mocker.patch.object(cb_mock, 'to_records', return_value=records)
+        mocker.patch.object(cb_mock, 'column_names', ['timestamp', 'some_data'])
+
+        # Check if mock works as expected
+        assert cb_mock.to_records() == records
+        assert cb_mock.column_names == ['timestamp', 'some_data']
+
+        frequency_timeseries = FrequencyTimeSeries([cb_mock])
+
+        actual_df = frequency_timeseries.to_dataframe('timestamp')
+        actual_df.columns = actual_df.columns.droplevel(0) # MultiIndex to single index
+
+        actual_df = actual_df.astype(except_freq_df.dtypes.to_dict())  # Type conversion
+        assert actual_df.equals(except_freq_df)

--- a/src/test/plot/timeseries/test_frequency_timeseries.py
+++ b/src/test/plot/timeseries/test_frequency_timeseries.py
@@ -94,7 +94,6 @@ class TestGetTimestampRange:
         assert max_ts == 1
 
 
-
 def create_sample_record(record_raw_list: list[dict]) -> RecordsFactory:
     records = RecordsFactory.create_instance()
     columns = [ColumnValue(key) for key in record_raw_list[0].keys()]
@@ -108,6 +107,7 @@ def create_sample_record(record_raw_list: list[dict]) -> RecordsFactory:
 
 
 class TestFrequencyTimeSeries:
+
     def test_sample_record_to_dataframe(self, mocker):
         records = create_sample_record([
                 {'timestamp': 1, 'some_data': 2},
@@ -130,7 +130,7 @@ class TestFrequencyTimeSeries:
         frequency_timeseries = FrequencyTimeSeries([cb_mock])
 
         actual_df = frequency_timeseries.to_dataframe('timestamp')
-        actual_df.columns = actual_df.columns.droplevel(0) # MultiIndex to single index
+        actual_df.columns = actual_df.columns.droplevel(0)  # MultiIndex to single index
 
         actual_df = actual_df.astype(except_freq_df.dtypes.to_dict())  # Type conversion
         assert actual_df.equals(except_freq_df)


### PR DESCRIPTION
## Description

This PR add test for `FrequencyTimeSeries.to_timeseries_records_list()` and refactor `to_timeseries_records_list()`


## Related links

## Notes for reviewers

You can run added test with following command.
```
~/caret_ws/ros2_caret_ws/src/CARET/caret_analyze/src$ source ~/caret_ws/ros2_caret_ws/install/local_setup.bash 
~/caret_ws/ros2_caret_ws/src/CARET/caret_analyze/src$  pytest-3 test/plot/timeseries/test_frequency_timeseries.py 
```

I also checked that all test was passed except test_mypy linter test. But it is related to numpy version, so that is not related to this change.
```
~/caret_ws/ros2_caret_ws/src/CARET/caret_analyze/src$ source ~/caret_ws/ros2_caret_ws/install/local_setup.bash 
~/caret_ws/ros2_caret_ws/src/CARET/caret_analyze/src$  pytest-3 test
```

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
