### PR TITLE
fix: unable to run pytest in github actions

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   pytest:
     runs-on: ubuntu-latest
-    container: ghcr.io/autowarefoundation/autoware:latest-devel
+    container: ghcr.io/autowarefoundation/autoware:universe-devel
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

In pytest.yaml, rosdep is installed but fails due to PGP key expiration. 
Because of this, pytest could not run. The rosdep

## Related links

[https://tier4.atlassian.net/browse/RT0-38358](https://tier4.atlassian.net/browse/RT0-38358)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
