### PR TITLE
fix: ignore setuptools 80.x to avoid 'error: option --editable not re…

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-setuptools>=68.2.2
+setuptools>=68.2.2,<80.0.0
 colorcet
 pandas>=2.1.1
 bokeh>=3,<3.7.0


### PR DESCRIPTION
…cognized'

## Description

- Build error occurs with setuptools>=80.0.0
- This PR ignores the above version of setuptools

```
#24 2.931 usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
#24 2.931    or: setup.py --help [cmd1 cmd2 ...]
#24 2.931    or: setup.py --help-commands
#24 2.931    or: setup.py cmd --help
#24 2.931 
#24 2.931 error: option --editable not recognized
```

## Related links

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT2-2418)

## Notes for reviewers

- before (build error occurs)
  - https://github.com/tier4/caret/actions/runs/14771019620/job/41470961200
- after (build passed)
  - https://github.com/tier4/caret/actions/runs/14771035732/job/41471002491#step:3:6963
  - not yet finished for build with autoware, but CARET build has been completed

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
