### PR TITLE
fix: raise exception at executor has no callbacks

### DIFF
--- a/src/caret_analyze/plot/visualize_lib/bokeh/callback_scheduling.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/callback_scheduling.py
@@ -26,6 +26,7 @@ import pandas as pd
 from .util import (apply_x_axis_offset, ColorSelectorFactory, get_callback_param_desc,
                    HoverKeysFactory, HoverSource, init_figure, LegendManager, RectValues)
 from ....common import ClockConverter, Util
+from ....exceptions import ItemNotFoundError
 from ....record import Clip, Range
 from ....runtime import CallbackBase, CallbackGroup, TimerCallback
 
@@ -68,6 +69,8 @@ class BokehCallbackSched:
         # Apply xaxis offset
         callbacks: list[CallbackBase] = Util.flatten(
             cbg.callbacks for cbg in self._callback_groups if len(cbg.callbacks) > 0)
+        if len(callbacks) == 0:
+            raise ItemNotFoundError("Not found callbacks")
         records_range = Range([cb.to_records() for cb in callbacks])
         range_min, range_max = records_range.get_range()
         clip_min = int(range_min + self._lstrip_s*1.0e9)


### PR DESCRIPTION
## Description

When drawing the Executor's callback_scheduling graph, if no callbacks are registered, an ItemNotFound exception shall be thrown.

## Related links

[](https://tier4.atlassian.net/browse/RT0-38385)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
