### PR TITLE
feat: improve accuracy of frequency calculation period determination

### DIFF
--- a/src/caret_analyze/plot/timeseries/frequency_timeseries.py
+++ b/src/caret_analyze/plot/timeseries/frequency_timeseries.py
@@ -170,7 +170,7 @@ class FrequencyTimeSeries(MetricsBase):
             INTERVAL_NS = 1000000000  # 1 second. Default value to calculate frequency.
             start_ns = min_time + offset_ns
             sample_num = (max_time - start_ns) // INTERVAL_NS
-            end_ns = start_ns + sample_num*INTERVAL_NS  # To trim the last sampling period due to insufficient duration.
+            end_ns = start_ns + sample_num*INTERVAL_NS - 1  # To trim the last sampling period due to insufficient duration.
 
             frequency = Frequency(
                 records,

--- a/src/caret_analyze/plot/timeseries/frequency_timeseries.py
+++ b/src/caret_analyze/plot/timeseries/frequency_timeseries.py
@@ -167,14 +167,20 @@ class FrequencyTimeSeries(MetricsBase):
         frequency_timeseries_list: list[RecordsInterface] = []
         for records in timeseries_records_list:
             offset_ns = _get_frequency_computing_timestamp_offset_ns(records)
+            INTERVAL_NS = 1000000000  # 1 second. Default value to calculate frequency.
+            start_ns = min_time + offset_ns
+            sample_num = (max_time - start_ns) // INTERVAL_NS
+            end_ns = start_ns + sample_num*INTERVAL_NS  # To trim the last sampling period due to insufficient duration.
+
             frequency = Frequency(
                 records,
                 row_filter=row_filter_communication
                 if isinstance(records, Communication) else None
             )
             frequency_record = frequency.to_records(
-                base_timestamp=min_time + offset_ns,
-                until_timestamp=max_time,
+                interval_ns=INTERVAL_NS,
+                base_timestamp=start_ns,
+                until_timestamp=end_ns,
                 converter=converter
             )
             frequency_timeseries_list.append(frequency_record)

--- a/src/caret_analyze/plot/timeseries/frequency_timeseries.py
+++ b/src/caret_analyze/plot/timeseries/frequency_timeseries.py
@@ -166,11 +166,14 @@ class FrequencyTimeSeries(MetricsBase):
 
         frequency_timeseries_list: list[RecordsInterface] = []
         for records in timeseries_records_list:
+            # Calculate the start time to shift calculation period from event period.
             offset_ns = _get_frequency_computing_timestamp_offset_ns(records)
-            INTERVAL_NS = 1000000000  # 1 second. Default value to calculate frequency.
             start_ns = min_time + offset_ns
+
+            # Calculate the end time to exclude periods with insufficient data.
+            INTERVAL_NS = 1000000000  # 1 second. Default value to calculate frequency.
             sample_num = (max_time - start_ns) // INTERVAL_NS
-            end_ns = start_ns + sample_num*INTERVAL_NS - 1  # To trim the last sampling period due to insufficient duration.
+            end_ns = start_ns + sample_num*INTERVAL_NS - 1
 
             frequency = Frequency(
                 records,

--- a/src/caret_analyze/record/records_service/frequency.py
+++ b/src/caret_analyze/record/records_service/frequency.py
@@ -140,6 +140,7 @@ class Frequency:
             timestamp_array = np.round(convert_vector(timestamp_array)).astype(np.int64)
 
         timestamp_array = timestamp_array[timestamp_array >= base_timestamp]
+        timestamp_array = timestamp_array[timestamp_array <= until_timestamp]
         if len(timestamp_array) == 0:
             return [base_timestamp], [0]
 

--- a/src/test/plot/timeseries/test_frequency_timeseries.py
+++ b/src/test/plot/timeseries/test_frequency_timeseries.py
@@ -124,26 +124,11 @@ class TestFrequencyTimeSeries:
 
         return actual_df
 
-    def test_to_dataframe_return_data(self, mocker):
-        records = [
-            {'timestamp': 1, 'some_data': 2}
-        ]
-        except_freq_df = pd.DataFrame(
-            data=[
-                {'timestamp [ns]': 1, 'frequency [Hz]': 1}
-            ]
-        )
-
-        actual_df = self.get_frequency_dataframe(mocker, records)
-        actual_df = actual_df.astype(except_freq_df.dtypes.to_dict())  # Type conversion
-
-        assert actual_df.equals(except_freq_df)
-
     def test_to_dataframe_remove_last_period(self, mocker):
         records = [
             {'timestamp': 1, 'some_data': 2},
             {'timestamp': 2, 'some_data': 3},
-            {'timestamp': 1000000002, 'some_data': 4},
+            {'timestamp': 1000000001, 'some_data': 4},
         ]
         except_freq_df = pd.DataFrame(
             data=[

--- a/src/test/plot/timeseries/test_frequency_timeseries.py
+++ b/src/test/plot/timeseries/test_frequency_timeseries.py
@@ -124,10 +124,26 @@ class TestFrequencyTimeSeries:
 
         return actual_df
 
-    def test_sample_record_to_dataframe(self, mocker):
+    def test_to_dataframe_return_data(self, mocker):
         records = [
-                {'timestamp': 1, 'some_data': 2},
-                {'timestamp': 2, 'some_data': 3}
+            {'timestamp': 1, 'some_data': 2}
+        ]
+        except_freq_df = pd.DataFrame(
+            data=[
+                {'timestamp [ns]': 1, 'frequency [Hz]': 1}
+            ]
+        )
+
+        actual_df = self.get_frequency_dataframe(mocker, records)
+        actual_df = actual_df.astype(except_freq_df.dtypes.to_dict())  # Type conversion
+
+        assert actual_df.equals(except_freq_df)
+
+    def test_to_dataframe_remove_last_period(self, mocker):
+        records = [
+            {'timestamp': 1, 'some_data': 2},
+            {'timestamp': 2, 'some_data': 3},
+            {'timestamp': 1000000002, 'some_data': 4},
         ]
         except_freq_df = pd.DataFrame(
             data=[

--- a/src/test/plot/timeseries/test_frequency_timeseries.py
+++ b/src/test/plot/timeseries/test_frequency_timeseries.py
@@ -94,31 +94,22 @@ class TestGetTimestampRange:
         assert max_ts == 1
 
 
-def create_sample_record(record_raw_list: list[dict]) -> RecordsFactory:
-    records = RecordsFactory.create_instance()
-    columns = [ColumnValue(key) for key in record_raw_list[0].keys()]
-    for column in columns:
-        records.append_column(column, [])
-
-    for record_raw in record_raw_list:
-        record = RecordFactory.create_instance(record_raw)
-        records.append(record)
-    return records
-
-
 class TestFrequencyTimeSeries:
 
-    def test_sample_record_to_dataframe(self, mocker):
-        records = create_sample_record([
-                {'timestamp': 1, 'some_data': 2},
-                {'timestamp': 2, 'some_data': 3}
-        ])
-        except_freq_df = pd.DataFrame(
-            data=[
-                {'timestamp [ns]': 1, 'frequency [Hz]': 2}
-            ]
-        )
+    @staticmethod
+    def create_sample_record(record_raw_list: list[dict]) -> RecordsFactory:
+        records = RecordsFactory.create_instance()
+        columns = [ColumnValue(key) for key in record_raw_list[0].keys()]
+        for column in columns:
+            records.append_column(column, [])
 
+        for record_raw in record_raw_list:
+            record = RecordFactory.create_instance(record_raw)
+            records.append(record)
+        return records
+
+    def get_frequency_dataframe(self, mocker, input_records: list[dict]):
+        records = TestFrequencyTimeSeries.create_sample_record(input_records)
         cb_mock = mocker.Mock(spec=CallbackBase)
         mocker.patch.object(cb_mock, 'to_records', return_value=records)
         mocker.patch.object(cb_mock, 'column_names', ['timestamp', 'some_data'])
@@ -128,9 +119,23 @@ class TestFrequencyTimeSeries:
         assert cb_mock.column_names == ['timestamp', 'some_data']
 
         frequency_timeseries = FrequencyTimeSeries([cb_mock])
-
         actual_df = frequency_timeseries.to_dataframe('timestamp')
-        actual_df.columns = actual_df.columns.droplevel(0)  # MultiIndex to single index
+        actual_df.columns = actual_df.columns.droplevel(0)
 
+        return actual_df
+
+    def test_sample_record_to_dataframe(self, mocker):
+        records = [
+                {'timestamp': 1, 'some_data': 2},
+                {'timestamp': 2, 'some_data': 3}
+        ]
+        except_freq_df = pd.DataFrame(
+            data=[
+                {'timestamp [ns]': 1, 'frequency [Hz]': 2}
+            ]
+        )
+
+        actual_df = self.get_frequency_dataframe(mocker, records)
         actual_df = actual_df.astype(except_freq_df.dtypes.to_dict())  # Type conversion
+
         assert actual_df.equals(except_freq_df)


### PR DESCRIPTION
## Description

- Added calculation end time to trim the last sampling period.
- Refactored frequency plotting test
- Fixed missing end time limitation in frequency calculation.

### Background of change

Previously, the final segment of the frequency calculation often contained incomplete data. This occurred because the recording's finish time was not synchronized with the defined calculation period boundaries. As a result, the frequency plot would show a sudden drop at the very end, as illustrated in the figure below:

![image](https://github.com/user-attachments/assets/5fbb21a1-854d-4d09-a6f0-c437cf3c05a8)

With this change, only time intervals with complete data samples are used for the calculation period. This leads to a more stable and accurate frequency plot:

![image](https://github.com/user-attachments/assets/0919c481-8ffe-4d70-a654-1b1df35b922f)

## Notes for reviewers

In the scenario where `start_ns` > `end_ns`, the frequency is calculated as 0 Hz without triggering an error.

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
