### PR TITLE
feat: calculate frequency computing offset

### DIFF
--- a/src/caret_analyze/plot/timeseries/frequency_timeseries.py
+++ b/src/caret_analyze/plot/timeseries/frequency_timeseries.py
@@ -63,6 +63,8 @@ def _get_frequency_computing_timestamp_offset_ns(timeseries_record: RecordsInter
         return 0
 
     # Calculate timestamp offset
+    # Approximate period estimation using the first two timestamps.
+    # Accuracy is not critical, as the offset only needs to prevent boundary collisions.
     timestamp_diff = int(timestamp_list[1]) - int(timestamp_list[0])
     timestamp_offset_ns = int(timestamp_diff / 2)
     return timestamp_offset_ns

--- a/src/caret_analyze/plot/timeseries/frequency_timeseries.py
+++ b/src/caret_analyze/plot/timeseries/frequency_timeseries.py
@@ -20,7 +20,7 @@ import pandas as pd
 
 from ..metrics_base import MetricsBase
 from ..util import get_clock_converter
-from ...common import ClockConverter, Util
+from ...common import Util
 from ...record import Frequency, RecordsInterface
 from ...runtime import CallbackBase, Communication, Publisher, Subscription
 
@@ -111,12 +111,13 @@ class FrequencyTimeSeries(MetricsBase):
                     return False
 
         timeseries_records_list: list[RecordsInterface] = [
-            _.to_records() for _ in self._target_objects
+            obj.to_records() for obj in self._target_objects
         ]
 
-        converter: ClockConverter | None = None
         if xaxis_type == 'sim_time':
             converter = get_clock_converter(self._target_objects)
+        else:
+            converter = None
 
         min_time, max_time = self._get_timestamp_range(timeseries_records_list)
 
@@ -127,10 +128,12 @@ class FrequencyTimeSeries(MetricsBase):
                 row_filter=row_filter_communication
                 if isinstance(records, Communication) else None
             )
-            frequency_timeseries_list.append(frequency.to_records(
-                base_timestamp=min_time, until_timestamp=max_time,
+            frequency_record = frequency.to_records(
+                base_timestamp=min_time,
+                until_timestamp=max_time,
                 converter=converter
-            ))
+            )
+            frequency_timeseries_list.append(frequency_record)
 
         return frequency_timeseries_list
 

--- a/src/caret_analyze/plot/timeseries/frequency_timeseries.py
+++ b/src/caret_analyze/plot/timeseries/frequency_timeseries.py
@@ -27,7 +27,7 @@ from ...runtime import CallbackBase, Communication, Publisher, Subscription
 TimeSeriesTypes = CallbackBase | Communication | (Publisher | Subscription)
 
 
-def _get_calculation_offset_ns(timeseries_record: RecordsInterface) -> int:
+def _get_frequency_computing_timestamp_offset_ns(timeseries_record: RecordsInterface) -> int:
     """
     Calculate the offset time for frequency calculation.
 
@@ -164,7 +164,7 @@ class FrequencyTimeSeries(MetricsBase):
 
         frequency_timeseries_list: list[RecordsInterface] = []
         for records in timeseries_records_list:
-            offset_ns = _get_calculation_offset_ns(records)
+            offset_ns = _get_frequency_computing_timestamp_offset_ns(records)
             frequency = Frequency(
                 records,
                 row_filter=row_filter_communication

--- a/src/caret_analyze/plot/timeseries/frequency_timeseries.py
+++ b/src/caret_analyze/plot/timeseries/frequency_timeseries.py
@@ -54,13 +54,15 @@ def _get_calculation_offset_ns(timeseries_record: RecordsInterface) -> int:
     if len(timeseries_record) == 0:
         return 0
 
-    # Get the timestamp array
+    # Get timestamp array
     timestamp_column_name = timeseries_record.columns[0]
     timestamp_list = timeseries_record.get_column_series(timestamp_column_name)
     if len(timestamp_list) < 2:
         return 0
     if timestamp_list[0] is None or timestamp_list[1] is None:
         return 0
+
+    # Calculate timestamp offset
     timestamp_diff = int(timestamp_list[1]) - int(timestamp_list[0])
     timestamp_offset_ns = int(timestamp_diff / 2)
     return timestamp_offset_ns

--- a/src/test/plot/timeseries/test_frequency_timeseries.py
+++ b/src/test/plot/timeseries/test_frequency_timeseries.py
@@ -15,6 +15,8 @@
 from caret_analyze.plot.timeseries.frequency_timeseries import FrequencyTimeSeries
 from caret_analyze.record import ColumnValue
 from caret_analyze.record.record_factory import RecordFactory, RecordsFactory
+from caret_analyze.runtime.callback import CallbackBase
+import pandas as pd
 
 
 def create_expect_records(records_raw):
@@ -29,7 +31,7 @@ def create_expect_records(records_raw):
     return records
 
 
-class TestFrequencyTimeSeries:
+class TestGetTimestampRange:
 
     def test_get_timestamp_range_normal(self, mocker):
         records0 = create_expect_records([
@@ -90,3 +92,45 @@ class TestFrequencyTimeSeries:
 
         assert min_ts == 0
         assert max_ts == 1
+
+
+def create_sample_record(record_raw_list: list[dict]) -> RecordsFactory:
+    records = RecordsFactory.create_instance()
+    columns = [ColumnValue(key) for key in record_raw_list[0].keys()]
+    for column in columns:
+        records.append_column(column, [])
+
+    for record_raw in record_raw_list:
+        record = RecordFactory.create_instance(record_raw)
+        records.append(record)
+    return records
+
+
+class TestFrequencyTimeSeries:
+
+    def test_sample_record_to_dataframe(self, mocker):
+        records = create_sample_record([
+                {'timestamp': 1, 'some_data': 2},
+                {'timestamp': 2, 'some_data': 3}
+        ])
+        except_freq_df = pd.DataFrame(
+            data=[
+                {'timestamp [ns]': 1, 'frequency [Hz]': 2}
+            ]
+        )
+
+        cb_mock = mocker.Mock(spec=CallbackBase)
+        mocker.patch.object(cb_mock, 'to_records', return_value=records)
+        mocker.patch.object(cb_mock, 'column_names', ['timestamp', 'some_data'])
+
+        # Check if mock works as expected
+        assert cb_mock.to_records() == records
+        assert cb_mock.column_names == ['timestamp', 'some_data']
+
+        frequency_timeseries = FrequencyTimeSeries([cb_mock])
+
+        actual_df = frequency_timeseries.to_dataframe('timestamp')
+        actual_df.columns = actual_df.columns.droplevel(0)  # MultiIndex to single index
+
+        actual_df = actual_df.astype(except_freq_df.dtypes.to_dict())  # Type conversion
+        assert actual_df.equals(except_freq_df)


### PR DESCRIPTION
## Description

- Added test for plot/timeseries/frequency_timeseriers.py
- Added function to calculate frequency with timestamp offset.

### Background of change
Frequency is computed over each 1-second interval.
If the data frequency is around 1Hz, computing it without an offset can lead to unstable results.
For instance, if the time difference between consecutive data points is slightly less or more than 1 second (e.g., 999ms or 1001ms), a fixed 1-second window might capture a variable number of data points. This can cause the computed frequency to fluctuate (e.g., alternating between 0Hz and 2Hz) even if the true data frequency is stable.
This explains why the plotting result looks unstable, as shown in the following figure.

![image](https://github.com/user-attachments/assets/0db3d9d0-f7b6-4030-be4f-2bb1a1303a5a)

Therefore, as a countermeasure, I have added an offset to the start time of the frequency computation window.
The offset is half the duration of the window. For example, if the duration is 1000ms, the offset is 500ms.
When this offset is applied, the frequency calculation becomes stable, as shown in the following figure.

![image](https://github.com/user-attachments/assets/bcd0bd48-e0c6-4ae7-8f76-c6e065c586b9)


<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

For all unit test, there is only 1 failure related to flake8 test. But they are not warnings for frequency_timeseriers.py

```sh
~/caret_ws/ros2_caret_ws/src/CARET/caret_analyze/src$ pytest test
======================================================= short test summary info =======================================================
FAILED test/test_flake8.py::test_flake8 - ValueError: 'choice' is not callable
============================================= 1 failed, 654 passed, 18 warnings in 16.81s ==========================================
```

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
