### PR TITLE
fix: last node of path use take-method

### DIFF
--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -66,6 +66,22 @@ class Architecture(Summarizable):
         self._verify(self._nodes)
 
     def get_node(self, node_name: str) -> NodeStructValue:
+        """
+        Get node.
+
+        Returns
+        -------
+        NodeStructValue
+            Node struct value.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         try:
             return Util.find_one(lambda x: x.node_name == node_name, self.nodes)
         except ItemNotFoundError:
@@ -74,14 +90,55 @@ class Architecture(Summarizable):
             raise ItemNotFoundError(msg)
 
     def get_executor(self, executor_name: str) -> ExecutorStructValue:
+        """
+        Get executor.
+
+        Returns
+        -------
+        ExecutorStructValue
+            Executor struct value.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         return Util.find_one(lambda x: x.executor_name == executor_name, self.executors)
 
     def get_callback_group(self, callback_group_name: str) -> CallbackGroupStructValue:
+        """
+        Get callback group.
+
+        Returns
+        -------
+        CallbackGroupStructValue
+            CallbackGroup struct value.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         return Util.find_one(lambda x: x.callback_group_name == callback_group_name,
                              self.callback_groups)
 
     @property
     def callback_groups(self) -> tuple[CallbackGroupStructValue, ...]:
+        """
+        Get callback groups.
+
+        Returns
+        -------
+        tuple[CallbackGroupStructValue, ...]
+            CallbackGroup struct value.
+
+        """
         cbg: list[CallbackGroupStructValue] = []
         for node in self.nodes:
             if node.callback_groups is not None:
@@ -90,19 +147,62 @@ class Architecture(Summarizable):
 
     @property
     def callback_group_names(self) -> tuple[str, ...]:
+        """
+        Get callback group names.
+
+        Returns
+        -------
+        tuple[str, ...]
+            CallbackGroup names.
+
+        """
         return tuple(sorted(_.callback_group_name for _ in self.callback_groups))
 
     @property
     def topic_names(self) -> tuple[str, ...]:
+        """
+        Get topic names.
+
+        Returns
+        -------
+        tuple[str, ...]
+            Topic names.
+
+        """
         topic_names = {_.topic_name for _ in self.publishers}
         topic_names |= {_.topic_name for _ in self.subscriptions}
         return tuple(sorted(topic_names))
 
     def get_callback(self, callback_name: str) -> CallbackStructValue:
+        """
+        Get callback.
+
+        Returns
+        -------
+        CallbackStructValue
+            Callback struct value.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         return Util.find_one(lambda x: x.callback_name == callback_name, self.callbacks)
 
     @property
     def callbacks(self) -> tuple[CallbackStructValue, ...]:
+        """
+        Get callbacks.
+
+        Returns
+        -------
+        tuple[CallbackStructValue, ...]
+            Callbacks.
+
+        """
         return tuple(Util.flatten(_.callbacks for _ in self.callback_groups))
 
     def get_communication(
@@ -114,6 +214,35 @@ class Architecture(Summarizable):
         publisher_construction_order: int = 0,
         subscription_construction_order: int = 0
     ) -> CommunicationStructValue:
+        """
+        Get communication.
+
+        Parameters
+        ----------
+        publisher_node_name : str
+            Publisher node name.
+        subscription_node_name : str
+            Subscription node name.
+        topic_name : str
+            Topic name.
+        publisher_construction_order : int
+            Publisher construction order.
+        subscription_construction_order : int
+            Subscription construction order.
+
+        Returns
+        -------
+        CommunicationStructValue
+            Communication struct value.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         def is_target_comm(comm: CommunicationStructValue):
             return comm.publish_node_name == publisher_node_name and \
                 comm.subscribe_node_name == subscription_node_name and \
@@ -124,6 +253,29 @@ class Architecture(Summarizable):
         return Util.find_one(is_target_comm, self.communications)
 
     def get_path(self, path_name: str) -> PathStructValue:
+        """
+        Get path name.
+
+        Parameters
+        ----------
+        path_name : str
+            Path name.
+
+        Returns
+        -------
+        PathStructValue
+            Path struct value.
+
+        Raises
+        ------
+        InvalidArgumentError
+            Occurs when path name were not exist.
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         if path_name not in self.path_names:
             raise InvalidArgumentError(f'Failed to get named path. {path_name} not exist.')
 
@@ -131,6 +283,26 @@ class Architecture(Summarizable):
         return named_path.to_value()
 
     def add_path(self, path_name: str, path_info: PathStructValue) -> None:
+        """
+        Add path.
+
+        Parameters
+        ----------
+        path_name : str
+            Path name.
+        path_info : PathStructValue
+            path information.
+
+        Raises
+        ------
+        InvalidArgumentError
+            Occurs when path name were duplicate.
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         if path_name in self.path_names:
             raise InvalidArgumentError('Failed to add named path. Duplicate path name.')
 
@@ -186,6 +358,20 @@ class Architecture(Summarizable):
         self._paths.append(named_path_info)
 
     def remove_path(self, path_name: str) -> None:
+        """
+        Remove path.
+
+        Parameters
+        ----------
+        path_name : str
+            Path name.
+
+        Raises
+        ------
+        InvalidArgumentError
+            Occurs when path name were not exist.
+
+        """
         if path_name not in self.path_names:
             raise InvalidArgumentError(f'Failed to remove named path. {path_name} not exist.')
 
@@ -198,6 +384,22 @@ class Architecture(Summarizable):
             self._paths.pop(idx)
 
     def update_path(self, path_name: str, path: PathStructValue) -> None:
+        """
+        Update path.
+
+        Parameters
+        ----------
+        path_name : str
+            Path name.
+        path : PathStructValue
+            Path struct value.
+
+        Raises
+        ------
+        InvalidArgumentError
+            Occurs when path name were not exist.
+
+        """
         if path.path_name is None:
             raise InvalidArgumentError('path_info.path_name is None')
 
@@ -206,54 +408,165 @@ class Architecture(Summarizable):
 
     @property
     def nodes(self) -> tuple[NodeStructValue, ...]:
+        """
+        Get nodes.
+
+        Returns
+        -------
+        tuple[NodeStructValue, ...]
+            Node struct value.
+
+        """
         return tuple(v.to_value() for v in self._nodes)
 
     @property
     def node_names(self) -> tuple[str, ...]:
+        """
+        Get node names.
+
+        Returns
+        -------
+        tuple[str, ...]
+            Node names.
+
+        """
         return tuple(sorted(_.node_name for _ in self._nodes))
 
     @property
     def executors(self) -> tuple[ExecutorStructValue, ...]:
+        """
+        Get executors.
+
+        Returns
+        -------
+        tuple[ExecutorStructValue, ...]
+            Executors.
+
+        """
         return tuple(v.to_value() for v in self._executors)
 
     @property
     def executor_names(self) -> tuple[str, ...]:
+        """
+        Get executor names.
+
+        Returns
+        -------
+        tuple[str, ...]
+            Executor names.
+
+        """
         return tuple(sorted(_.executor_name for _ in self._executors))
 
     @property
     def paths(self) -> tuple[PathStructValue, ...]:
+        """
+        Get paths.
+
+        Returns
+        -------
+        tuple[PathStructValue, ...]
+            Path struct value.
+
+        """
         return tuple([v.to_value() for v in self._paths])
 
     @property
     def path_names(self) -> tuple[str, ...]:
+        """
+        Get path names.
+
+        Returns
+        -------
+        tuple[str, ...]
+            Path names.
+
+        """
         return tuple(sorted(v.path_name for v in self._paths if v.path_name is not None))
 
     @property
     def communications(self) -> tuple[CommunicationStructValue, ...]:
+        """
+        Get communications.
+
+        Returns
+        -------
+        tuple[CommunicationStructValue, ...]
+            Communication struct value.
+
+        """
         return tuple(v.to_value() for v in self._communications)
 
     @property
     def publishers(self) -> tuple[PublisherStructValue, ...]:
+        """
+        Get publishers.
+
+        Returns
+        -------
+        tuple[PublisherStructValue, ...]
+            Publisher struct value.
+
+        """
         publishers = Util.flatten(_.publishers for _ in self.nodes)
         return tuple(sorted(publishers, key=lambda x: x.topic_name))
 
     @property
     def subscriptions(self) -> tuple[SubscriptionStructValue, ...]:
+        """
+        Get subscriptions.
+
+        Returns
+        -------
+        tuple[SubscriptionStructValue, ...]
+            Subscription struct value.
+
+        """
         subscriptions = Util.flatten(_.subscriptions for _ in self.nodes)
         return tuple(sorted(subscriptions, key=lambda x: x.topic_name))
 
     @property
     def services(self) -> tuple[ServiceStructValue, ...]:
+        """
+        Get services.
+
+        Returns
+        -------
+        tuple[ServiceStructValue, ...]
+            Service struct value.
+
+        """
         services = Util.flatten(_.services for _ in self.nodes)
         return tuple(sorted(services, key=lambda x: x.service_name))
 
     @property
     def summary(self) -> Summary:
+        """
+        Get summary.
+
+        Returns
+        -------
+        Summary
+            Summary about value objects and runtime data objects.
+
+        """
         return Summary({
             'nodes': self.node_names
         })
 
     def export(self, file_path: str, force: bool = False):
+        """
+        Architecture export.
+
+        Parameters
+        ----------
+        file_path : str
+            File path.
+        force : bool
+            Forced specification, by default False.
+            If True, a file with the same name will be overwritten if it exists.
+
+        """
         exporter = ArchitectureExporter(
             self.nodes, self.executors, self.paths, force)
         exporter.execute(file_path)
@@ -265,6 +578,26 @@ class Architecture(Summarizable):
         node_filter: Callable[[str], bool] | None = None,
         communication_filter: Callable[[str], bool] | None = None,
     ) -> list[PathStructValue]:
+        """
+        Search for paths between specified nodes.
+
+        Parameters
+        ----------
+        node_names : str
+            Specifies the name of the node included in the path to search.
+        max_node_depth : int | None
+            Max node depth.
+        node_filter : Callable[[str], bool] | None
+            Node filter.
+        communication_filter : Callable[[str], bool] | None
+            Communication filter.
+
+        Returns
+        -------
+        list[PathStructValue]
+            Search result path struct value.
+
+        """
         for node_name in node_names:
             if node_name not in self.node_names:
                 raise ItemNotFoundError(f'Failed to find node. {node_name}')
@@ -319,7 +652,22 @@ class Architecture(Summarizable):
         path_left: PathStructValue,
         path_right: PathStructValue
     ) -> PathStructValue:
+        """
+        Combine path.
 
+        Parameters
+        ----------
+        path_left : PathStructValue
+            Path left.
+        path_right : PathStructValue
+            Path right.
+
+        Returns
+        -------
+        PathStructValue:
+            Path struct value of combined results.
+
+        """
         def get_node(node_name: str) -> NodeStructValue:
             return self.get_node(node_name)
 
@@ -384,6 +732,13 @@ class Architecture(Summarizable):
         publish_topic_name : str
             name of publish topic of target node_path
 
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
         """
         node: NodeStruct =\
             Util.find_one(lambda x: x.node_name == node_name, self._nodes)
@@ -424,6 +779,13 @@ class Architecture(Summarizable):
         publisher_construction_order : int
             construction order of target publisher
 
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
         """
         node: NodeStruct = Util.find_one(lambda x: x.node_name == node_name, self._nodes)
 
@@ -450,6 +812,13 @@ class Architecture(Summarizable):
             name of write callback to be inserted in variable_passing
         callback_name_read : str
             name of read callback to be inserted in variable_passing
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
 
         """
         node: NodeStruct = Util.find_one(lambda x: x.node_name == node_name, self._nodes)
@@ -480,6 +849,13 @@ class Architecture(Summarizable):
         publisher_construction_order : int
             construction order of target publisher
 
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
         """
         node: NodeStruct = Util.find_one(lambda x: x.node_name == node_name, self._nodes)
 
@@ -506,6 +882,13 @@ class Architecture(Summarizable):
             name of write callback to be removed from variable_passing
         callback_name_read : str
             name of read callback to be removed from variable_passing
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
 
         """
         node: NodeStruct = Util.find_one(lambda x: x.node_name == node_name, self._nodes)
@@ -543,6 +926,11 @@ class Architecture(Summarizable):
             current callback name
         dst : str
             updated callback name
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
 
         """
         cb_s: list[CallbackStruct] =\
@@ -583,6 +971,11 @@ class Architecture(Summarizable):
         dst : str
             updated path name
 
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+
         """
         p: PathStruct = Util.find_similar_one(src, self._paths, lambda x: x.path_name)
         p.path_name = dst
@@ -597,6 +990,11 @@ class Architecture(Summarizable):
             current executor name
         dst : str
             updated executor name
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
 
         """
         e: ExecutorStruct = Util.find_similar_one(src, self._executors, lambda x: x.executor_name)
@@ -728,6 +1126,19 @@ class ContextUpdater:
 
     def update_message_context(self, context_type: str,
                                subscribe_topic_name: str, publish_topic_name: str) -> None:
+        """
+        Update message context.
+
+        Parameters
+        ----------
+        context_type : str
+            type name of message_context to be added
+        subscribe_topic_name : str
+            name of subscribe topic of target node_path
+        publish_topic_name : str
+            name of publish topic of target node_path
+
+        """
         for context in self._contexts:
             if (context['subscription_topic_name'], context['publisher_topic_name']) ==\
                (subscribe_topic_name, publish_topic_name):
@@ -754,6 +1165,21 @@ class ContextUpdater:
         publish_topic_name: str,
         publisher_construction_order: int
     ) -> None:
+        """
+        Remove callback chain.
+
+        Parameters
+        ----------
+        subscribe_topic_name : str
+            topic name of target subscription from which callback is removed
+        subscription_construction_order : int
+            construction order of target subscription
+        publish_topic_name : str
+            topic name of target publisher from which callback is removed
+        publisher_construction_order : int
+            construction order of target publisher
+
+        """
         self._contexts = [
             context for context in self._contexts
             if (context['subscription_topic_name'],
@@ -783,6 +1209,15 @@ class DiffArchitecture:
         self._right_arch = right_arch
 
     def diff_node_names(self) -> tuple[tuple[str, ...], tuple[str, ...]]:
+        """
+        Compare two architecture objects and return the difference of nodes name.
+
+        Returns
+        -------
+        tuple[tuple[str,...], tuple[str,...]]
+            Returns node names that exist only in the respective architectures.
+
+        """
         set_left_node_names = set(self._left_arch.node_names)
         set_right_node_names = set(self._right_arch.node_names)
         common_node_names = set_left_node_names & set_right_node_names
@@ -791,6 +1226,15 @@ class DiffArchitecture:
         return left_only_names, right_only_names
 
     def diff_topic_names(self) -> tuple[tuple[str, ...], tuple[str, ...]]:
+        """
+        Compare two architecture objects and return the difference of pub/sub topic names.
+
+        Returns
+        -------
+        tuple[tuple[str,...], tuple[str,...]]
+            Returns pub/sub topic names that exist only in the respective architectures.
+
+        """
         set_left_topics = set(self._left_arch.topic_names)
         set_right_topics = set(self._right_arch.topic_names)
         common_node_topics = set_left_topics & set_right_topics

--- a/src/caret_analyze/architecture/architecture.py
+++ b/src/caret_analyze/architecture/architecture.py
@@ -292,7 +292,12 @@ class Architecture(Summarizable):
 
         # Search
         path_searcher = NodePathSearcher(
-            tuple(self._nodes), tuple(self._communications), node_filter, communication_filter)
+            tuple(self._nodes),
+            tuple(self._communications),
+            self._max_callback_construction_order_on_path_searching,
+            node_filter,
+            communication_filter
+        )
         paths = [v.to_value() for v in
                  path_searcher.search(*node_names, max_node_depth=max_node_depth)]
 

--- a/src/caret_analyze/architecture/architecture_exporter.py
+++ b/src/caret_analyze/architecture/architecture_exporter.py
@@ -44,6 +44,15 @@ class ArchitectureExporter():
         self._force = force
 
     def execute(self, file_path: str) -> None:
+        """
+        Dump information about the objects that make up the architecture file.
+
+        Parameters
+        ----------
+        file_path : str
+            File path.
+
+        """
         mode = 'w' if self._force else 'x'
         with open(file_path, mode=mode) as f:
             f.write(str(self))
@@ -53,6 +62,7 @@ class ArchitectureExporter():
         return yaml.dump(obj, indent=2, default_flow_style=False, sort_keys=False)
 
     def to_dict(self):
+        """Get to dict."""
         named_path_dicts = NamedPathsDicts(list(self._named_path_values))
         executor_dicts = ExecutorsDicts(list(self._executor_values))
         nodes_dicts = NodesDicts(list(self._node_values))
@@ -72,6 +82,15 @@ class NamedPathsDicts:
 
     @property
     def data(self) -> list[dict]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[dict]
+            Dict data.
+
+        """
         return self._data
 
     def _to_dict(self, path_value: PathStructValue):
@@ -154,6 +173,15 @@ class CallbackDicts:
 
     @property
     def data(self) -> list[dict]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[dict]
+            Dict data.
+
+        """
         return self._data
 
 
@@ -191,6 +219,15 @@ class VarPassDicts:
 
     @property
     def data(self) -> list[dict]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[dict]
+            Dict data.
+
+        """
         return self._data
 
 
@@ -219,6 +256,15 @@ class PubDicts:
 
     @property
     def data(self) -> list[dict]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[dict]
+            Dict data.
+
+        """
         return self._data
 
 
@@ -240,6 +286,15 @@ class SubDicts:
 
     @property
     def data(self) -> list[dict]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[dict]
+            Dict data.
+
+        """
         return self._data
 
 
@@ -254,6 +309,15 @@ class NodesDicts:
 
     @property
     def data(self) -> list[dict]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[dict]
+            Dict data.
+
+        """
         return self._data
 
     def _to_dict(
@@ -324,6 +388,15 @@ class MessageContextDicts:
 
     @property
     def data(self) -> list[dict]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[dict]
+            Dict data.
+
+        """
         return self._data
 
 
@@ -337,6 +410,15 @@ class ExecutorsDicts:
 
     @property
     def data(self) -> list[dict]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[dict]
+            Dict data.
+
+        """
         return self._data
 
     @staticmethod

--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -109,18 +109,54 @@ class ArchitectureLoaded():
 
     @property
     def paths(self) -> list[PathStruct]:
+        """
+        Get paths.
+
+        Returns
+        -------
+        list[PathStruct]
+            PathValuesLoaded data.
+
+        """
         return self._paths
 
     @property
     def executors(self) -> list[ExecutorStruct]:
+        """
+        Get executors.
+
+        Returns
+        -------
+        list[ExecutorStruct]
+            ExecutorValuesLoaded data.
+
+        """
         return self._executors
 
     @property
     def nodes(self) -> list[NodeStruct]:
+        """
+        Get nodes.
+
+        Returns
+        -------
+        list[NodeStruct]
+            NodeValuesLoaded data.
+
+        """
         return self._nodes
 
     @property
     def communications(self) -> list[CommunicationStruct]:
+        """
+        Get communications.
+
+        Returns
+        -------
+        list[NodeStruct]
+            CommValuesLoaded data.
+
+        """
         return self._communications
 
     def _ignore_service(self) -> None:
@@ -213,6 +249,15 @@ class CommValuesLoaded():
 
     @property
     def data(self) -> list[CommunicationStruct]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[CommunicationStruct]
+            Communication struct data.
+
+        """
         return self._data
 
     def find_communication(
@@ -223,6 +268,35 @@ class CommValuesLoaded():
         subscribe_node_name: str,
         subscription_construction_order: int | None,
     ) -> CommunicationStruct:
+        """
+        Find communication.
+
+        Parameters
+        ----------
+        topic_name : str
+            topic name.
+        publish_node_name : str
+            publish node name.
+        publisher_construction_order : int | None
+            construction order of publisher.
+        subscribe_node_name : str
+            subscribe node name.
+        subscription_construction_order : int | None
+            construction order of subscription.
+
+        Returns
+        -------
+        CommunicationStruct
+            Found communication struct.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         def is_target(comm: CommunicationStruct):
             return comm.publish_node_name == publish_node_name and \
                 comm.subscribe_node_name == subscribe_node_name and \
@@ -348,12 +422,42 @@ class NodeValuesLoaded():
 
     @property
     def data(self) -> list[NodeStruct]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[NodeStruct]
+            Node struct data.
+
+        """
         return self._data
 
     def get_callbacks(
         self,
         node_name: str
     ) -> list[CallbackStruct]:
+        """
+        Get callbacks.
+
+        Parameters
+        ----------
+        node_name : str
+            node name.
+
+        Returns
+        -------
+        list[CallbackStruct]
+            Found callback struct.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         try:
             cb_loaded: CallbacksLoaded
             cb_loaded = Util.find_one(lambda x: x.node_name == node_name, self._cb_loaded)
@@ -364,6 +468,27 @@ class NodeValuesLoaded():
             raise ItemNotFoundError(msg)
 
     def find_node(self, node_name: str) -> NodeStruct:
+        """
+        Find node.
+
+        Parameters
+        ----------
+        node_name : str
+            node name.
+
+        Returns
+        -------
+        NodeStruct
+            Found node struct.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         try:
             return Util.find_one(lambda x: x.node_name == node_name, self.data)
         except ItemNotFoundError:
@@ -375,6 +500,27 @@ class NodeValuesLoaded():
         self,
         node_path_value: NodePathValue,
     ) -> NodePathStruct:
+        """
+        Find node path.
+
+        Parameters
+        ----------
+        node_path_value : NodePathValue
+            node path value.
+
+        Returns
+        -------
+        NodePathStruct
+            Found node path struct.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         def is_target(value: NodePathStruct):
             return (value.publish_topic_name == node_path_value.publish_topic_name and
                     value.subscribe_topic_name == node_path_value.subscribe_topic_name and
@@ -409,6 +555,25 @@ class NodeValuesLoaded():
         self,
         callback_group_id: str
     ) -> CallbackGroupStruct:
+        """
+        Find callback group.
+
+        Parameters
+        ----------
+        callback_group_id : str
+            callback group id.
+
+        Returns
+        -------
+        CallbackGroupStruct
+            Found callback group struct.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Failed to find callback group.
+
+        """
         for cbg_loaded in self._cbg_loaded:
             try:
                 return cbg_loaded.find_callback_group(callback_group_id)
@@ -426,6 +591,25 @@ class NodeValuesLoaded():
         self,
         callback_id: str
     ) -> CallbackStruct:
+        """
+        Find callback.
+
+        Parameters
+        ----------
+        callback_id : str
+            callback id.
+
+        Returns
+        -------
+        CallbackStruct
+            Found callback struct.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Failed to find callback.
+
+        """
         for cb_loaded in self._cb_loaded:
             try:
                 return cb_loaded.find_callback(callback_id)
@@ -437,6 +621,25 @@ class NodeValuesLoaded():
         self,
         callback_ids: list[str]
     ) -> list[CallbackStruct]:
+        """
+        Find callbacks.
+
+        Parameters
+        ----------
+        callback_ids : list[str]
+            callback ids.
+
+        Returns
+        -------
+        list[CallbackStruct]
+            Found callback struct.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Failed to find callback.
+
+        """
         callbacks: list[CallbackStruct] = []
         for cb_loaded in self._cb_loaded:
             callbacks += cb_loaded.search_callbacks(callback_ids)
@@ -687,6 +890,35 @@ class MessageContextsLoaded:
         subscription_construction_order: int,
         publisher_construction_order: int
     ) -> NodePathStruct:
+        """
+        Get node path.
+
+        Parameters
+        ----------
+        node_paths : Sequence[NodePathStruct]
+            node paths.
+        publisher_topic_name : str
+            publisher topic name.
+        subscription_topic_name : str
+            subscription topic name.
+        publisher_construction_order : int
+            construction order of publisher.
+        subscription_construction_order : int
+            construction order of subscription.
+
+        Returns
+        -------
+        NodePathStruct
+            Found node path struct.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         def is_target(path: NodePathValue):
             return path.publish_topic_name == publisher_topic_name and \
                 path.subscribe_topic_name == subscription_topic_name and \
@@ -696,6 +928,15 @@ class MessageContextsLoaded:
 
     @property
     def data(self) -> list[MessageContextStruct]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[MessageContextStruct]
+            Message context struct.
+
+        """
         return self._data
 
     @staticmethod
@@ -753,6 +994,15 @@ class NodePathCreated:
 
     @property
     def data(self) -> list[NodePathStruct]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[NodePathStruct]
+            Node path struct.
+
+        """
         return self._data
 
 
@@ -818,6 +1068,15 @@ class PublishersLoaded:
 
     @property
     def data(self) -> list[PublisherStruct]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[PublisherStruct]
+            Publisher struct.
+
+        """
         return self._data
 
 
@@ -890,6 +1149,15 @@ class SubscriptionsLoaded:
 
     @property
     def data(self) -> list[SubscriptionStruct]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[SubscriptionStruct]
+            Subscription struct.
+
+        """
         return self._data
 
 
@@ -962,6 +1230,15 @@ class ServicesLoaded:
 
     @property
     def data(self) -> list[ServiceStruct]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[ServiceStruct]
+            Service struct.
+
+        """
         return self._data
 
 
@@ -1034,6 +1311,15 @@ class TimersLoaded:
 
     @property
     def data(self) -> list[TimerStruct]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[TimerStruct]
+            Timer struct.
+
+        """
         return self._data
 
 
@@ -1065,6 +1351,15 @@ class VariablePassingsLoaded():
 
     @property
     def data(self) -> list[VariablePassingStruct]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[VariablePassingStruct]
+            Variable passing struct.
+
+        """
         return self._data
 
 
@@ -1172,9 +1467,32 @@ class CallbackGroupsLoaded():
 
     @property
     def data(self) -> list[CallbackGroupStruct]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[CallbackGroupStruct]
+            Callback group struct.
+
+        """
         return list(self._data.values())
 
     def find_callback_group(self, callback_group_id: str):
+        """
+        Find callback group.
+
+        Parameters
+        ----------
+        callback_group_id : str
+            callback group id.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Failed to find callback group.
+
+        """
         if callback_group_id in self._data:
             return self._data[callback_group_id]
 
@@ -1231,10 +1549,28 @@ class CallbacksLoaded():
 
     @property
     def node_name(self) -> str:
+        """
+        Get node name.
+
+        Returns
+        -------
+        str
+            Node name.
+
+        """
         return self._node.node_name
 
     @property
     def data(self) -> list[CallbackStruct]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[CallbackStruct]
+            Callback struct.
+
+        """
         return list(self._cb_dict.values())
 
     def _to_struct(
@@ -1336,6 +1672,20 @@ class CallbacksLoaded():
         self,
         callback_id: str
     ) -> CallbackStruct:
+        """
+        Find callback.
+
+        Parameters
+        ----------
+        callback_id : str
+            callback id.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Failed to find callback.
+
+        """
         if callback_id in self._cb_dict.keys():
             return self._cb_dict[callback_id]
 
@@ -1480,6 +1830,15 @@ class ExecutorValuesLoaded():
 
     @property
     def data(self) -> list[ExecutorStruct]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[ExecutorStruct]
+            Executor struct.
+
+        """
         return self._data
 
 
@@ -1576,6 +1935,15 @@ class PathValuesLoaded():
 
     @property
     def data(self) -> list[PathStruct]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[PathStruct]
+            Path struct.
+
+        """
         return self._data
 
 
@@ -1627,6 +1995,15 @@ class CallbackPathSearched():
 
     @property
     def data(self) -> list[NodePathStruct]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[NodePathStruct]
+            Node path struct.
+
+        """
         return self._data
 
 
@@ -1641,6 +2018,20 @@ class TopicIgnoredReader(ArchitectureReader):
         self._ignore_callback_ids = self._get_ignore_callback_ids(reader, ignore_topics)
 
     def get_publishers(self, node: NodeValue) -> list[PublisherValue]:
+        """
+        Get publishers.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        list[PublisherValue]
+            Publisher value.
+
+        """
         publishers: list[PublisherValue] = []
         for publisher in self._reader.get_publishers(node):
             if publisher.topic_name in self._ignore_topics:
@@ -1649,6 +2040,20 @@ class TopicIgnoredReader(ArchitectureReader):
         return publishers
 
     def get_timers(self, node: NodeValue) -> list[TimerValue]:
+        """
+        Get timers.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        list[TimerValue]
+            Timer value.
+
+        """
         timers: list[TimerValue] = []
         for timer in self._reader.get_timers(node):
             timers.append(timer)
@@ -1658,6 +2063,20 @@ class TopicIgnoredReader(ArchitectureReader):
         self,
         node: NodeValue
     ) -> Sequence[CallbackGroupValue]:
+        """
+        Get callback groups.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[CallbackGroupValue]
+            Callback group value.
+
+        """
         return [
             CallbackGroupValue(
                 cbg.callback_group_type.type_name,
@@ -1676,12 +2095,35 @@ class TopicIgnoredReader(ArchitectureReader):
         ]
 
     def get_executors(self) -> Sequence[ExecutorValue]:
+        """
+        Get executors.
+
+        Returns
+        -------
+        Sequence[ExecutorValue]
+            Executor value.
+
+        """
         return self._reader.get_executors()
 
     def get_message_contexts(
         self,
         node: NodeValue
     ) -> Sequence[dict]:
+        """
+        Get message contexts.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[dict]
+            Message contexts.
+
+        """
         return self._reader.get_message_contexts(node)
 
     def _filter_callback_id(
@@ -1718,18 +2160,64 @@ class TopicIgnoredReader(ArchitectureReader):
         return set(ignore_callback_ids)
 
     def get_paths(self) -> Sequence[PathValue]:
+        """
+        Get paths.
+
+        Returns
+        -------
+        Sequence[PathValue]
+            Path value.
+
+        """
         return self._reader.get_paths()
 
     def get_node_names_and_cb_symbols(
         self,
         callback_group_id: str
     ) -> Sequence[tuple[str | None, str | None]]:
+        """
+        Get node names and callback symbols.
+
+        Parameters
+        ----------
+        callback_group_id : str
+            Target callback group id.
+
+        Returns
+        -------
+        Sequence[tuple[str | None, str | None]]
+            Node names and callback symbols.
+
+        """
         return self._reader.get_node_names_and_cb_symbols(callback_group_id)
 
     def get_nodes(self) -> Sequence[NodeValueWithId]:
+        """
+        Get nodes.
+
+        Returns
+        -------
+        Sequence[NodeValueWithId]
+            Node value with id.
+
+        """
         return self._reader.get_nodes()
 
     def get_subscriptions(self, node: NodeValue) -> list[SubscriptionValue]:
+        """
+        Get subscriptions.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        list[SubscriptionValue]
+            Subscription value.
+
+        """
         subscriptions: list[SubscriptionValue] = []
         for subscription in self._reader.get_subscriptions(node):
             if subscription.topic_name in self._ignore_topics:
@@ -1738,24 +2226,80 @@ class TopicIgnoredReader(ArchitectureReader):
         return subscriptions
 
     def get_services(self, node: NodeValue) -> list[ServiceValue]:
+        """
+        Get services.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        list[ServiceValue]
+            Service value.
+
+        """
         return list(self._reader.get_services(node))
 
     def get_variable_passings(
         self,
         node: NodeValue
     ) -> Sequence[VariablePassingValue]:
+        """
+        Get variable passings.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[VariablePassingValue]
+            Variable passing value.
+
+        """
         return self._reader.get_variable_passings(node)
 
     def get_timer_callbacks(
         self,
         node: NodeValue
     ) -> Sequence[TimerCallbackValue]:
+        """
+        Get timer callbacks.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[TimerCallbackValue]
+            Timer callback value.
+
+        """
         return self._reader.get_timer_callbacks(node)
 
     def get_subscription_callbacks(
         self,
         node: NodeValue
     ) -> Sequence[SubscriptionCallbackValue]:
+        """
+        Get subscription callbacks.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[SubscriptionCallbackValue]
+            Subscription callback value.
+
+        """
         callbacks: list[SubscriptionCallbackValue] = []
         for subscription_callback in self._reader.get_subscription_callbacks(node):
             if subscription_callback.subscribe_topic_name in self._ignore_topics:
@@ -1767,4 +2311,18 @@ class TopicIgnoredReader(ArchitectureReader):
         self,
         node: NodeValue
     ) -> Sequence[ServiceCallbackValue]:
+        """
+        Get service callbacks.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[ServiceCallbackValue]
+            Service callback value.
+
+        """
         return self._reader.get_service_callbacks(node)

--- a/src/caret_analyze/architecture/architecture_loaded.py
+++ b/src/caret_analyze/architecture/architecture_loaded.py
@@ -1587,7 +1587,7 @@ class CallbackPathSearched():
     ) -> None:
         self._data: list[NodePathStruct]
 
-        searcher = CallbackPathSearcher(node)
+        searcher = CallbackPathSearcher(node, max_callback_construction_order)
 
         callbacks = node.callbacks
         paths: list[NodePathStruct] = []

--- a/src/caret_analyze/architecture/architecture_reader_factory.py
+++ b/src/caret_analyze/architecture/architecture_reader_factory.py
@@ -20,6 +20,23 @@ class ArchitectureReaderFactory:
 
     @staticmethod
     def create_instance(file_type: str, file_path: str | list[str]):
+        """
+        Create an instance of ArchitectureReaderFactory.
+
+        Parameters
+        ----------
+        file_type : str
+            File type.
+            File type allows 'yaml','yml','lttng','ctf'.
+        file_path : str | list[str]
+            File path.
+
+        Raises
+        ------
+        ValueError
+            Unsupported file_type or multiple yaml files are provided.
+
+        """
         if file_type in ['yaml', 'yml']:
             if not isinstance(file_path, str):
                 raise ValueError(

--- a/src/caret_analyze/architecture/combine_path.py
+++ b/src/caret_analyze/architecture/combine_path.py
@@ -119,6 +119,17 @@ class CombinePath():
         left_last_child,    # 'singledispatchmethod' doesn't
         right_first_child,  # allow to attach annotation to parameters.
     ) -> None:
+        """
+        Validate to be able to combine.
+
+        Parameters
+        ----------
+        left_last_child : NodePathStructValue
+            left last child
+        right_first_child : NodePathStructValue
+            right first child
+
+        """
         msg = 'Unsupported type.'
         raise UnsupportedTypeError(msg)
 
@@ -295,6 +306,29 @@ class CombinePath():
         right_first_child: NodePathStructValue | CommunicationStructValue,
         node_paths: NodePathStructValue
     ) -> NodePathStructValue:
+        """
+        Find node path.
+
+        Parameters
+        ----------
+        left_last_child : NodePathStructValue
+            left last child
+        right_first_child : NodePathStructValue
+            right last child
+        node_paths : tuple[NodePathStructValue, ...]
+            candidate node paths
+
+        Returns
+        -------
+        NodePathStructValue
+            node path
+
+        Raises
+        ------
+        NotImplementedError
+            This module is not implemented.
+
+        """
         raise NotImplementedError('')
 
     @_find_node_path_core.register
@@ -426,6 +460,24 @@ class CombinePath():
         right_first_child: NodePathStructValue | CommunicationStructValue,
         node_paths: tuple[NodePathStructValue, ...],
     ) -> NodePathStructValue:
+        """
+        Find node path.
+
+        Parameters
+        ----------
+        left_last_child : NodePathStructValue | CommunicationStructValue
+            left last child
+        right_first_child : NodePathStructValue | CommunicationStructValue
+            right last child
+        node_paths : tuple[NodePathStructValue, ...]
+            candidate node paths
+
+        Returns
+        -------
+        NodePathStructValue
+            node path
+
+        """
         return self._find_node_path_core(left_last_child, right_first_child, node_paths)
 
     @staticmethod
@@ -670,6 +722,11 @@ class CombinePath():
         -------
         PathStructValue
             combined path
+
+        Raises
+        ------
+        NotImplementedError
+            This module is not implemented.
 
         """
         msg = 'This is a not implemented COMBINE case. Please contact maintainer if necessary.'

--- a/src/caret_analyze/architecture/graph_search.py
+++ b/src/caret_analyze/architecture/graph_search.py
@@ -47,9 +47,27 @@ class GraphPathCore(UserList):
 
     @property
     def path(self) -> tuple[GraphEdgeCore, ...]:
+        """
+        Get path.
+
+        Returns
+        -------
+        tuple[GraphEdgeCore, ...]
+            path.
+
+        """
         return tuple(self.data)
 
     def to_graph_node_indices(self) -> list[int]:
+        """
+        Get a list of node indices representing path.
+
+        Returns
+        -------
+        list[int]
+            nodes indices.
+
+        """
         if len(self) == 0:
             return []
 
@@ -74,6 +92,19 @@ class GraphCore:
         self._graph = defaultdict(list)
 
     def add_edge(self, u: int, v: int, label: str | None = None):
+        """
+        Add edge.
+
+        Parameters
+        ----------
+        u : int
+            from index.
+        v : int
+            to index.
+        label : str | None
+            label.
+
+        """
         self._v = max(self._v, u + 1, v + 1)
         self._graph[u].append(GraphEdgeCore(u, v, label))
 
@@ -167,6 +198,15 @@ class GraphNode(ValueObject):
 
     @property
     def node_name(self) -> str:
+        """
+        Get node name.
+
+        Returns
+        -------
+        str
+            Node name.
+
+        """
         return self._node_name
 
 
@@ -184,22 +224,67 @@ class GraphEdge(ValueObject):
 
     @property
     def label(self) -> str:
+        """
+        Get label.
+
+        Returns
+        -------
+        str
+            label.
+
+        """
         return self._label
 
     @property
     def node_from(self) -> GraphNode:
+        """
+        Get starting point of GraphNode.
+
+        Returns
+        -------
+        GraphNode
+            Starting point of GraphNode instance.
+
+        """
         return self._node_from
 
     @property
     def node_name_from(self) -> str:
+        """
+        Get starting point of node name.
+
+        Returns
+        -------
+        str
+           Starting point of node name.
+
+        """
         return self.node_from.node_name
 
     @property
     def node_to(self) -> GraphNode:
+        """
+        Get ending point of GraphNode.
+
+        Returns
+        -------
+        GraphNode
+            Ending point of GraphNode instance.
+
+        """
         return self._node_to
 
     @property
     def node_name_to(self) -> str:
+        """
+        Get ending point of node name.
+
+        Returns
+        -------
+        str
+            Ending point of node name.
+
+        """
         return self.node_to.node_name
 
 
@@ -211,10 +296,28 @@ class GraphPath(UserList):
 
     @property
     def edges(self) -> list[GraphEdge]:
+        """
+        Get edges.
+
+        Returns
+        -------
+        list[GraphEdge]
+            GraphEdge.
+
+        """
         return self.data
 
     @property
     def nodes(self) -> list[GraphNode]:
+        """
+        Get nodes.
+
+        Returns
+        -------
+        list[GraphNode]
+            GraphNode.
+
+        """
         if len(self) == 0:
             return []
 
@@ -240,12 +343,34 @@ class Graph:
         self._graph = GraphCore()
 
     def add_node(self, node: GraphNode) -> None:
+        """
+        Add node.
+
+        Parameters
+        ----------
+        node : GraphNode
+            node.
+
+        """
         index = len(self._nodes)
         self._idx_to_node[index] = node
         self._node_to_idx[node] = index
         self._nodes.add(node)
 
     def add_edge(self, node_from: GraphNode, node_to: GraphNode, label: str | None = None):
+        """
+        Add edge.
+
+        Parameters
+        ----------
+        node_from : GraphNode
+            from node.
+        node_to : GraphNode
+            to node.
+        label : str | None
+            label.
+
+        """
         if node_from not in self._nodes:
             self.add_node(node_from)
 
@@ -269,6 +394,27 @@ class Graph:
         *nodes: GraphNode,
         max_depth: int | None = None
     ) -> list[GraphPath]:
+        """
+        Search paths.
+
+        Parameters
+        ----------
+        nodes : GraphNode
+            Nodes.
+        max_depth : int | None
+            Max depth.
+
+        Returns
+        -------
+        list[GraphPath]:
+            Searched Graph Path.
+
+        Raises
+        ------
+        InvalidArgumentError
+            Occurs when there are 2 or fewer nodes.
+
+        """
         if len(nodes) < 2:
             raise InvalidArgumentError('nodes must be at least 2')
 
@@ -299,6 +445,7 @@ class Graph:
 
 
 class CallbackPathSearcher:
+    """Searcher of callback path."""
 
     def __init__(
         self,
@@ -348,6 +495,24 @@ class CallbackPathSearcher:
         end_callback: CallbackStruct,
         node: NodeStruct
     ) -> tuple[NodePathStruct, ...]:
+        """
+        Search paths.
+
+        Parameters
+        ----------
+        start_callback : CallbackStruct
+            start callback.
+        end_callback : CallbackStruct
+            end callback.
+        node : NodeStruct
+            node.
+
+        Returns
+        -------
+        tuple[NodePathStruct, ...]
+            Searched Node Path struct.
+
+        """
         # src_node = GraphNode(self._to_node_point_name(start_callback.callback_name, 'write'))
         # dst_node = GraphNode(self._to_node_point_name(end_callback.callback_name, 'read'))
 
@@ -501,6 +666,7 @@ CommKey = tuple[
 
 
 class NodePathSearcher:
+    """Searcher of node path."""
 
     def __init__(
         self,
@@ -634,6 +800,22 @@ class NodePathSearcher:
         *node_names: str,
         max_node_depth: int | None = None
     ) -> list[PathStruct]:
+        """
+        Search paths.
+
+        Parameters
+        ----------
+        node_names : str
+            Node names.
+        max_node_depth : int | None
+            Max node depth.
+
+        Returns
+        -------
+        list[PathStruct]
+            Searched path struct.
+
+        """
         paths: list[PathStruct] = []
 
         max_search_depth = max_node_depth or 0

--- a/src/caret_analyze/architecture/graph_search.py
+++ b/src/caret_analyze/architecture/graph_search.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 from collections import defaultdict, UserList
 from collections.abc import Callable
-from copy import deepcopy
 from itertools import product
 from logging import getLogger
 
@@ -78,106 +77,85 @@ class GraphCore:
         self._v = max(self._v, u + 1, v + 1)
         self._graph[u].append(GraphEdgeCore(u, v, label))
 
-    def _search_paths_recursion(
+    def search_paths(
         self,
         u: int,
         d: int,
-        edge: GraphEdgeCore | None,
-        visited: dict[tuple[int, int], bool],
-        path: GraphPathCore,
-        paths: list[GraphPathCore],
-    ) -> None:
-
-        if edge is not None:
-            path.append(edge)
-
-        if u == d:
-            paths.append(deepcopy(path))
-        else:
-            for edge in self._graph[u]:
-                i = edge.i_to
-
-                if visited[u, i] is False:
-                    visited[u, i] = True
-                    self._search_paths_recursion(
-                        i, d, edge, visited, path, paths)
-                    visited[u, i] = False
-
-        if len(path) > 0:
-            path.pop()
-
-    def _search_paths(
-        self,
-        u: int,
-        d: int,
-        edge: GraphEdgeCore | None,
-        visited: dict[tuple[int, int], bool],
-        path: GraphPathCore,
-        paths: list[GraphPathCore],
         max_depth: int = 0
-    ) -> None:
+    ) -> list[GraphPathCore]:
+        """
+        Search for paths from the given start to end node using Depth First Search (DFS).
 
+        Parameters
+        ----------
+        u : int
+            Index of the start node
+        d : int
+            Index of the end node
+        max_depth : int
+            Maximum depth of the search. Defaults to 0=unlimited (optional)
+
+        Returns
+        -------
+        list[GraphPathCore]
+            Returns list to all found paths.
+
+        """
+        paths: list[GraphPathCore] = []        # for result
+        # Initialize visited node management
+        visited = [[False for _ in range(self._v)] for _ in range(self._v)]
+        edge: GraphEdgeCore | None = None      # Last edge used in the current search path
+        path: GraphPathCore = GraphPathCore()  # List to store the current search path
+        has_max_depth = max_depth > 0
         edges_cache = []
         forward = True
-
-        def get_next_edge(u, edges_cache) -> GraphEdgeCore | None:
-            last_cache = edges_cache[-1]
-            if 0 < max_depth and max_depth < len(path):
-                return None
-            while len(last_cache) > 0:
-                edge = last_cache.pop()
-                i = edge.i_to
-                if visited[u, i] is False:
-                    return edge
-            return None
-
         u_start = u
 
-        edges_cache.append(deepcopy(self._graph[u]))
-        while True:
-            if u == d and forward and len(path) > 0:
-                paths.append(deepcopy(path))
+        # Add the initial edge list.
+        current_edges = self._graph[u].copy()
+        edges_cache.append(current_edges)
 
-            if u != d or u == u_start:
-                edge = get_next_edge(u, edges_cache)
-            else:
-                edge = None
+        while edges_cache:
+            if u == d and forward and path:
+                # If the goal is reached, record the path.
+                paths.append(path.copy())
+
+            # Get the next edge.
+            edge = None
+            if (u != d or u == u_start):
+                last_cache = edges_cache[-1]
+                if not (has_max_depth and len(path) > max_depth):
+                    idx = len(last_cache) - 1
+                    while idx >= 0:
+                        candidate_edge = last_cache[idx]
+                        i = candidate_edge.i_to
+                        if not visited[u][i]:
+                            edge = candidate_edge
+                            last_cache.pop(idx)
+                            break
+                        idx -= 1
+
+                    if edge is None:
+                        last_cache.clear()
 
             if edge is not None:
+                # forward.
                 i = edge.i_to
-                visited[u, i] = True
+                visited[u][i] = True
                 u = i
                 path.append(edge)
-                edges_cache.append(deepcopy(self._graph[u]))
-                forward = True
+                current_edges = self._graph[u].copy()
+                edges_cache.append(current_edges)
+                forward = True  # Set the flag to forward.
             else:
-                forward = False
+                # backward.
+                forward = False  # Set the flag to backward.
                 edges_cache.pop()
-                if len(path) > 0:
+                if path:
                     last_edge = path.pop()
                     u = last_edge.i_from
                     i = last_edge.i_to
-                    visited[u, i] = False
-
-                if edges_cache == []:
-                    return
-
-    def search_paths(
-        self,
-        start: int,
-        goal: int,
-        max_depth: int = 0
-    ) -> list[GraphPathCore]:
-
-        visited: dict[tuple[int, int], bool] = {}
-        for i, j in product(range(self._v), range(self._v)):
-            visited[i, j] = False
-
-        path: GraphPathCore = GraphPathCore()
-        paths: list[GraphPathCore] = []
-
-        # self._search_paths_recursion(start, goal, None, visited, path, paths)
-        self._search_paths(start, goal, None, visited, path, paths, max_depth)
+                    visited[u][i] = False
 
         return paths
 
@@ -325,6 +303,7 @@ class CallbackPathSearcher:
     def __init__(
         self,
         node: NodeStruct,
+        max_callback_construction_order: int
     ) -> None:
         self._node = node
 
@@ -337,7 +316,10 @@ class CallbackPathSearcher:
         self._graph = Graph()
 
         for callback in callbacks:
-            if callback.callback_name is None:
+            if callback.callback_name is None or (
+                max_callback_construction_order != 0 and
+                callback.construction_order > max_callback_construction_order
+            ):
                 continue
 
             write_name = self._to_node_point_name(callback.callback_name, 'write')
@@ -345,10 +327,14 @@ class CallbackPathSearcher:
 
             self._graph.add_edge(GraphNode(read_name), GraphNode(write_name))
 
+        callback_names = [callback.callback_name for callback in callbacks]
+
         for var_pass in var_passes:
-            if var_pass.callback_name_read is None:
+            if var_pass.callback_name_read is None or \
+                    var_pass.callback_name_read not in callback_names:
                 continue
-            if var_pass.callback_name_write is None:
+            if var_pass.callback_name_write is None or \
+                    var_pass.callback_name_write not in callback_names:
                 continue
 
             write_name = self._to_node_point_name(var_pass.callback_name_write, 'write')
@@ -378,8 +364,6 @@ class CallbackPathSearcher:
             publisher = node.get_publisher_from_callback(end_callback.callback_name)
             paths += self._to_paths(
                 graph_path,
-                start_callback,
-                end_callback,
                 subscription,
                 publisher
             )
@@ -389,8 +373,6 @@ class CallbackPathSearcher:
     def _to_paths(
         self,
         callback_graph_path: GraphPath,
-        start_callback: CallbackStruct,
-        end_callback: CallbackStruct,
         start_callback_subscription: SubscriptionStruct | None,
         end_callback_publishers: list[PublisherStruct] | None
     ) -> list[NodePathStruct]:
@@ -524,6 +506,7 @@ class NodePathSearcher:
         self,
         nodes: tuple[NodeStruct, ...],
         communications: tuple[CommunicationStruct, ...],
+        max_callback_construction_order: int,
         node_filter: Callable[[str], bool] | None = None,
         communication_filter: Callable[[str], bool] | None = None,
     ) -> None:
@@ -567,6 +550,11 @@ class NodePathSearcher:
             if node_filter is not None and not node_filter(comm.publish_node_name):
                 continue
             if node_filter is not None and not node_filter(comm.subscribe_node_name):
+                continue
+
+            sub_cb = comm.subscribe_callback
+            if max_callback_construction_order != 0 and sub_cb is not None and \
+                    sub_cb.construction_order > max_callback_construction_order:
                 continue
 
             key = self._comm_key(comm)

--- a/src/caret_analyze/architecture/reader_interface.py
+++ b/src/caret_analyze/architecture/reader_interface.py
@@ -56,7 +56,7 @@ class ArchitectureReader(metaclass=ABCMeta):
 
         Returns
         -------
-        Sequence[NodeValue]
+        Sequence[NodeValueWithId]
             node values.
 
         """
@@ -77,7 +77,7 @@ class ArchitectureReader(metaclass=ABCMeta):
 
         Returns
         -------
-        Sequence[TimerCallbackStructInfo]
+        Sequence[TimerCallbackValue]
             timer callback values
 
         """
@@ -93,12 +93,12 @@ class ArchitectureReader(metaclass=ABCMeta):
 
         Parameters
         ----------
-        node : NodeInfo
+        node : NodeValue
             target node
 
         Returns
         -------
-        Sequence[SubscriptionCallbackInfo]
+        Sequence[SubscriptionCallbackValue]
             subscription callback values
 
         """
@@ -119,7 +119,7 @@ class ArchitectureReader(metaclass=ABCMeta):
 
         Returns
         -------
-        Sequence[ServiceCallbackInfo]
+        Sequence[ServiceCallbackValue]
             service callback values
 
         """
@@ -216,7 +216,7 @@ class ArchitectureReader(metaclass=ABCMeta):
 
         Returns
         -------
-        Sequence[PathInfo]
+        Sequence[PathValue]
             path values
 
         """
@@ -238,6 +238,7 @@ class ArchitectureReader(metaclass=ABCMeta):
         Returns
         -------
         Sequence[dict]
+            message contexts
 
         """
         pass
@@ -252,7 +253,7 @@ class ArchitectureReader(metaclass=ABCMeta):
 
         Parameters
         ----------
-        node : NodeInfo
+        node : NodeValue
             target node
 
         Returns
@@ -286,7 +287,7 @@ class ArchitectureReader(metaclass=ABCMeta):
 
         Parameters
         ----------
-        node : NodeInfo
+        node : NodeValue
             target node
 
         Returns

--- a/src/caret_analyze/architecture/struct/callback.py
+++ b/src/caret_analyze/architecture/struct/callback.py
@@ -145,6 +145,20 @@ class CallbackStruct(metaclass=ABCMeta):
         pass
 
     def insert_publisher(self, publish_topic_info: PublishTopicInfoValue) -> None:
+        """
+        Insert publisher.
+
+        Parameters
+        ----------
+        publish_topic_info : PublishTopicInfoValue
+            Publish topic info to insert.
+
+        Raises
+        ------
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         if self.publish_topics is not None:
             for count in range(len(self.publish_topics)):
                 if self.publish_topics[count] == publish_topic_info:
@@ -162,16 +176,47 @@ class CallbackStruct(metaclass=ABCMeta):
                                          publish_topic_info.construction_order))
 
     def remove_publisher(self, publish_topic_info: PublishTopicInfoValue) -> None:
+        """
+        Remove publisher.
+
+        Parameters
+        ----------
+        publish_topic_info : PublishTopicInfoValue
+            Publish topic info to remove.
+
+        """
         if self.publish_topics is not None:
             for publish_topic in self.publish_topics:
                 if publish_topic == publish_topic_info:
                     self.publish_topics.remove(publish_topic)
 
     def rename_node(self, src: str, dst: str) -> None:
+        """
+        Rename node.
+
+        Parameters
+        ----------
+        src : str
+            Current node name.
+        dst : str
+            Updated node name.
+
+        """
         if self.node_name == src:
             self._node_name = dst
 
     def rename_topic(self, src: str, dst: str) -> None:
+        """
+        Rename topic.
+
+        Parameters
+        ----------
+        src : str
+            Current topic name.
+        dst : str
+            Updated topic name.
+
+        """
         if self.publish_topics is not None:
             for i, p in enumerate(self.publish_topics):
                 if p.topic_name == src:
@@ -214,6 +259,15 @@ class TimerCallbackStruct(CallbackStruct):
         return self._period_ns
 
     def to_value(self) -> TimerCallbackStructValue:
+        """
+        Get timer callback struct value.
+
+        Returns
+        -------
+        TimerCallbackStructValue
+            Timer callback struct value instance.
+
+        """
         return TimerCallbackStructValue(
             self.node_name, self.symbol, self.period_ns,
             None if self.publish_topics is None else tuple(self.publish_topics),
@@ -251,6 +305,15 @@ class SubscriptionCallbackStruct(CallbackStruct):
         return self.__subscribe_topic_name
 
     def to_value(self) -> SubscriptionCallbackStructValue:
+        """
+        Get subscription callback struct value.
+
+        Returns
+        -------
+        SubscriptionCallbackStructValue
+            Subscription callback struct value instance.
+
+        """
         return SubscriptionCallbackStructValue(
             self.node_name, self.symbol,
             self.subscribe_topic_name,
@@ -258,6 +321,17 @@ class SubscriptionCallbackStruct(CallbackStruct):
             self.construction_order, self.callback_name)
 
     def rename_topic(self, src: str, dst: str) -> None:
+        """
+        Rename topic.
+
+        Parameters
+        ----------
+        src : str
+            Current topic name.
+        dst : str
+            Updated topic name.
+
+        """
         if self.publish_topics is not None:
             for i, p in enumerate(self.publish_topics):
                 if p.topic_name == src:
@@ -298,6 +372,15 @@ class ServiceCallbackStruct(CallbackStruct):
         return self.__service_name
 
     def to_value(self) -> ServiceCallbackStructValue:
+        """
+        Get service callback struct value.
+
+        Returns
+        -------
+        ServiceCallbackStructValue
+            Service callback struct value instance.
+
+        """
         return ServiceCallbackStructValue(
             self.node_name,
             self.symbol,

--- a/src/caret_analyze/architecture/struct/callback_group.py
+++ b/src/caret_analyze/architecture/struct/callback_group.py
@@ -39,14 +39,10 @@ class CallbackGroupStruct():
             callback group type
         node_name: str
             node name
-        callbacks: tuple[CallbackStruct, ...]
+        callbacks: list[CallbackStruct, ...]
             callbacks
         callback_group_name: str
             callback group name
-
-        Returns
-        -------
-        None
 
         """
         self._callback_group_type = callback_group_type
@@ -57,11 +53,12 @@ class CallbackGroupStruct():
     @property
     def callback_group_type(self) -> CallbackGroupType:
         """
-        Get callback_group_type.
+        Get callback group type.
 
         Returns
         -------
         CallbackGroupType
+            Callback group type.
 
         """
         return self._callback_group_type
@@ -69,17 +66,27 @@ class CallbackGroupStruct():
     @property
     def callback_group_type_name(self) -> str:
         """
-        Get callback_group_type name.
+        Get callback group type name.
 
         Returns
         -------
-        CallbackGroupType name
+        str
+            Callback group type name.
 
         """
         return self._callback_group_type.type_name
 
     @property
     def callback_group_name(self) -> str:
+        """
+        Get callback group name.
+
+        Returns
+        -------
+        str
+            Callback group name.
+
+        """
         return self._callback_group_name
 
     @property
@@ -90,7 +97,7 @@ class CallbackGroupStruct():
         Returns
         -------
         str
-            node name
+            Node name.
 
         """
         return self._node_name
@@ -104,11 +111,31 @@ class CallbackGroupStruct():
         return [i.callback_name for i in self._callbacks]
 
     def to_value(self) -> CallbackGroupStructValue:
+        """
+        Get callback group struct value.
+
+        Returns
+        -------
+        CallbackGroupStructValue
+            Callback group struct value instance.
+
+        """
         return CallbackGroupStructValue(self.callback_group_type, self.node_name,
                                         tuple(v.to_value() for v in self.callbacks),
                                         self.callback_group_name)
 
     def rename_node(self, src: str, dst: str) -> None:
+        """
+        Rename node.
+
+        Parameters
+        ----------
+        src : str
+            Current node name.
+        dst : str
+            Updated node name.
+
+        """
         if self.node_name == src:
             self._node_name = dst
 
@@ -116,5 +143,16 @@ class CallbackGroupStruct():
             c.rename_node(src, dst)
 
     def rename_topic(self, src: str, dst: str) -> None:
+        """
+        Rename topic.
+
+        Parameters
+        ----------
+        src : str
+            Current topic name.
+        dst : str
+            Updated topic name.
+
+        """
         for c in self._callbacks:
             c.rename_topic(src, dst)

--- a/src/caret_analyze/architecture/struct/communication.py
+++ b/src/caret_analyze/architecture/struct/communication.py
@@ -101,6 +101,15 @@ class CommunicationStruct():
         return self._node_pub.node_name
 
     def to_value(self) -> CommunicationStructValue:
+        """
+        Get Communication struct value.
+
+        Returns
+        -------
+        CommunicationStructValue
+            Communication struct value instance.
+
+        """
         return CommunicationStructValue(
             self.publish_node.to_value(),
             self.subscribe_node.to_value(),
@@ -112,6 +121,17 @@ class CommunicationStruct():
             else self.subscribe_callback.to_value())
 
     def rename_node(self, src: str, dst: str) -> None:
+        """
+        Rename node.
+
+        Parameters
+        ----------
+        src : str
+            Current node name.
+        dst : str
+            Updated node name.
+
+        """
         self._node_pub.rename_node(src, dst)
         self._node_sub.rename_node(src, dst)
         self._publisher_value.rename_node(src, dst)
@@ -123,6 +143,17 @@ class CommunicationStruct():
             self._subscription_callback_value.rename_node(src, dst)
 
     def rename_topic(self, src: str, dst: str) -> None:
+        """
+        Rename topic.
+
+        Parameters
+        ----------
+        src : str
+            Current topic name.
+        dst : str
+            Updated topic name.
+
+        """
         if self.topic_name == src:
             self._topic_name = dst
 

--- a/src/caret_analyze/architecture/struct/executor.py
+++ b/src/caret_analyze/architecture/struct/executor.py
@@ -69,14 +69,45 @@ class ExecutorStruct():
         return cbg_names
 
     def to_value(self) -> ExecutorStructValue:
+        """
+        Get executor struct value.
+
+        Returns
+        -------
+        ExecutorStructValue
+            Executor struct value instance.
+
+        """
         return ExecutorStructValue(self.executor_type,
                                    tuple(v.to_value() for v in self.callback_groups),
                                    self.executor_name)
 
     def rename_node(self, src: str, dst: str) -> None:
+        """
+        Rename node.
+
+        Parameters
+        ----------
+        src : str
+            Current node name.
+        dst : str
+            Updated node name.
+
+        """
         for c in self._cbg_values:
             c.rename_node(src, dst)
 
     def rename_topic(self, src: str, dst: str) -> None:
+        """
+        Rename topic.
+
+        Parameters
+        ----------
+        src : str
+            Current topic name.
+        dst : str
+            Updated topic name.
+
+        """
         for c in self._cbg_values:
             c.rename_topic(src, dst)

--- a/src/caret_analyze/architecture/struct/message_context.py
+++ b/src/caret_analyze/architecture/struct/message_context.py
@@ -76,6 +76,15 @@ class MessageContextStruct():
         return self._callbacks
 
     def to_dict(self) -> dict:
+        """
+        Get message context struct dict data.
+
+        Returns
+        -------
+        dict
+            Message context struct dict data.
+
+        """
         return {
             'context_type': str(self.type_name),
             'subscription_topic_name': self.subscription_topic_name,
@@ -90,6 +99,24 @@ class MessageContextStruct():
         publisher: PublisherStruct | None,
         callbacks: list[CallbackStruct] | None
     ) -> bool:
+        """
+        Get applicable path.
+
+        Parameters
+        ----------
+        subscription : SubscriptionStruct | None
+            Target subscription value.
+        publisher : PublisherStruct | None
+            Target publisher value.
+        callbacks : list[CallbackStruct] | None
+            Target callbacks.
+
+        Returns
+        -------
+        bool
+            True if applicable path, false otherwise.
+
+        """
         def _to_value(struct):
             return None if struct is None else struct.to_value()
         return _to_value(self._sub) == _to_value(subscription) \
@@ -128,6 +155,35 @@ class MessageContextStruct():
         publisher: PublisherStruct | None,
         child: list[CallbackStruct] | None
     ) -> MessageContextStruct:
+        """
+        Get create instance.
+
+        Parameters
+        ----------
+        context_type_name : str
+            Context type name.
+        context_dict : dict
+            Context dict.
+        node_name : str
+            Node name.
+        subscription : SubscriptionStruct | None
+            Target subscription value.
+        publisher: PublisherStruct | None
+            Target publisher.
+        child : list[CallbackStruct] | None
+            Child elements.
+
+        Returns
+        -------
+        MessageContextStruct
+            Created MessageContextStruct instance.
+
+        Raises
+        ------
+        UnsupportedTypeError
+            Argument context_type_name is not supported.
+
+        """
         if context_type_name == str(MessageContextType.CALLBACK_CHAIN):
             return CallbackChainStruct(node_name,
                                        context_dict,
@@ -160,6 +216,17 @@ class MessageContextStruct():
         pass
 
     def rename_node(self, src: str, dst: str) -> None:
+        """
+        Rename node.
+
+        Parameters
+        ----------
+        src : str
+            Current node name.
+        dst : str
+            Updated node name.
+
+        """
         if self.node_name == src:
             self._node_name = dst
 
@@ -174,6 +241,17 @@ class MessageContextStruct():
                 c.rename_node(src, dst)
 
     def rename_topic(self, src: str, dst: str) -> None:
+        """
+        Rename topic.
+
+        Parameters
+        ----------
+        src : str
+            Current topic name.
+        dst : str
+            Updated topic name.
+
+        """
         if self._pub is not None:
             self._pub.rename_topic(src, dst)
 
@@ -195,6 +273,15 @@ class UseLatestMessageStruct(MessageContextStruct):
         return MessageContextType.USE_LATEST_MESSAGE
 
     def to_value(self) -> UseLatestMessage:
+        """
+        Get use latest message.
+
+        Returns
+        -------
+        UseLatestMessage
+            UseLatestMessage instance.
+
+        """
         return UseLatestMessage(
             self.node_name, self._message_context_dict,
             None if self._sub is None else self._sub.to_value(),
@@ -217,6 +304,15 @@ class InheritUniqueStampStruct(MessageContextStruct):
         return MessageContextType.INHERIT_UNIQUE_STAMP
 
     def to_value(self) -> InheritUniqueStamp:
+        """
+        Get inherit unique stamp.
+
+        Returns
+        -------
+        InheritUniqueStamp
+            InheritUniqueStamp instance.
+
+        """
         return InheritUniqueStamp(
             self.node_name, self._message_context_dict,
             None if self._sub is None else self._sub.to_value(),
@@ -263,6 +359,24 @@ class CallbackChainStruct(MessageContextStruct):
         publisher: PublisherStruct | None,
         callbacks: list[CallbackStruct] | None
     ) -> bool:
+        """
+        Get applicable path.
+
+        Parameters
+        ----------
+        subscription : SubscriptionStruct | None
+            Target subscription value.
+        publisher : PublisherStruct | None
+            Target publisher value.
+        callbacks : list[CallbackStruct] | None
+            Target callbacks.
+
+        Returns
+        -------
+        bool
+            True if applicable path, false otherwise.
+
+        """
         def _to_values(structs):
             if structs is None:
                 return None
@@ -273,12 +387,30 @@ class CallbackChainStruct(MessageContextStruct):
         return _to_values(self.callbacks) == _to_values(callbacks)
 
     def to_dict(self) -> dict:
+        """
+        Get callback chain struct dict data.
+
+        Returns
+        -------
+        dict
+            Callback chain struct dict data.
+
+        """
         d = super().to_dict()
         if self.callbacks is not None:
             d['callbacks'] = [_.callback_name for _ in self.callbacks]
         return d
 
     def to_value(self) -> CallbackChain:
+        """
+        Get callback chain.
+
+        Returns
+        -------
+        CallbackChain
+            Callback chain instance.
+
+        """
         return CallbackChain(
             self.node_name, self._message_context_dict,
             None if self._sub is None else self._sub.to_value(),
@@ -320,11 +452,38 @@ class TildeStruct(MessageContextStruct):
         publisher: PublisherStruct | None,
         callbacks: list[CallbackStruct] | None
     ) -> bool:
+        """
+        Get applicable path.
+
+        Parameters
+        ----------
+        subscription : SubscriptionStruct | None
+            Target subscription value.
+        publisher : PublisherStruct | None
+            Target publisher value.
+        callbacks : list[CallbackStruct] | None
+            Target callbacks.
+
+        Returns
+        -------
+        bool
+            True if applicable path, false otherwise.
+
+        """
         if not super().is_applicable_path(subscription, publisher, callbacks):
             return False
         return True
 
     def to_value(self) -> Tilde:
+        """
+        Get tilde value.
+
+        Returns
+        -------
+        Tilde
+            Tilde value instance.
+
+        """
         return Tilde(
             self.node_name, self._message_context_dict,
             None if self._sub is None else self._sub.to_value(),

--- a/src/caret_analyze/architecture/struct/node.py
+++ b/src/caret_analyze/architecture/struct/node.py
@@ -113,6 +113,30 @@ class NodeStruct():
         subscribe_topic_name: str,
         construction_order: int | None = None
     ) -> SubscriptionStruct:
+        """
+        Get subscription.
+
+        Parameters
+        ----------
+        subscribe_topic_name : str
+            Topic name to get.
+        construction_order : int | None
+            Construction order to get.
+            If construction_order is None, searches for information only by topic_name.
+
+        Returns
+        -------
+        SubscriptionStruct
+            Subscription instance that matches the condition.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
 
         def is_target(subscription: SubscriptionStruct):
             match = subscription.topic_name == subscribe_topic_name
@@ -133,6 +157,30 @@ class NodeStruct():
         service_name: str,
         construction_order: int | None
     ) -> ServiceStruct:
+        """
+        Get service.
+
+        Parameters
+        ----------
+        service_name : str
+            Service name to get.
+        construction_order : int | None
+            Construction order to get.
+            If construction_order is None, searches for information only by service_name.
+
+        Returns
+        -------
+        ServiceStruct
+            Service instance that matches the condition.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
 
         def is_target(service: ServiceStruct):
             match = service.service_name == service_name
@@ -153,6 +201,30 @@ class NodeStruct():
         publish_topic_name: str,
         construction_order: int | None
     ) -> PublisherStruct:
+        """
+        Get publisher.
+
+        Parameters
+        ----------
+        publish_topic_name : str
+            Publish topic name to get.
+        construction_order : int | None
+            Construction order to get.
+            If construction_order is None, searches for information only by topic_name.
+
+        Returns
+        -------
+        PublisherStruct
+            Publisher instance that matches the condition.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         try:
             def is_target_publisher(publisher: PublisherStruct):
                 return publisher.topic_name == publish_topic_name and \
@@ -167,6 +239,15 @@ class NodeStruct():
             raise ItemNotFoundError(msg)
 
     def to_value(self) -> NodeStructValue:
+        """
+        Get node struct value.
+
+        Returns
+        -------
+        NodeStructValue
+            Node struct value instance.
+
+        """
         return NodeStructValue(
             self.node_name,
             tuple(v.to_value() for v in self.publishers),
@@ -180,6 +261,15 @@ class NodeStruct():
             else tuple(v.to_value() for v in self.variable_passings))
 
     def update_node_path(self, paths: list[NodePathStruct]) -> None:
+        """
+        Update node path.
+
+        Parameters
+        ----------
+        paths : list[NodePathStruct]
+            Node path to update.
+
+        """
         self._node_paths = paths
 
     # def update_message_context(self, node_name: str, context_type: str,
@@ -193,6 +283,26 @@ class NodeStruct():
                                   publish_topic_name: str,
                                   callback_name: str,
                                   publisher_construction_order: int) -> None:
+        """
+        Insert publisher callback.
+
+        Parameters
+        ----------
+        publish_topic_name : str
+            Publish topic name to insert.
+        callback_name : str
+            Publish callback name to insert.
+        publisher_construction_order : int
+            Publisher construction order to insert.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         callback: CallbackStruct = \
             Util.find_one(lambda x: x.callback_name == callback_name, self.callbacks)
         pub_info = PublishTopicInfoValue(publish_topic_name, publisher_construction_order)
@@ -215,6 +325,24 @@ class NodeStruct():
         publisher.insert_callback(callback)
 
     def insert_variable_passing(self, callback_name_write: str, callback_name_read: str) -> None:
+        """
+        Insert variable passing.
+
+        Parameters
+        ----------
+        callback_name_write : str
+            callback name on the write side.
+        callback_name_read : str
+            callback name on the read side.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         callback_write: CallbackStruct =\
             Util.find_one(lambda x: x.callback_name == callback_name_write, self.callbacks)
         callback_read: CallbackStruct =\
@@ -232,6 +360,26 @@ class NodeStruct():
                                       publish_topic_name: str,
                                       callback_name: str,
                                       publisher_construction_order: int) -> None:
+        """
+        Remove publisher and callback.
+
+        Parameters
+        ----------
+        publish_topic_name : str
+            Publish topic name to remove.
+        callback_name : str
+            Publish callback name to remove.
+        publisher_construction_order : int
+            Publisher construction order to remove.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         callback: CallbackStruct = \
             Util.find_one(lambda x: x.callback_name == callback_name, self.callbacks)
         pub_info = PublishTopicInfoValue(publish_topic_name, publisher_construction_order)
@@ -254,6 +402,17 @@ class NodeStruct():
         publisher.remove_callback(callback)
 
     def remove_variable_passing(self, callback_name_write: str, callback_name_read: str) -> None:
+        """
+        Remove variable passing.
+
+        Parameters
+        ----------
+        callback_name_write : str
+            callback name on the write side.
+        callback_name_read : str
+            callback name on the read side.
+
+        """
         if self._variable_passings_info:
             self._variable_passings_info =\
                 [passing for passing in self._variable_passings_info
@@ -261,6 +420,17 @@ class NodeStruct():
                  (passing.callback_name_write, passing.callback_name_read)]
 
     def rename_node(self, src: str, dst: str) -> None:
+        """
+        Rename node.
+
+        Parameters
+        ----------
+        src : str
+            Current node name.
+        dst : str
+            Updated node name.
+
+        """
         if self.node_name == src:
             self._node_name = dst
 
@@ -285,6 +455,17 @@ class NodeStruct():
                 v.rename_node(src, dst)
 
     def rename_topic(self, src: str, dst: str) -> None:
+        """
+        Rename topic.
+
+        Parameters
+        ----------
+        src : str
+            Current topic name.
+        dst : str
+            Updated topic name.
+
+        """
         for p in self._publishers:
             p.rename_topic(src, dst)
 
@@ -306,6 +487,20 @@ class NodeStruct():
                 v.rename_topic(src, dst)
 
     def get_publisher_from_callback(self, callback_name: str) -> list[PublisherStruct]:
+        """
+        Get publisher from callback.
+
+        Parameters
+        ----------
+        callback_name : str
+            callback name to get.
+
+        Returns
+        -------
+        list[PublisherStruct]
+            Publisher instance that matches the condition.
+
+        """
         l: list[PublisherStruct] = []
         for publisher in self.publishers:
             if publisher.callback_names and callback_name in publisher.callback_names:
@@ -313,6 +508,20 @@ class NodeStruct():
         return l
 
     def get_subscription_from_callback(self, callback_name: str) -> SubscriptionStruct | None:
+        """
+        Get subscription from callback.
+
+        Parameters
+        ----------
+        callback_name : str
+            callback name to get.
+
+        Returns
+        -------
+        SubscriptionStruct
+            Subscription instance that matches the condition.
+
+        """
         for subscription in self.subscriptions:
             if subscription.callback_name == callback_name:
                 return subscription

--- a/src/caret_analyze/architecture/struct/node_path.py
+++ b/src/caret_analyze/architecture/struct/node_path.py
@@ -138,6 +138,15 @@ class NodePathStruct():
         return self._subscription.topic_name
 
     def to_value(self) -> NodePathStructValue:
+        """
+        Get node path struct value.
+
+        Returns
+        -------
+        NodePathStructValue
+            Node path struct value instance.
+
+        """
         return NodePathStructValue(
             self.node_name,
             None if self.subscription is None else self.subscription.to_value(),
@@ -146,6 +155,17 @@ class NodePathStruct():
             None if self.message_context is None else self.message_context.to_value())
 
     def rename_node(self, src: str, dst: str) -> None:
+        """
+        Rename node.
+
+        Parameters
+        ----------
+        src : str
+            Current node name.
+        dst : str
+            Updated node name.
+
+        """
         if self.node_name == src:
             self._node_name = dst
 
@@ -167,6 +187,17 @@ class NodePathStruct():
                 v.rename_node(src, dst)
 
     def rename_topic(self, src: str, dst: str) -> None:
+        """
+        Rename topic.
+
+        Parameters
+        ----------
+        src : str
+            Current topic name.
+        dst : str
+            Updated topic name.
+
+        """
         if self._publisher is not None:
             self._publisher.rename_topic(src, dst)
 

--- a/src/caret_analyze/architecture/struct/path.py
+++ b/src/caret_analyze/architecture/struct/path.py
@@ -100,10 +100,30 @@ class PathStruct():
             raise InvalidArgumentError(msg)
 
     def to_value(self) -> PathStructValue:
+        """
+        Get path struct value.
+
+        Returns
+        -------
+        PathStructValue
+            Path struct value instance.
+
+        """
         return PathStructValue(None if self.path_name is None else self.path_name,
                                tuple(v.to_value() for v in self.child))
 
     def rename_node(self, src: str, dst: str) -> None:
+        """
+        Rename node.
+
+        Parameters
+        ----------
+        src : str
+            Current node name.
+        dst : str
+            Updated node name.
+
+        """
         for n in self.node_paths:
             n.rename_node(src, dst)
 
@@ -111,6 +131,17 @@ class PathStruct():
             c.rename_node(src, dst)
 
     def rename_topic(self, src: str, dst: str) -> None:
+        """
+        Rename topic.
+
+        Parameters
+        ----------
+        src : str
+            Current topic name.
+        dst : str
+            Updated topic name.
+
+        """
         for n in self.node_paths:
             n.rename_topic(src, dst)
 

--- a/src/caret_analyze/architecture/struct/publisher.py
+++ b/src/caret_analyze/architecture/struct/publisher.py
@@ -62,6 +62,15 @@ class PublisherStruct():
         return self._construction_order
 
     def to_value(self) -> PublisherStructValue:
+        """
+        Get publisher struct value.
+
+        Returns
+        -------
+        PublisherStructValue
+            Publisher struct value instance.
+
+        """
         return PublisherStructValue(
             node_name=self.node_name,
             topic_name=self.topic_name,
@@ -71,16 +80,45 @@ class PublisherStruct():
             construction_order=self.construction_order)
 
     def insert_callback(self, callback: CallbackStruct) -> None:
+        """
+        Insert callback.
+
+        Parameters
+        ----------
+        callback : CallbackStruct
+            callback struct to insert.
+
+        """
         if self._callbacks is None:
             self._callbacks = [callback]
         elif callback.callback_name not in (self.callback_names or []):
             self._callbacks.append(callback)
 
     def remove_callback(self, callback: CallbackStruct) -> None:
+        """
+        Remove callback.
+
+        Parameters
+        ----------
+        callback : CallbackStruct
+            callback struct to remove.
+
+        """
         if self._callbacks and callback in self._callbacks:
             self._callbacks.remove(callback)
 
     def rename_node(self, src: str, dst: str) -> None:
+        """
+        Rename node.
+
+        Parameters
+        ----------
+        src : str
+            Current node name.
+        dst : str
+            Updated node name.
+
+        """
         if self.node_name == src:
             self._node_name = dst
 
@@ -89,6 +127,17 @@ class PublisherStruct():
                 c.rename_node(src, dst)
 
     def rename_topic(self, src: str, dst: str) -> None:
+        """
+        Rename topic.
+
+        Parameters
+        ----------
+        src : str
+            Current topic name.
+        dst : str
+            Updated topic name.
+
+        """
         if self.topic_name == src:
             self._topic_name = dst
 

--- a/src/caret_analyze/architecture/struct/service.py
+++ b/src/caret_analyze/architecture/struct/service.py
@@ -57,6 +57,15 @@ class ServiceStruct():
         return self._construction_order
 
     def to_value(self) -> ServiceStructValue:
+        """
+        Get service struct value.
+
+        Returns
+        -------
+        ServiceStructValue
+            Service struct value instance.
+
+        """
         return ServiceStructValue(
             node_name=self.node_name,
             service_name=self.service_name,

--- a/src/caret_analyze/architecture/struct/subscription.py
+++ b/src/caret_analyze/architecture/struct/subscription.py
@@ -57,6 +57,15 @@ class SubscriptionStruct():
         return self._construction_order
 
     def to_value(self) -> SubscriptionStructValue:
+        """
+        Get subscription struct value.
+
+        Returns
+        -------
+        SubscriptionStructValue
+            Subscription struct value instance.
+
+        """
         return SubscriptionStructValue(
             node_name=self.node_name,
             topic_name=self.topic_name,
@@ -65,6 +74,17 @@ class SubscriptionStruct():
         )
 
     def rename_node(self, src: str, dst: str) -> None:
+        """
+        Rename node.
+
+        Parameters
+        ----------
+        src : str
+            Current node name.
+        dst : str
+            Updated node name.
+
+        """
         if self.node_name == src:
             self._node_name = dst
 
@@ -72,6 +92,17 @@ class SubscriptionStruct():
             self._callback_value.rename_node(src, dst)
 
     def rename_topic(self, src: str, dst: str) -> None:
+        """
+        Rename topic.
+
+        Parameters
+        ----------
+        src : str
+            Current topic name.
+        dst : str
+            Updated topic name.
+
+        """
         if self.topic_name == src:
             self._topic_name = dst
 

--- a/src/caret_analyze/architecture/struct/timer.py
+++ b/src/caret_analyze/architecture/struct/timer.py
@@ -57,6 +57,15 @@ class TimerStruct():
         return self._construction_order
 
     def to_value(self) -> TimerStructValue:
+        """
+        Get timer struct value.
+
+        Returns
+        -------
+        TimerStructValue
+            Timer struct value instance.
+
+        """
         return TimerStructValue(
             node_name=self.node_name,
             period_ns=self.period_ns,
@@ -64,6 +73,17 @@ class TimerStruct():
             construction_order=self.construction_order)
 
     def rename_node(self, src: str, dst: str) -> None:
+        """
+        Rename node.
+
+        Parameters
+        ----------
+        src : str
+            Current node name.
+        dst : str
+            Updated node name.
+
+        """
         if self.node_name == src:
             self._node_name = dst
 
@@ -71,5 +91,16 @@ class TimerStruct():
             self._callback_value.rename_node(src, dst)
 
     def rename_topic(self, src: str, dst: str) -> None:
+        """
+        Rename topic.
+
+        Parameters
+        ----------
+        src : str
+            Current topic name.
+        dst : str
+            Updated topic name.
+
+        """
         if self._callback_value is not None:
             self._callback_value.rename_topic(src, dst)

--- a/src/caret_analyze/architecture/struct/variable_passing.py
+++ b/src/caret_analyze/architecture/struct/variable_passing.py
@@ -39,7 +39,7 @@ class VariablePassingStruct():
         Returns
         -------
         str
-            node name
+            Node name.
 
         """
         return self._node_name
@@ -51,8 +51,8 @@ class VariablePassingStruct():
 
         Returns
         -------
-        [str]
-            write-side callback name.
+        str
+            Write-side callback name.
 
         """
         return self._cb_write.callback_name
@@ -64,8 +64,8 @@ class VariablePassingStruct():
 
         Returns
         -------
-        [str]
-            read-side callback name.
+        str
+            Read-side callback name.
 
         """
         return self._cb_read.callback_name
@@ -79,11 +79,31 @@ class VariablePassingStruct():
         return self._cb_read
 
     def to_value(self) -> VariablePassingStructValue:
+        """
+        Get variable passing struct value.
+
+        Returns
+        -------
+        VariablePassingStructValue
+            VariablePassing struct value instance.
+
+        """
         return VariablePassingStructValue(self.node_name,
                                           self.callback_write.to_value(),
                                           self.callback_read.to_value())
 
     def rename_node(self, src: str, dst: str) -> None:
+        """
+        Rename node.
+
+        Parameters
+        ----------
+        src : str
+            Current node name.
+        dst : str
+            Updated node name.
+
+        """
         if self.node_name == src:
             self._node_name = dst
 
@@ -91,5 +111,16 @@ class VariablePassingStruct():
         self._cb_write.rename_node(src, dst)
 
     def rename_topic(self, src: str, dst: str) -> None:
+        """
+        Rename topic.
+
+        Parameters
+        ----------
+        src : str
+            Current topic name.
+        dst : str
+            Updated topic name.
+
+        """
         self._cb_read.rename_topic(src, dst)
         self._cb_write.rename_topic(src, dst)

--- a/src/caret_analyze/architecture/util.py
+++ b/src/caret_analyze/architecture/util.py
@@ -29,7 +29,6 @@ def check_procedure(
     app_arch: Architecture,
     node_name: str,
 ) -> tuple[NodePathStructValue, ...]:
-
     handler = StreamHandler()
     handler.setLevel(INFO)
 

--- a/src/caret_analyze/infra/interface.py
+++ b/src/caret_analyze/infra/interface.py
@@ -41,12 +41,12 @@ class RecordsProvider(metaclass=ABCMeta):
         Parameters
         ----------
         callback_info : CallbackStructValue
-            [description]
+            Static info of callback.
 
         Returns
         -------
         RecordsInterface
-            [description]
+            Records interface
 
         """
         pass
@@ -70,6 +70,7 @@ class RecordsProvider(metaclass=ABCMeta):
         Returns
         -------
         RecordsInterface
+            Records interface
 
         """
         pass

--- a/src/caret_analyze/infra/lttng/architecture_reader_lttng.py
+++ b/src/caret_analyze/infra/lttng/architecture_reader_lttng.py
@@ -49,77 +49,258 @@ class ArchitectureReaderLttng(ArchitectureReader):
         self,
         callback_group_id: str
     ) -> Sequence[tuple[str | None, str | None]]:
+        """
+        Get node names and callback symbols.
+
+        Parameters
+        ----------
+        callback_group_id : str
+            callback group id.
+
+        Returns
+        -------
+        Sequence[tuple[str | None, str | None]]
+            Node names and callback symbols.
+
+        """
         return self._lttng.get_node_names_and_cb_symbols(callback_group_id)
 
     def get_nodes(self) -> Sequence[NodeValueWithId]:
+        """
+        Get nodes.
+
+        Returns
+        -------
+        Sequence[NodeValueWithId]
+            Node value with id.
+
+        """
         return self._lttng.get_nodes()
 
     def get_timer_callbacks(
         self,
         node: NodeValue
     ) -> Sequence[TimerCallbackValue]:
+        """
+        Get timer callback values.
+
+        Parameters
+        ----------
+        node : NodeValue
+            target node
+
+        Returns
+        -------
+        Sequence[TimerCallbackValue]
+            timer callback values
+
+        """
         return self._lttng.get_timer_callbacks(node)
 
     def get_variable_passings(
         self,
         node: NodeValue
     ) -> Sequence[VariablePassingValue]:
+        """
+        Get variable passings.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[VariablePassingValue]
+            Always empty sequence.
+
+        """
         return []
 
     def get_message_contexts(
         self,
         node: NodeValue
     ) -> Sequence[dict]:
+        """
+        Get message contexts.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[dict]
+            Always empty sequence.
+
+        """
         return []
 
     def get_executors(
         self
     ) -> Sequence[ExecutorValue]:
+        """
+        Get executors.
+
+        Returns
+        -------
+        Sequence[ExecutorValue]
+            Executor value.
+
+        """
         return self._lttng.get_executors()
 
     def get_subscription_callbacks(
         self,
         node: NodeValue
     ) -> Sequence[SubscriptionCallbackValue]:
+        """
+        Get subscription callbacks.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[SubscriptionCallbackValue]
+            Subscription callback value.
+
+        """
         return self._lttng.get_subscription_callbacks(node)
 
     def get_service_callbacks(
         self,
         node: NodeValue
     ) -> Sequence[ServiceCallbackValue]:
+        """
+        Get service callbacks.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[ServiceCallbackValue]
+            Service callback value.
+
+        """
         return self._lttng.get_service_callbacks(node)
 
     def get_publishers(
         self,
         node: NodeValue
     ) -> Sequence[PublisherValue]:
+        """
+        Get publishers.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[PublisherValue]
+            Publisher value.
+
+        """
         return self._lttng.get_publishers(node)
 
     def get_timers(
         self,
         node: NodeValue
     ) -> Sequence[TimerValue]:
+        """
+        Get timers.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[TimerValue]
+            Timer value.
+
+        """
         return self._lttng.get_timers(node)
 
     def get_callback_groups(
         self,
         node: NodeValue
     ) -> Sequence[CallbackGroupValue]:
+        """
+        Get callback groups.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[CallbackGroupValue]
+            Callback group value.
+
+        """
         return self._lttng.get_callback_groups(node)
 
     def get_paths(
         self
     ) -> Sequence[PathValue]:
+        """
+        Get paths.
+
+        Returns
+        -------
+        Sequence[PathValue]
+            Path value.
+
+        """
         return []
 
     def get_subscriptions(
         self,
         node: NodeValue
     ) -> Sequence[SubscriptionValue]:
+        """
+        Get subscriptions.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[SubscriptionValue]
+            Subscription value.
+
+        """
         return self._lttng.get_subscriptions(node)
 
     def get_services(
         self,
         node: NodeValue
     ) -> Sequence[ServiceValue]:
+        """
+        Get services.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[ServiceValue]
+            Service value.
+
+        """
         return self._lttng.get_services(node)

--- a/src/caret_analyze/infra/lttng/bridge.py
+++ b/src/caret_analyze/infra/lttng/bridge.py
@@ -44,16 +44,17 @@ class LttngBridge:
         - node name
         - callback type
         - period_ns
-        - publish topic names
+        - symbol
+        - construction order
 
         Parameters
         ----------
-        callback :TimerCallbackStructValueTimerCallbackStructValue
+        callback :TimerCallbackStructValue
             Callback value to be searched.
 
         Returns
         -------
-        [TimerCallbackValueLttng]
+        TimerCallbackValueLttng
             Timer callback value, including runtime information.
 
         Raises
@@ -90,8 +91,9 @@ class LttngBridge:
         used conditions:
         - node name
         - callback type
-        - subscription topic name
-        - publish topic names
+        - symbol
+        - subscribe topic name
+        - construction order
 
         Parameters
         ----------
@@ -134,6 +136,11 @@ class LttngBridge:
         """
         Get publisher handles.
 
+        used conditions:
+        - node name
+        - topic name
+        - construction order
+
         Parameters
         ----------
         publisher_value : PublisherStructValue
@@ -143,6 +150,11 @@ class LttngBridge:
         -------
         list[PublisherValueLttng]
             publisher values that match the condition
+
+        Raises
+        ------
+        ItemNotFoundError
+            No value matching the search condition is found.
 
         """
         try:
@@ -166,7 +178,8 @@ class TimerCallbackBindCondition:
     - node name
     - callback type
     - period_ns
-    - publish topic names
+    - symbol
+    - construction order
 
     """
 
@@ -212,8 +225,9 @@ class SubscriptionCallbackBindCondition:
     used conditions:
     - node name
     - callback type
-    - subscription topic name
-    - publish topic names
+    - symbol
+    - subscribe topic name
+    - construction order
 
     """
 
@@ -265,6 +279,7 @@ class PublisherBindCondition:
     used conditions:
     - node name
     - topic name
+    - construction order
 
     """
 

--- a/src/caret_analyze/infra/lttng/event_counter.py
+++ b/src/caret_analyze/infra/lttng/event_counter.py
@@ -36,6 +36,25 @@ class EventCounter:
             self._validate()
 
     def get_count(self, groupby: list[str]) -> pd.DataFrame:
+        """
+        Get event counter in pandas DataFrame format.
+
+        Parameters
+        ----------
+        groupby : list[str]
+            Data group.
+
+        Returns
+        -------
+        pd.DataFrame
+            Event counter dataframe.
+
+        Raises
+        ------
+        InvalidArgumentError
+            Occurs when groupby keys were invalid.
+
+        """
         if len(set(groupby) - self._allowed_keys) > 0:
             raise InvalidArgumentError(
                 f'invalid groupby: {groupby}. {self._allowed_keys} are allowed.')

--- a/src/caret_analyze/infra/lttng/lttng.py
+++ b/src/caret_analyze/infra/lttng/lttng.py
@@ -90,6 +90,15 @@ class EventCollection(Iterable, Sized):
         return iter(self._iterable_events)
 
     def time_range(self) -> tuple[int, int]:
+        """
+        Get begin and end time range.
+
+        Returns
+        -------
+        tuple[int, int]
+            begin and end time.
+
+        """
         return self._iterable_events.time_range()
 
     def _cache_path(self, events_path: str) -> str:
@@ -174,9 +183,27 @@ class PickleEventCollection(IterableEvents):
 
     @property
     def events(self) -> list[dict]:
+        """
+        Get events.
+
+        Returns
+        -------
+        list[dict]
+            events.
+
+        """
         return self._events
 
     def time_range(self) -> tuple[int, int]:
+        """
+        Get begin and end time range.
+
+        Returns
+        -------
+        tuple[int, int]
+            begin and end time.
+
+        """
         begin_time = self._events[0][LttngEventFilter.TIMESTAMP]
         end_time = self._events[-1][LttngEventFilter.TIMESTAMP]
         return begin_time, end_time
@@ -237,9 +264,27 @@ class CtfEventCollection(IterableEvents):
 
     @cached_property
     def events(self) -> list[dict]:
+        """
+        Get events.
+
+        Returns
+        -------
+        list[dict]
+            events.
+
+        """
         return self._to_dicts(self._events_path, self._size)
 
     def time_range(self) -> tuple[int, int]:
+        """
+        Get begin and end time range.
+
+        Returns
+        -------
+        tuple[int, int]
+            begin and end time.
+
+        """
         return self._begin_time, self._end_time
 
     @staticmethod
@@ -274,6 +319,15 @@ class MultiHostIdRemapper:
         self._next_id = 1000000000
 
     def remap(self, event: dict):
+        """
+        Remap target id as necessary.
+
+        Parameters
+        ----------
+        event : dict
+            event data.
+
+        """
         target_id = get_field(event, self._id_key)
         if target_id in self._other_host_ids or target_id in self._current_host_remapped_ids:
             if target_id in self._current_host_id_map:
@@ -292,6 +346,7 @@ class MultiHostIdRemapper:
             self._current_host_not_remapped_ids.add(target_id)
 
     def change_host(self):
+        """Change internal state to remap IDs of trace data measured by other hosts."""
         self._other_host_ids |= self._current_host_remapped_ids
         self._other_host_ids |= self._current_host_not_remapped_ids
         self._current_host_remapped_ids.clear()
@@ -577,6 +632,17 @@ class Lttng(InfraBase):
         events: list,
         monotonic_to_system_offset: int | None,
     ):
+        """
+        Apply init timestamp.
+
+        Parameters
+        ----------
+        events : list
+            event data.
+        monotonic_to_system_offset : int | None
+            monotonic to system offset.
+
+        """
         for event in events:
             if monotonic_to_system_offset is not None:
                 if 'init_timestamp' in event:
@@ -608,10 +674,15 @@ class Lttng(InfraBase):
         """
         Get node names and callback symbols from callback group id.
 
+        Parameters
+        ----------
+        callback_group_id : str
+            Callback group id.
+
         Returns
         -------
         Sequence[tuple[str | None, str | None]]
-            node names and callback symbols.
+            Node names and callback symbols.
             tuple structure: (node_name, callback_symbol)
 
         """
@@ -629,7 +700,7 @@ class Lttng(InfraBase):
         Returns
         -------
         Sequence[NodeValueWithId]
-            nodes info.
+            Nodes value.
 
         """
         return self._info.get_nodes()
@@ -643,7 +714,7 @@ class Lttng(InfraBase):
         Returns
         -------
         str
-            rmw_implementation
+            Name of rmw implementation.
 
         """
         return self._info.get_rmw_impl()
@@ -657,6 +728,7 @@ class Lttng(InfraBase):
         Returns
         -------
         Sequence[ExecutorValue]
+            Executor values
 
         """
         return self._info.get_executors()
@@ -668,9 +740,15 @@ class Lttng(InfraBase):
         """
         Get callback group information.
 
+        Parameters
+        ----------
+        node : NodeValue
+            Target node.
+
         Returns
         -------
         Sequence[CallbackGroupValue]
+            Callback group value.
 
         """
         return self._info.get_callback_groups(node)
@@ -685,11 +763,12 @@ class Lttng(InfraBase):
         Parameters
         ----------
         node : NodeValue
-            target node.
+            Target node.
 
         Returns
         -------
-        Sequence[PublisherInfoLttng]
+        Sequence[PublisherValueLttng]
+            Publisher value.
 
         """
         return self._info.get_publishers(node)
@@ -704,11 +783,12 @@ class Lttng(InfraBase):
         Parameters
         ----------
         node : NodeValue
-            target node.
+            Target node.
 
         Returns
         -------
         Sequence[SubscriptionValue]
+            Subscription value.
 
         """
         return self._info.get_subscriptions(node)
@@ -723,11 +803,12 @@ class Lttng(InfraBase):
         Parameters
         ----------
         node : NodeValue
-            target node.
+            Target node.
 
         Returns
         -------
         Sequence[ServiceValue]
+            Service value
 
         """
         return self._info.get_services(node)
@@ -742,11 +823,12 @@ class Lttng(InfraBase):
         Parameters
         ----------
         node : NodeValue
-            target node name.
+            Target node.
 
         Returns
         -------
         Sequence[TimerValue]
+            Timer value
 
         """
         return self._info.get_timers(node)
@@ -761,11 +843,12 @@ class Lttng(InfraBase):
         Parameters
         ----------
         node : NodeValue
-            target node name.
+            Target node.
 
         Returns
         -------
         Sequence[TimerCallbackValueLttng]
+            Timer callback value
 
         """
         return self._info.get_timer_callbacks(node)
@@ -780,11 +863,12 @@ class Lttng(InfraBase):
         Parameters
         ----------
         node : NodeValue
-            target node name.
+            Target node.
 
         Returns
         -------
         Sequence[SubscriptionCallbackValueLttng]
+            Subscription callback value
 
         """
         return self._info.get_subscription_callbacks(node)
@@ -799,11 +883,12 @@ class Lttng(InfraBase):
         Parameters
         ----------
         node : NodeValue
-            target node name.
+            Target node.
 
         Returns
         -------
         Sequence[ServiceCallbackValueLttng]
+            Service callback value
 
         """
         return self._info.get_service_callbacks(node)
@@ -818,11 +903,12 @@ class Lttng(InfraBase):
         Parameters
         ----------
         pub : PublisherValueLttng
-            target publisher
+            Target publisher.
 
         Returns
         -------
         Qos
+            Publisher qos
 
         """
         return self._info.get_publisher_qos(pub)
@@ -837,11 +923,12 @@ class Lttng(InfraBase):
         Parameters
         ----------
         sub : SubscriptionCallbackValueLttng
-            target subscription
+            Target subscription.
 
         Returns
         -------
         Qos
+            Subscription qos
 
         """
         return self._info.get_subscription_qos(sub)
@@ -851,6 +938,27 @@ class Lttng(InfraBase):
         min_ns: float,
         max_ns: float
     ) -> ClockConverter:
+        """
+        Get sim time converter.
+
+        Parameters
+        ----------
+        min_ns : float
+            Min time.
+        max_ns : float
+            Max time.
+
+        Returns
+        -------
+        ClockConverter
+            Clock converter
+
+        Raises
+        ------
+        InvalidArgumentError
+            Failed to load sim_time.
+
+        """
         records: RecordsInterface = self._source.system_and_sim_times
         system_times = records.get_column_series('system_time')
         sim_times = records.get_column_series('sim_time')
@@ -880,6 +988,20 @@ class Lttng(InfraBase):
         self,
         groupby: list[str] | None = None
     ) -> pd.DataFrame:
+        """
+        Get count.
+
+        Parameters
+        ----------
+        groupby : list[str] | None
+            Data group.
+
+        Returns
+        -------
+        pd.DataFrame
+            Event counter in pandas DataFrame format.
+
+        """
         groupby = groupby or ['trace_point']
         return self._counter.get_count(groupby)
 
@@ -891,7 +1013,7 @@ class Lttng(InfraBase):
 
         Returns
         -------
-        trace_range: tuple[datetime, datetime]
+        tuple[datetime, datetime]
             Trace begin time and trace end time.
 
         """
@@ -906,7 +1028,7 @@ class Lttng(InfraBase):
 
         Returns
         -------
-        trace_creation_datetime: datetime
+        datetime
             Date and time the trace data was created.
 
         """
@@ -954,32 +1076,118 @@ class Lttng(InfraBase):
     def compose_publish_records(
         self,
     ) -> RecordsInterface:
+        """
+        Compose publish records of all communications in one records.
+
+        Returns
+        -------
+        RecordsInterface
+            Columns
+
+            - publisher_handle
+            - rclcpp_publish_timestamp
+            - rcl_publish_timestamp (Optional)
+            - dds_write_timestamp (Optional)
+            - message_timestamp
+            - source_timestamp
+
+        """
         return self._source.publish_records.clone()
 
     def compose_subscribe_records(
         self,
     ) -> RecordsInterface:
+        """
+        Compose subscribe records of all communications in one records.
+
+        Returns
+        -------
+        RecordsInterface
+            Columns
+
+            - callback_start_timestamp
+            - callback_object
+            - is_intra_process
+            - source_timestamp
+
+        """
         return self._source.subscribe_records.clone()
 
     def compose_rmw_take_records(
         self,
     ) -> RecordsInterface:
+        """
+        Compose rmw_take records of all communications in one records.
+
+        Returns
+        -------
+        RecordsInterface
+            Columns
+
+            - tid
+            - rmw_take_timestamp
+            - rmw_subscription_handle
+            - message
+            - source_timestamp
+
+        """
         return self._source.rmw_take_records.clone()
 
     def create_timer_events_factory(
         self,
         timer_callback: TimerCallbackValueLttng
     ) -> EventsFactory:
+        """
+        Create timer events factory.
+
+        Parameters
+        ----------
+        timer_callback : TimerCallbackValueLttng
+            Timer callback.
+
+        Returns
+        -------
+        EventsFactory
+            Callback to create timer events.
+
+        """
         return self._source.create_timer_events_factory(timer_callback)
 
     def compose_tilde_publish_records(
         self,
     ) -> RecordsInterface:
+        """
+        Compose tilde publish records of all communications in one records.
+
+        Returns
+        -------
+        RecordsInterface
+            Columns
+
+            - tilde_publish_timestamp
+            - tilde_publisher
+            - tilde_message_id
+            - tilde_subscription
+
+        """
         return self._source.tilde_publish_records.clone()
 
     def compose_tilde_subscribe_records(
         self,
     ) -> RecordsInterface:
+        """
+        Compose tilde subscribe records of all communications in one records.
+
+        Returns
+        -------
+        RecordsInterface
+            Columns
+
+            - tilde_subscribe_timestamp
+            - tilde_subscription
+            - tilde_message_id
+
+        """
         return self._source.tilde_subscribe_records.clone()
 
     def compose_path_beginning_records(

--- a/src/caret_analyze/infra/lttng/lttng_event_filter.py
+++ b/src/caret_analyze/infra/lttng/lttng_event_filter.py
@@ -64,6 +64,24 @@ class SameAddressFilter(LttngEventFilter):
         self._list_callback_group: dict = {}
 
     def accept(self, event: Event, common: LttngEventFilter.Common) -> bool:
+        """
+        Determine whether the same address is accepted.
+
+        Accept if the specified event name is already registered and is within the max count.
+
+        Parameters
+        ----------
+        event : Event
+            Target event.
+        common : LttngEventFilter.Common
+            Lttng event filter common.
+
+        Returns
+        -------
+        bool
+            False if the maximum number is exceeded, true otherwise.
+
+        """
         event_name = event[self.NAME]
         if event_name == 'ros2_caret:construct_executor':
             event_addr = event['executor_addr']
@@ -90,6 +108,24 @@ class SameAddressFilter(LttngEventFilter):
 class InitEventPassFilter(LttngEventFilter):
 
     def accept(self, event: Event, common: LttngEventFilter.Common) -> bool:
+        """
+        Determine whether initialization event is accepted.
+
+        Accept if the specified event is an initialization event.
+
+        Parameters
+        ----------
+        event : Event
+            Target event.
+        common : LttngEventFilter.Common
+            Lttng event filter common.
+
+        Returns
+        -------
+        bool
+            True if included in initialization event, false otherwise.
+
+        """
         # TODO(hsgwa): Definitions on tracepoint types are scattered. Refactor required.
         init_events = {
             'ros2:rcl_init',
@@ -152,6 +188,24 @@ class EventStripFilter(LttngEventFilter):
         self._init_events = InitEventPassFilter()
 
     def accept(self, event: Event, common: LttngEventFilter.Common) -> bool:
+        """
+        Strip acceptance judgment.
+
+        Accept if the timestamp x of the specified event satisfies l_strip < x < r_strip.
+
+        Parameters
+        ----------
+        event : Event
+            Target event.
+        common : LttngEventFilter.Common
+            Lttng event filter common.
+
+        Returns
+        -------
+        bool
+            Acceptance is true, otherwise false.
+
+        """
         if self._init_events.accept(event, common):
             return True
 
@@ -177,6 +231,28 @@ class EventDurationFilter(LttngEventFilter):
         self._init_events = InitEventPassFilter()
 
     def accept(self, event: Event, common: LttngEventFilter.Common) -> bool:
+        """
+        Duration acceptance judgment.
+
+        The acceptance conditions for this class are as follows:
+
+            offset <= elapsed_s and elapsed_s < (offset + duration)
+
+                elapsed_s is (event[TIMESTAMP] - common.start_time) * 1.0e-9
+
+        Parameters
+        ----------
+        event : Event
+            Target event.
+        common : LttngEventFilter.Common
+            Lttng event filter common.
+
+        Returns
+        -------
+        bool
+            Acceptance is true, otherwise false.
+
+        """
         if self._init_events.accept(event, common):
             return True
 

--- a/src/caret_analyze/infra/lttng/lttng_info.py
+++ b/src/caret_analyze/infra/lttng/lttng_info.py
@@ -855,6 +855,8 @@ class LttngInfo:
         for _, row in tim.df.iterrows():
             if row['node_id'] != node_id:
                 continue
+            if row['callback_id'] is pd.NA:
+                continue
 
             times_info.append(
                 TimerValue(

--- a/src/caret_analyze/infra/lttng/lttng_info.py
+++ b/src/caret_analyze/infra/lttng/lttng_info.py
@@ -163,7 +163,8 @@ class LttngInfo:
 
         Returns
         -------
-        Sequence[TimerCallbackInfo]
+        Sequence[TimerCallbackValueLttng]
+            Timer callback value of lttng.
 
         """
         if node.node_id is None:
@@ -183,8 +184,8 @@ class LttngInfo:
 
         Returns
         -------
-        Sequence[NodeValue]
-            node names.
+        Sequence[NodeValueLttng]
+            node names of lttng.
 
         """
         nodes_data = self._formatted.nodes.clone()
@@ -281,7 +282,8 @@ class LttngInfo:
 
         Returns
         -------
-        Sequence[SubscriptionCallbackInfo]
+        Sequence[SubscriptionCallbackValueLttng]
+            Subscription callback values of lttng.
 
         """
         if node.node_id is None:
@@ -359,7 +361,8 @@ class LttngInfo:
 
         Returns
         -------
-        Sequence[ServiceCallbackInfo]
+        Sequence[ServiceCallbackValueLttng]
+            Service callback value of lttng.
 
         """
         if node.node_id is None:
@@ -388,7 +391,8 @@ class LttngInfo:
 
         Returns
         -------
-        list[PublisherInfo]
+        list[PublisherValueLttng]
+            Publisher value of lttng.
 
         """
         if node.node_id is None:
@@ -408,12 +412,13 @@ class LttngInfo:
 
         Parameters
         ----------
-        node: NodeValue
+        node: NodeValueLttng
             target node.
 
         Returns
         -------
         list[SubscriptionValue]
+            Subscription values.
 
         """
         node_id = node.node_id
@@ -483,12 +488,13 @@ class LttngInfo:
 
         Parameters
         ----------
-        node: NodeValue
+        node: NodeValueLttng
             target node.
 
         Returns
         -------
         list[ServiceValue]
+            Service value
 
         """
         node_id = node.node_id
@@ -562,7 +568,8 @@ class LttngInfo:
 
         Returns
         -------
-        list[PublisherInfo]
+        list[PublisherValueLttng]
+            Publisher value of lttng.
 
         """
         pub = self._formatted.publishers.clone()
@@ -679,9 +686,15 @@ class LttngInfo:
         """
         Get callback groups value.
 
+        Parameters
+        ----------
+        node: NodeValue
+            target node.
+
         Returns
         -------
-        list[CallbackGroupInfo]
+        list[CallbackGroupValueLttng]
+            Callback group value of lttng.
 
         """
         if node.node_id is None:
@@ -700,7 +713,8 @@ class LttngInfo:
 
         Returns
         -------
-        list[ExecutorInfo]
+        list[ExecutorValue]
+            Executor value.
 
         """
         executor = self._formatted.executor.clone()
@@ -722,6 +736,25 @@ class LttngInfo:
         return execs
 
     def get_publisher_qos(self, publisher: PublisherValueLttng) -> Qos:
+        """
+        Get publishers qos information.
+
+        Parameters
+        ----------
+        publisher : PublisherValueLttng
+            target publisher value
+
+        Returns
+        -------
+        Qos
+            Publisher qos.
+
+        Raises
+        ------
+        InvalidArgumentError
+            Occurs when publisher were not exist.
+
+        """
         publishers = self._formatted.publishers.clone()
         publishers.filter_rows('publisher_handle', publisher.publisher_handle)
 
@@ -736,6 +769,25 @@ class LttngInfo:
         return Qos(depth)
 
     def get_subscription_qos(self, callback: SubscriptionCallbackValueLttng) -> Qos:
+        """
+        Get subscription qos information.
+
+        Parameters
+        ----------
+        callback : SubscriptionCallbackValueLttng
+            target Subscription callback value
+
+        Returns
+        -------
+        Qos
+            Subscription qos.
+
+        Raises
+        ------
+        InvalidArgumentError
+            Occurs when subscription were not exist.
+
+        """
         subscription = self._formatted.subscription_callbacks.clone()
         subscription.filter_rows('callback_object', callback.callback_object)
 
@@ -756,12 +808,13 @@ class LttngInfo:
 
         Parameters
         ----------
-        node: NodeValue
+        node: NodeValueLttng
             target node.
 
         Returns
         -------
         list[TimerValue]
+            Timers information.
 
         """
         node_id = node.node_id
@@ -779,6 +832,7 @@ class LttngInfo:
         Returns
         -------
         list[TimerValue]
+            Timers information.
 
         """
         tim = self._formatted.timers.clone()
@@ -815,6 +869,20 @@ class LttngInfo:
         return times_info
 
     def get_timer_controls(self) -> Sequence[TimerControl]:
+        """
+        Get timer controls information.
+
+        Returns
+        -------
+        Sequence[TimerControl]
+            Timer controls information.
+
+        Raises
+        ------
+        NotImplementedError
+            Unsupported timer control type.
+
+        """
         timer_controls = self._formatted.timer_controls.clone()
         controls: list[TimerControl] = []
         for _, row in timer_controls.df.iterrows():
@@ -861,13 +929,9 @@ class DataFrameFormatted:
         """
         Build timer callbacks table.
 
-        Parameters
-        ----------
-        data : Ros2DataModel
-
         Returns
         -------
-        pd.DataFrame
+        TracePointData
             Column
 
             - callback_id
@@ -887,13 +951,9 @@ class DataFrameFormatted:
         """
         Build subscription callback table.
 
-        Parameters
-        ----------
-        data : Ros2DataModel
-
         Returns
         -------
-        pd.DataFrame
+        TracePointData
             columns
 
             - callback_id
@@ -915,13 +975,9 @@ class DataFrameFormatted:
         """
         Build service callback table.
 
-        Parameters
-        ----------
-        data : Ros2DataModel
-
         Returns
         -------
-        pd.DataFrame
+        TracePointData
             Columns
 
             - callback_id
@@ -941,13 +997,9 @@ class DataFrameFormatted:
         """
         Build node table.
 
-        Parameters
-        ----------
-        data : Ros2DataModel
-
         Returns
         -------
-        pd.DataFrame
+        TracePointData
             Columns
 
             - node_id
@@ -964,7 +1016,7 @@ class DataFrameFormatted:
 
         Returns
         -------
-        pd.DataFrame
+        TracePointData
             Columns
 
             - publisher_id
@@ -984,7 +1036,7 @@ class DataFrameFormatted:
 
         Returns
         -------
-        pd.DataFrame
+        TracePointData
             Columns
 
             - subscription_id
@@ -1004,7 +1056,7 @@ class DataFrameFormatted:
 
         Returns
         -------
-        pd.DataFrame
+        TracePointData
             Columns
 
             - service_id
@@ -1023,7 +1075,7 @@ class DataFrameFormatted:
 
         Returns
         -------
-        pd.DataFrame
+        TracePointData
             Columns
 
             - timer_id
@@ -1042,7 +1094,7 @@ class DataFrameFormatted:
 
         Returns
         -------
-        pd.DataFrame
+        TracePointData
             Columns
 
             - executor_id
@@ -1059,13 +1111,13 @@ class DataFrameFormatted:
 
         Returns
         -------
-        pd.DataFrame
+        TracePointData
             Columns
 
             - callback_group_id
             - callback_group_addr
-            - executor_addr
             - group_type_name
+            - executor_addr
 
         """
         return self._cbg
@@ -1077,7 +1129,7 @@ class DataFrameFormatted:
 
         Returns
         -------
-        pd.DataFrame
+        TracePointData
             Columns
 
             - tilde_publisher
@@ -1095,7 +1147,7 @@ class DataFrameFormatted:
 
         Returns
         -------
-        pd.DataFrame
+        TracePointData
             Columns
             - tilde_subscription
             - node_name
@@ -1106,6 +1158,20 @@ class DataFrameFormatted:
 
     @property
     def timer_controls(self) -> TracePointData:
+        """
+        Get timer controls info table.
+
+        Returns
+        -------
+        TracePointData
+            Columns
+
+            - timestamp
+            - timer_handle
+            - type
+            - params
+
+        """
         return self._timer_control
 
     @staticmethod

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -246,7 +246,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
             Columns
 
             - [topic_name]/source_timestamp
-            - rmw_take_timestamp
+            - [topic_name]/rmw_take_timestamp
 
         Raises
         ------

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -112,6 +112,25 @@ class RecordsProviderLttng(RuntimeDataProvider):
         self,
         node_path_val: NodePathStructValue,
     ) -> RecordsInterface:
+        """
+        Provide node records.
+
+        Parameters
+        ----------
+        node_path_val : NodePathStructValue
+            Node path value.
+
+        Returns
+        -------
+        RecordsInterface
+            Record corresponding to specified message context type.
+
+        Raises
+        ------
+        UnsupportedNodeRecordsError
+            Occurs when message context type is unknown.
+
+        """
         if node_path_val.message_context is None:
             # dummy record
             msg = 'message context is None. return dummy record. '
@@ -146,7 +165,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         Parameters
         ----------
         callback : CallbackStructValue
-            target callback value.
+            Target callback value.
 
         Returns
         -------
@@ -193,6 +212,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         Raises
         ------
         InvalidArgumentError
+            Occurs when callback value were not exist.
 
         """
         callback = subscription.callback
@@ -227,6 +247,11 @@ class RecordsProviderLttng(RuntimeDataProvider):
 
             - [topic_name]/source_timestamp
             - rmw_take_timestamp
+
+        Raises
+        ------
+        InvalidArgumentError
+            Occurs when callback value were not exist.
 
         """
         callback = subscription.callback
@@ -298,6 +323,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         Raises
         ------
         InvalidArgumentError
+            Occurs when callback value were not exist.
 
         """
         callback = subscription.callback
@@ -352,6 +378,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         Raises
         ------
         InvalidArgumentError
+            Occurs when callback value were not exist.
 
         """
         callback = subscription.callback
@@ -411,7 +438,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         Parameters
         ----------
         publisher : PublisherStructValue
-            target publisher
+            Target publisher.
 
         Returns
         -------
@@ -452,23 +479,32 @@ class RecordsProviderLttng(RuntimeDataProvider):
         Parameters
         ----------
         publisher : PublisherStructValue
-            target publisher
+            Target publisher.
 
         Returns
         -------
         RecordsInterface
+            (in the case of tilde publisher)
+
             Columns
 
             - [topic_name]/rclcpp_publish_timestamp
-            - [topic_name]/rclcpp_intra_publish_timestamp (Optional)
-            - [topic_name]/rclcpp_inter_publish_timestamp (Optional)
             - [topic_name]/rcl_publish_timestamp (Optional)
             - [topic_name]/dds_write_timestamp (Optional)
             - [topic_name]/message_timestamp
-            - [topic_name]/source_timestamp (Optional)
-            ---
-            - [topic_name]/tilde_publish_timestamp (Optional)
-            - [topic_name]/tilde_message_id (Optional)
+            - [topic_name]/source_timestamp
+            - [topic_name]/tilde_publish_timestamp
+            - [topic_name]/tilde_message_id
+
+            (for cases other than tilde publisher)
+
+            Columns
+
+            - [topic_name]/rclcpp_publish_timestamp
+            - [topic_name]/rcl_publish_timestamp (Optional)
+            - [topic_name]/dds_write_timestamp (Optional)
+            - [topic_name]/message_timestamp
+            - [topic_name]/source_timestamp
 
         """
         tilde_publishers = self._helper.get_tilde_publishers(publisher)
@@ -487,7 +523,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         Parameters
         ----------
         publisher : PublisherStructValue
-            target publisher
+            Target publisher.
 
         Returns
         -------
@@ -495,8 +531,6 @@ class RecordsProviderLttng(RuntimeDataProvider):
             Columns
 
             - [topic_name]/rclcpp_publish_timestamp
-            - [topic_name]/rclcpp_intra_publish_timestamp
-            - [topic_name]/rclcpp_inter_publish_timestamp
             - [topic_name]/rcl_publish_timestamp (Optional)
             - [topic_name]/dds_write_timestamp (Optional)
             - [topic_name]/message_timestamp
@@ -548,7 +582,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         Parameters
         ----------
         timer : TimerStructValue
-            [description]
+            Target timer.
 
         Returns
         -------
@@ -608,6 +642,25 @@ class RecordsProviderLttng(RuntimeDataProvider):
         subscription: SubscriptionStructValue,
         publisher: PublisherStructValue
     ) -> RecordsInterface:
+        """
+        Return tilde records.
+
+        Parameters
+        ----------
+        subscription : SubscriptionStructValue
+            Target subscription value.
+        publisher : PublisherStructValue
+            Target publisher value.
+
+        Returns
+        -------
+        RecordsInterface
+            Columns
+
+            - tilde_subscribe_timestamp
+            - tilde_publish_timestamp
+
+        """
         assert subscription.callback is not None
 
         publisher_addresses = self._helper.get_tilde_publishers(publisher)
@@ -641,12 +694,40 @@ class RecordsProviderLttng(RuntimeDataProvider):
         return records
 
     def get_rmw_implementation(self) -> str:
+        """
+        Get rmw implementation.
+
+        Returns
+        -------
+        str
+            Rmw implementation.
+
+        """
         return self._lttng.get_rmw_impl()
 
     def get_qos(
         self,
         pub_sub: PublisherStructValue | SubscriptionStructValue
     ) -> Qos:
+        """
+        Get qos.
+
+        Parameters
+        ----------
+        pub_sub : PublisherStructValue | SubscriptionStructValue
+            Target subscription or publisher.
+
+        Returns
+        -------
+        Qos
+            Subscription qos or publisher qos.
+
+        Raises
+        ------
+        InvalidArgumentError
+            Occurs when callback were not exist.
+
+        """
         if isinstance(pub_sub, SubscriptionStructValue):
             sub_cb = pub_sub.callback
             if sub_cb is None:
@@ -666,6 +747,29 @@ class RecordsProviderLttng(RuntimeDataProvider):
         return self._lttng.get_publisher_qos(pubs_lttng[0])
 
     def get_sim_time_converter(self, min_ns, max_ns) -> ClockConverter:
+        """
+        Get sim time converter.
+
+        Parameters
+        ----------
+        min_ns : float
+            Minimum timestamp value of the data
+                used to create the system time to sim_time converter.
+        max_ns : float
+            Maximum timestamp value of the data
+                used to create the system time to sim_time converter.
+
+        Returns
+        -------
+        ClockConverter
+            Object that converts timestamps from system time to sim_time.
+
+        Raises
+        ------
+        InvalidArgumentError
+            Failed to load sim_time.
+
+        """
         return self._lttng.get_sim_time_converter(min_ns, max_ns)
 
     def variable_passing_records(
@@ -678,7 +782,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         Parameters
         ----------
         variable_passing_info : VariablePassingStructValue
-            target variable passing info.
+            Target variable passing info.
 
         Returns
         -------
@@ -721,6 +825,20 @@ class RecordsProviderLttng(RuntimeDataProvider):
         self,
         communication_value: CommunicationStructValue
     ) -> bool | None:
+        """
+        If inter-proc communication.
+
+        Parameters
+        ----------
+        communication_value : CommunicationStructValue
+            Communication value.
+
+        Returns
+        -------
+        bool | None
+            Intra process communication records count.
+
+        """
         intra_record = self._compose_intra_proc_comm_records(communication_value)
         return len(intra_record) > 0
 
@@ -734,7 +852,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         Parameters
         ----------
         publisher : PublisherStructValue
-            target publisher
+            Target publisher.
 
         Returns
         -------
@@ -766,7 +884,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         Parameters
         ----------
         callback : CallbackStructValue
-            target callback
+            Target callback.
 
         Returns
         -------
@@ -808,6 +926,21 @@ class RecordsProviderLttng(RuntimeDataProvider):
         self,
         communication: CommunicationStructValue,
     ) -> bool:
+        """
+        Verify communication.
+
+        Parameters
+        ----------
+        communication : CommunicationStructValue
+            Communication value.
+
+        Returns
+        -------
+        bool
+            True if the trace points required to constitute a communication record are included
+            in the trace data, false otherwise.
+
+        """
         is_intra_proc = self.is_intra_process_communication(communication)
         if is_intra_proc is True:
             pub_node = communication.publish_node.node_name
@@ -891,7 +1024,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
         Parameters
         ----------
         comm_value : CommunicationStructValue
-            target communication value.
+            Target communication value.
 
         Returns
         -------
@@ -1036,6 +1169,25 @@ class RecordsProviderLttngHelper:
         self,
         callback: CallbackStructValue
     ) -> tuple[int, int | None]:
+        """
+        Get callback objects.
+
+        Parameters
+        ----------
+        callback : CallbackStructValue
+            Target callback.
+
+        Returns
+        -------
+        tuple[int, int | None]
+            Isinstance of TimerCallbackStructValue or SubscriptionCallbackStructValue.
+
+        Raises
+        ------
+        UnsupportedTypeError
+            Argument callback object is not supported.
+
+        """
         if isinstance(callback, TimerCallbackStructValue):
             return self.get_timer_callback_object(callback), None
 
@@ -1054,6 +1206,20 @@ class RecordsProviderLttngHelper:
         self,
         callback: TimerCallbackStructValue
     ) -> int:
+        """
+        Get timer callback objects.
+
+        Parameters
+        ----------
+        callback : TimerCallbackStructValue
+            Target callback.
+
+        Returns
+        -------
+        int
+            Timer callback object.
+
+        """
         callback_lttng = self._bridge.get_timer_callback(callback)
         return callback_lttng.callback_object
 
@@ -1061,12 +1227,40 @@ class RecordsProviderLttngHelper:
         self,
         callback: SubscriptionCallbackStructValue
     ) -> tuple[int, int | None]:
+        """
+        Get subscription callback objects.
+
+        Parameters
+        ----------
+        callback : SubscriptionCallbackStructValue
+            Target callback.
+
+        Returns
+        -------
+        tuple[int, int | None]
+            Subscription callback object.
+
+        """
         return self.get_callback_objects(callback)
 
     def get_subscription_callback_object_inter(
         self,
         callback: SubscriptionCallbackStructValue
     ) -> int:
+        """
+        Get subscription callback objects.
+
+        Parameters
+        ----------
+        callback : SubscriptionCallbackStructValue
+            Target callback.
+
+        Returns
+        -------
+        int
+            Subscription callback object.
+
+        """
         callback_lttng = self._bridge.get_subscription_callback(callback)
         return callback_lttng.callback_object
 
@@ -1074,6 +1268,20 @@ class RecordsProviderLttngHelper:
         self,
         callback: SubscriptionCallbackStructValue
     ) -> int | None:
+        """
+        Get intra subscription callback objects.
+
+        Parameters
+        ----------
+        callback : SubscriptionCallbackStructValue
+            Target callback.
+
+        Returns
+        -------
+        int | None
+            Intra subscription callback object.
+
+        """
         callback_lttng = self._bridge.get_subscription_callback(callback)
         return callback_lttng.callback_object_intra
 
@@ -1081,6 +1289,20 @@ class RecordsProviderLttngHelper:
         self,
         callback: SubscriptionCallbackStructValue
     ) -> int | None:
+        """
+        Get tilde subscription callback objects.
+
+        Parameters
+        ----------
+        callback : SubscriptionCallbackStructValue
+            Target callback.
+
+        Returns
+        -------
+        int | None
+            Tilde subscription callback object.
+
+        """
         callback_lttng = self._bridge.get_subscription_callback(callback)
         return callback_lttng.tilde_subscription
 
@@ -1088,6 +1310,20 @@ class RecordsProviderLttngHelper:
         self,
         publisher: PublisherStructValue
     ) -> list[int]:
+        """
+        Get publisher callback objects.
+
+        Parameters
+        ----------
+        publisher : PublisherStructValue
+            Target publisher.
+
+        Returns
+        -------
+        list[int]
+            Publisher handles.
+
+        """
         publisher_lttng = self._bridge.get_publishers(publisher)
         return [pub_info.publisher_handle
                 for pub_info
@@ -1097,6 +1333,20 @@ class RecordsProviderLttngHelper:
         self,
         publisher_info: PublisherStructValue
     ) -> list[int]:
+        """
+        Get tilde publisher.
+
+        Parameters
+        ----------
+        publisher_info : PublisherStructValue
+            Target publisher info.
+
+        Returns
+        -------
+        list[int]
+            Tilde publisher.
+
+        """
         publisher_lttng = self._bridge.get_publishers(publisher_info)
         publisher = [pub_info.tilde_publisher
                      for pub_info
@@ -1108,18 +1358,60 @@ class RecordsProviderLttngHelper:
         self,
         publisher: PublisherStructValue
     ) -> list[PublisherValueLttng]:
+        """
+        Get lttng publishers.
+
+        Parameters
+        ----------
+        publisher : PublisherStructValue
+            Target publisher.
+
+        Returns
+        -------
+        list[PublisherValueLttng]
+            Publisher values of Lttng.
+
+        """
         return self._bridge.get_publishers(publisher)
 
     def get_lttng_subscription(
         self,
         callback: SubscriptionCallbackStructValue
     ) -> SubscriptionCallbackValueLttng:
+        """
+        Get lttng subscription.
+
+        Parameters
+        ----------
+        callback : SubscriptionCallbackStructValue
+            Target subscription callback.
+
+        Returns
+        -------
+        SubscriptionCallbackValueLttng
+            Subscription callback values of Lttng.
+
+        """
         return self._bridge.get_subscription_callback(callback)
 
     def get_lttng_timer(
         self,
         callback: TimerCallbackStructValue
     ) -> TimerCallbackValueLttng:
+        """
+        Get lttng timer.
+
+        Parameters
+        ----------
+        callback : TimerCallbackStructValue
+            Target timer callback.
+
+        Returns
+        -------
+        TimerCallbackValueLttng
+            Timer callback values of Lttng.
+
+        """
         return self._bridge.get_timer_callback(callback)
 
 
@@ -1543,6 +1835,12 @@ class FilteredRecordsSource:
             )
             records.drop_columns(['tilde_subscription])
 
+            Columns
+
+            - [topic_name]/tilde_subscribe_timestamp
+            - [topic_name]/tilde_subscription
+            - [topic_name]/tilde_message_id
+
         """
         grouped_records = self._grouped_tilde_sub_records
         if len(grouped_records) == 0:
@@ -1784,8 +2082,6 @@ class FilteredRecordsSource:
         - dds_write_timestamp (Optional)
         - message_timestamp
         - source_timestamp
-        - tilde_publish_timestamp (Optional)
-        - tilde_message_id (Optional)
 
         """
         grouped_records = self._grouped_publish_records
@@ -1906,7 +2202,6 @@ class FilteredRecordsSource:
 
         - callback_start_timestamp
         - callback_end_timestamp
-        - is_intra_process
         - callback_object
 
         """

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1092,7 +1092,6 @@ class RecordsProviderLttng(RuntimeDataProvider):
             - [topic_name]/dds_write_timestamp (Optional)
             - [topic_name]/source_timestamp
             - [topic_name]/rmw_take_timestamp
-            - [topic_name]/callback_start_timestamp (copied from rmw_take_timestamp)
 
         """
         publisher = comm_value.publisher

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1115,37 +1115,6 @@ class RecordsProviderLttng(RuntimeDataProvider):
 
         records = self._source.inter_take_comm_records(publisher_handles, rmw_handle)
 
-        num_rows = len(records.data)
-
-        empty_uint64_values = [0] * num_rows
-
-        column_name_str = COLUMN_NAME.CALLBACK_START_TIMESTAMP
-
-        if column_name_str not in records.columns:
-            try:
-                column_value_object_to_pass = ColumnValue(column_name_str)
-                records.append_column(column_value_object_to_pass, empty_uint64_values)
-            except Exception as e:
-                msg = (f"Failed to append column '{column_name_str}': {e}")
-                raise RuntimeError(msg) from e
-
-        # copy rmw_take_timestamp to callback_start_timestamp
-        try:
-            rmw_take_raw_values = records.get_column_series(COLUMN_NAME.RMW_TAKE_TIMESTAMP)
-
-            # Replace None in the list with a value that can be converted to uint64_t "0"
-            rmw_take_values_for_cpp = [v if v is not None else 0 for v in rmw_take_raw_values]
-
-            if COLUMN_NAME.CALLBACK_START_TIMESTAMP in records.columns:
-                records.drop_columns([COLUMN_NAME.CALLBACK_START_TIMESTAMP])
-
-            callback_start_column_value_for_copy = ColumnValue(COLUMN_NAME.CALLBACK_START_TIMESTAMP)
-            records.append_column(callback_start_column_value_for_copy, rmw_take_values_for_cpp)
-
-        except Exception as e:
-            msg = f"Failed to copy: {e}"
-            raise RuntimeError(msg) from e
-
         columns = [COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP]
         try:
             if COLUMN_NAME.RCL_PUBLISH_TIMESTAMP in records.columns:
@@ -1155,7 +1124,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
             columns += [
                 COLUMN_NAME.SOURCE_TIMESTAMP,
                 COLUMN_NAME.RMW_TAKE_TIMESTAMP,
-                COLUMN_NAME.CALLBACK_START_TIMESTAMP,
+                #COLUMN_NAME.CALLBACK_START_TIMESTAMP,
             ]
         except Exception as e:
             msg = f"Column list construction failed: {e}"

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -2021,6 +2021,7 @@ class FilteredRecordsSource:
             - dds_write_timestamp (Optional)
             - message_timestamp
             - source_timestamp
+            - rmw_take_timestamp (Optional)
 
         """
         pub_records = self.publish_records(publisher_handles)
@@ -2043,8 +2044,6 @@ class FilteredRecordsSource:
             COLUMN_NAME.PUBLISHER_HANDLE,
             COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP,
         ]
-        if COLUMN_NAME.RMW_TAKE_TIMESTAMP in merged.columns:
-            columns.append(COLUMN_NAME.RMW_TAKE_TIMESTAMP)
         if COLUMN_NAME.RCL_PUBLISH_TIMESTAMP in merged.columns:
             columns.append(COLUMN_NAME.RCL_PUBLISH_TIMESTAMP)
         if COLUMN_NAME.DDS_WRITE_TIMESTAMP in merged.columns:
@@ -2053,6 +2052,8 @@ class FilteredRecordsSource:
             COLUMN_NAME.MESSAGE_TIMESTAMP,
             COLUMN_NAME.SOURCE_TIMESTAMP
         ]
+        if COLUMN_NAME.RMW_TAKE_TIMESTAMP in merged.columns:
+            columns.append(COLUMN_NAME.RMW_TAKE_TIMESTAMP)
         drop = list(set(merged.columns) - set(columns))
         merged.drop_columns(drop)
         merged.reindex(columns)

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1056,7 +1056,10 @@ class RecordsProviderLttng(RuntimeDataProvider):
             columns.append(COLUMN_NAME.DDS_WRITE_TIMESTAMP)
         columns += [
             COLUMN_NAME.SOURCE_TIMESTAMP,
-            COLUMN_NAME.RMW_TAKE_TIMESTAMP,
+        ]
+        if COLUMN_NAME.RMW_TAKE_TIMESTAMP in records.columns:
+            columns.append(COLUMN_NAME.RMW_TAKE_TIMESTAMP)
+        columns += [
             COLUMN_NAME.CALLBACK_START_TIMESTAMP,
         ]
 
@@ -2040,8 +2043,9 @@ class FilteredRecordsSource:
             COLUMN_NAME.CALLBACK_START_TIMESTAMP,
             COLUMN_NAME.PUBLISHER_HANDLE,
             COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP,
-            COLUMN_NAME.RMW_TAKE_TIMESTAMP,
         ]
+        if COLUMN_NAME.RMW_TAKE_TIMESTAMP in merged.columns:
+            columns.append(COLUMN_NAME.RMW_TAKE_TIMESTAMP)
         if COLUMN_NAME.RCL_PUBLISH_TIMESTAMP in merged.columns:
             columns.append(COLUMN_NAME.RCL_PUBLISH_TIMESTAMP)
         if COLUMN_NAME.DDS_WRITE_TIMESTAMP in merged.columns:

--- a/src/caret_analyze/infra/lttng/records_source.py
+++ b/src/caret_analyze/infra/lttng/records_source.py
@@ -66,6 +66,7 @@ class RecordsSource():
         -------
         RecordsInterface
             Columns
+
             - publisher_handle
             - rclcpp_publish_timestamp
             - rcl_publish_timestamp (Optional)
@@ -199,6 +200,7 @@ class RecordsSource():
         Returns
         -------
         EventsFactory
+            Created timer events factory.
 
         """
         class TimerEventsFactory(EventsFactory):
@@ -243,6 +245,7 @@ class RecordsSource():
         -------
         RecordsInterface
             columns:
+
             - tilde_publish_timestamp
             - tilde_publisher
             - tilde_message_id
@@ -270,6 +273,7 @@ class RecordsSource():
         -------
         RecordsInterface
             columns:
+
             - tilde_subscribe_timestamp
             - tilde_subscription
             - tilde_message_id
@@ -281,6 +285,19 @@ class RecordsSource():
 
     @cached_property
     def intra_callback_records(self) -> RecordsInterface:
+        """
+        Compose intra callback records.
+
+        Returns
+        -------
+        RecordsInterface
+            columns:
+
+            - callback_start_timestamp
+            - callback_object
+            - is_intra_process
+
+        """
         intra_proc_subscribe = RecordsFactory.create_instance(
             None,
             columns=[
@@ -297,6 +314,20 @@ class RecordsSource():
 
     @cached_property
     def inter_callback_records(self) -> RecordsInterface:
+        """
+        Compose inter callback records.
+
+        Returns
+        -------
+        RecordsInterface
+            columns:
+
+            - tid
+            - callback_start_timestamp
+            - callback_object
+            - is_intra_process
+
+        """
         inter_proc_subscribe = RecordsFactory.create_instance(
             None,
             columns=[
@@ -320,6 +351,7 @@ class RecordsSource():
         -------
         RecordsInterface
             columns:
+
             - callback_start_timestamp
             - callback_object
             - is_intra_process
@@ -411,6 +443,7 @@ class RecordsSource():
         -------
         RecordsInterface
             columns:
+
             - tid
             - rmw_take_timestamp
             - rmw_subscription_handle
@@ -435,13 +468,28 @@ class RecordsSource():
         Returns
         -------
         RecordsInterface
+
+            (in the case of humble)
+
             columns:
+
             - tid
-            - callback_object
-            - callback_start_timestamp
             - publisher_handle
+            - callback_object
             - rclcpp_publish_timestamp
             - message_timestamp
+            - callback_start_timestamp
+
+
+            (in the case of iron and after)
+
+            columns:
+
+            - tid
+            - publisher_handle
+            - callback_object
+            - rclcpp_publish_timestamp
+            - callback_start_timestamp
 
         """
         if self._info.get_distribution()[0] >= 'i':
@@ -538,6 +586,7 @@ class RecordsSource():
         -------
         RecordsInterface
             columns:
+
             - tid
             - callback_object
             - callback_start_timestamp
@@ -655,6 +704,7 @@ class RecordsSource():
         -------
         RecordsInterface
             columns:
+
             - callback_start_timestamp
             - callback_end_timestamp
             - callback_object

--- a/src/caret_analyze/infra/lttng/records_source.py
+++ b/src/caret_analyze/infra/lttng/records_source.py
@@ -398,10 +398,10 @@ class RecordsSource():
         )
         rmw_sub_records.drop_columns(
             [
-                COLUMN_NAME.RMW_TAKE_TIMESTAMP,
+                # COLUMN_NAME.RMW_TAKE_TIMESTAMP,
                 COLUMN_NAME.TID,
                 COLUMN_NAME.MESSAGE,
-                COLUMN_NAME.RMW_SUBSCRIPTION_HANDLE,
+                # COLUMN_NAME.RMW_SUBSCRIPTION_HANDLE,
             ]
         )
 
@@ -412,6 +412,7 @@ class RecordsSource():
                 ColumnValue(COLUMN_NAME.CALLBACK_OBJECT),
                 ColumnValue(COLUMN_NAME.IS_INTRA_PROCESS),
                 ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
+                ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
             ]
         )
         inter_proc_subscribe.concat(dispatch_sub_records)

--- a/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/data_model_service.py
@@ -188,6 +188,20 @@ class DataModelService:
         self,
         cb_addr: int
     ) -> int | None:
+        """
+        Get rmw subscription handle from callback object.
+
+        Parameters
+        ----------
+        cb_addr : int
+            callback address.
+
+        Returns
+        -------
+        int | None
+            rmw subscription handle.
+
+        """
         try:
             sub = self._get_sub_from_callback_object(cb_addr)
             rmw_handle = None

--- a/src/caret_analyze/infra/lttng/ros2_tracing/processor.py
+++ b/src/caret_analyze/infra/lttng/ros2_tracing/processor.py
@@ -183,6 +183,7 @@ class Ros2Handler():
     def create_init_handler_map(
         self,
     ) -> None:
+        """Link a ROS trace initialize event to its corresponding handling method."""
         # Link a ROS trace event to its corresponding handling method
 
         handler_map = {}
@@ -297,6 +298,7 @@ class Ros2Handler():
     def create_runtime_handler_map(
         self,
     ) -> None:
+        """Link a ROS trace runtime event to its corresponding handling method."""
         # Link a ROS trace event to its corresponding handling method
 
         handler_map = {}
@@ -339,9 +341,14 @@ class Ros2Handler():
 
         self.handler_map = handler_map
 
-    def _is_valid_data(self, event) -> bool:
+    def _is_valid_data(self, event: dict) -> bool:
         """
         Confirm that the data to be converted is appropriate.
+
+        Parameters
+        ----------
+        event : dict
+            Target event.
 
         Returns
         -------

--- a/src/caret_analyze/infra/trace_point_data.py
+++ b/src/caret_analyze/infra/trace_point_data.py
@@ -300,6 +300,15 @@ class TracePointData:
 
     @singledispatchmethod
     def merge(self, arg) -> None:
+        """
+        Merge data.
+
+        Raises
+        ------
+        NotImplementedError
+            This module is not implemented.
+
+        """
         raise NotImplementedError('')
 
     @merge.register

--- a/src/caret_analyze/infra/yaml/architecture_reader_yaml.py
+++ b/src/caret_analyze/infra/yaml/architecture_reader_yaml.py
@@ -47,11 +47,34 @@ class ArchitectureReaderYaml(ArchitectureReader):
         self,
         callback_group_id: str
     ) -> Sequence[tuple[str | None, str | None]]:
+        """
+        Get node names and callback symbols.
+
+        Parameters
+        ----------
+        callback_group_id : str
+            callback group id.
+
+        Returns
+        -------
+        Sequence[tuple[str | None, str | None]]
+            Always empty sequence.
+
+        """
         logger.warning('get_node_names_and_cb_symbols method is not implemented '
                        'in ArchitectureReaderYaml class.')
         return []
 
     def get_nodes(self) -> Sequence[NodeValueWithId]:
+        """
+        Get nodes.
+
+        Returns
+        -------
+        Sequence[NodeValueWithId]
+            All node objects defined in the architecture file.
+
+        """
         nodes_dict = self._get_value(self._arch, 'nodes')
         nodes = []
         for node_dict in nodes_dict:
@@ -105,6 +128,20 @@ class ArchitectureReaderYaml(ArchitectureReader):
         self,
         node: NodeValue,
     ) -> list[TimerCallbackValue]:
+        """
+        Get timer callback values.
+
+        Parameters
+        ----------
+        node : NodeValue
+            target node
+
+        Returns
+        -------
+        list[TimerCallbackValue]
+            Timer callback object of specified node defined in architecture file.
+
+        """
         node_dict = self._get_node_dict(node.node_name)
 
         if 'callbacks' not in node_dict:
@@ -141,6 +178,20 @@ class ArchitectureReaderYaml(ArchitectureReader):
         self,
         node: NodeValue
     ) -> list[dict]:
+        """
+        Get message contexts.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        list[dict]
+            Message context object of specified node defined in architecture file.
+
+        """
         node_dict = self._get_node_dict(node.node_name)
         if 'message_contexts' not in node_dict.keys():
             return []
@@ -158,6 +209,20 @@ class ArchitectureReaderYaml(ArchitectureReader):
         self,
         node: NodeValue
     ) -> list[CallbackGroupValue]:
+        """
+        Get callback groups.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        list[CallbackGroupValue]
+            Callback group object of specified node defined in architecture file.
+
+        """
         node_dict = self._get_node_dict(node.node_name)
         if 'callback_groups' not in node_dict.keys():
             return []
@@ -179,6 +244,15 @@ class ArchitectureReaderYaml(ArchitectureReader):
         return callback_groups
 
     def get_paths(self) -> list[PathValue]:
+        """
+        Get paths.
+
+        Returns
+        -------
+        list[PathValue]
+            All path information objects defined in the architecture file.
+
+        """
         aliases_info = self._get_value(self._arch, 'named_paths')
 
         paths_info = []
@@ -218,6 +292,20 @@ class ArchitectureReaderYaml(ArchitectureReader):
         self,
         node: NodeValue,
     ) -> list[VariablePassingValue]:
+        """
+        Get variable passings.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        list[VariablePassingValue]
+            Variable passing object of specified node defined in architecture file.
+
+        """
         node_dict = self._get_node_dict(node.node_name)
 
         if 'variable_passings' not in node_dict.keys():
@@ -235,6 +323,15 @@ class ArchitectureReaderYaml(ArchitectureReader):
         return var_passes
 
     def get_executors(self) -> list[ExecutorValue]:
+        """
+        Get executors.
+
+        Returns
+        -------
+        list[ExecutorValue]
+            All executor objects defined in the architecture file.
+
+        """
         executors = []
         for e in self._get_value(self._arch, 'executors'):
             cbg_names = self._get_value(e, 'callback_group_names')
@@ -250,6 +347,20 @@ class ArchitectureReaderYaml(ArchitectureReader):
         self,
         node: NodeValue
     ) -> list[SubscriptionCallbackValue]:
+        """
+        Get subscription callbacks.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        list[SubscriptionCallbackValue]
+            Subscription callback object of specified node defined in architecture file.
+
+        """
         def is_target(x: dict):
             return self._get_value(x, 'callback_type') == CallbackType.SUBSCRIPTION.type_name
         node_dict = self._get_node_dict(node.node_name)
@@ -283,12 +394,40 @@ class ArchitectureReaderYaml(ArchitectureReader):
         return callbacks
 
     def get_service_callbacks(self, node: NodeValue) -> Sequence[ServiceCallbackValue]:
+        """
+        Get service callbacks.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[ServiceCallbackValue]
+            Always empty sequence.
+
+        """
         return []
 
     def get_publishers(
         self,
         node: NodeValue
     ) -> list[PublisherValue]:
+        """
+        Get publishers.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        list[PublisherValue]
+            Publisher object of specified node defined in architecture file.
+
+        """
         node_dict = self._get_node_dict(node.node_name)
         publishers = []
 
@@ -311,6 +450,20 @@ class ArchitectureReaderYaml(ArchitectureReader):
         self,
         node: NodeValue
     ) -> list[TimerValue]:
+        """
+        Get timers.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        list[TimerValue]
+            Timer object of specified node defined in architecture file.
+
+        """
         node_dict = self._get_node_dict(node.node_name)
         timers = []
 
@@ -338,6 +491,20 @@ class ArchitectureReaderYaml(ArchitectureReader):
         self,
         node: NodeValue
     ) -> list[SubscriptionValue]:
+        """
+        Get subscriptions.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        list[SubscriptionValue]
+            Subscription object of specified node defined in architecture file.
+
+        """
         node_dict = self._get_node_dict(node.node_name)
         subscriptions = []
 
@@ -357,6 +524,20 @@ class ArchitectureReaderYaml(ArchitectureReader):
         return subscriptions
 
     def get_services(self, node: NodeValue) -> Sequence[ServiceValue]:
+        """
+        Get services.
+
+        Parameters
+        ----------
+        node : NodeValue
+            Target node value.
+
+        Returns
+        -------
+        Sequence[ServiceValue]
+            Always empty sequence.
+
+        """
         return []
 
     def _get_node_dict(

--- a/src/caret_analyze/plot/callback_scheduling/callback_scheduling_plot.py
+++ b/src/caret_analyze/plot/callback_scheduling/callback_scheduling_plot.py
@@ -50,6 +50,20 @@ class CallbackSchedulingPlot(PlotBase):
         self._rstrip_s = rstrip_s
 
     def to_dataframe(self, xaxis_type: str = 'system_time') -> pd.DataFrame:
+        """
+        Get data in pandas DataFrame format.
+
+        Parameters
+        ----------
+        xaxis_type : str
+            Type of time for timestamp.
+
+        Returns
+        -------
+        pd.DataFrame
+            Callback scheduling plot DataFrame.
+
+        """
         logger.warning("'to_dataframe' method is not implemented in CallbackSchedulingPlot.")
         return pd.DataFrame()
 
@@ -115,6 +129,25 @@ class CallbackSchedulingPlot(PlotBase):
         full_legends: bool | None = None,
         coloring_rule: str | None = None,
     ) -> None:
+        """
+        Show a callback scheduling plot.
+
+        Parameters
+        ----------
+        xaxis_type : str, optional
+            Type of x-axis of the line graph to be plotted.
+            "system_time", "index", or "sim_time" can be specified, by default "system_time".
+        ywheel_zoom : bool, optional
+            If True, the drawn graph can be expanded in the y-axis direction
+            by the mouse wheel, by default False.
+        full_legends : bool, optional
+            If True, all legends are drawn
+            even if the number of legends exceeds the threshold, by default False.
+        coloring_rule : str, optional
+            The unit of color change
+            There are there rules which are [callback/callback_group/node], by default 'callback'
+
+        """
         p = self.figure(xaxis_type, ywheel_zoom, full_legends, coloring_rule)
         show(p)
 
@@ -127,6 +160,29 @@ class CallbackSchedulingPlot(PlotBase):
         full_legends: bool | None = None,
         coloring_rule: str | None = None
     ) -> None:
+        """
+        Save a callback scheduling plot.
+
+        Parameters
+        ----------
+        export_path : str
+            The graph will be saved as a file.
+        title: str, optional
+            Title of the graph, by default ''.
+        xaxis_type : str, optional
+            Type of x-axis of the line graph to be plotted.
+            "system_time", "index", or "sim_time" can be specified, by default "system_time".
+        ywheel_zoom : bool, optional
+            If True, the drawn graph can be expanded in the y-axis direction
+            by the mouse wheel, by default False.
+        full_legends : bool, optional
+            If True, all legends are drawn
+            even if the number of legends exceeds the threshold, by default False.
+        coloring_rule : str, optional
+            The unit of color change
+            There are there rules which are [callback/callback_group/node], by default 'callback'
+
+        """
         p = self.figure(xaxis_type, ywheel_zoom, full_legends, coloring_rule)
         save(p, export_path, title=title, resources=CDN)
 

--- a/src/caret_analyze/plot/graphviz/chain_latency.py
+++ b/src/caret_analyze/plot/graphviz/chain_latency.py
@@ -32,6 +32,35 @@ def chain_latency(
     lstrip_s=0,
     rstrip_s=0,
 ) -> Digraph | None:
+    """
+    Chain latency.
+
+    Parameters
+    ----------
+    path : Path
+        Path.
+    export_path : str | None
+        Export path.
+    granularity : str
+        Granularity.
+    treat_drop_as_delay : bool
+        Treat drop as delay.
+    lstrip_s : float, optional
+        Start time of cropping range, by default 0.
+    rstrip_s: float, optional
+        End point of cropping range, by default 0.
+
+    Returns
+    -------
+    Digraph | None
+        Created directed graph.
+
+    Raises
+    ------
+    UnsupportedTypeError
+        Argument granularity is not "node", "end-to-end".
+
+    """
     granularity = granularity or 'node'
     if granularity not in ['node', 'end-to-end']:
         raise InvalidArgumentError('granularity must be [ node / end-to-end ]')
@@ -84,6 +113,20 @@ class GraphAttr:
 
 
 def to_label(latency: np.ndarray) -> str:
+    """
+    To label.
+
+    Parameters
+    ----------
+    latency : np.ndarray
+        Latency.
+
+    Returns
+    -------
+    str
+        Label.
+
+    """
     latency = latency[[not pd.isnull(_) for _ in latency]]
     label = (
         'min: {:.2f} ms\n'.format(np.min(latency * 1.0e-6))
@@ -99,6 +142,26 @@ def get_attr_node(
     lstrip_s: float,
     rstrip_s: float
 ) -> GraphAttr:
+    """
+    Get attribute node.
+
+    Parameters
+    ----------
+    path : Path
+        Path.
+    treat_drop_as_delay : bool
+        Treat drop as delay.
+    lstrip_s : float, optional
+        Start time of cropping range, by default 0.
+    rstrip_s: float, optional
+        End point of cropping range, by default 0.
+
+    Returns
+    -------
+    GraphAttr
+        Graph attribute node.
+
+    """
     def calc_latency_from_path_df(target_columns: list[str]) -> np.ndarray:
         target_df = path.to_dataframe(
             remove_dropped=remove_dropped,
@@ -165,6 +228,26 @@ def get_attr_end_to_end(
     lstrip_s: float,
     rstrip_s: float
 ) -> GraphAttr:
+    """
+    Get attribute end to end.
+
+    Parameters
+    ----------
+    path : Path
+        Path.
+    treat_drop_as_delay : bool
+        Treat drop as delay.
+    lstrip_s : float, optional
+        Start time of cropping range, by default 0.
+    rstrip_s: float, optional
+        End point of cropping range, by default 0.
+
+    Returns
+    -------
+    GraphAttr
+        End to end graph attribute node.
+
+    """
     node_paths = path.node_paths
     remove_dropped = False
 

--- a/src/caret_analyze/plot/graphviz/chain_latency.py
+++ b/src/caret_analyze/plot/graphviz/chain_latency.py
@@ -128,11 +128,14 @@ def to_label(latency: np.ndarray) -> str:
 
     """
     latency = latency[[not pd.isnull(_) for _ in latency]]
-    label = (
-        'min: {:.2f} ms\n'.format(np.min(latency * 1.0e-6))
-        + 'avg: {:.2f} ms\n'.format(np.average(latency * 1.0e-6))
-        + 'max: {:.2f} ms'.format(np.max(latency * 1.0e-6))
-    )
+    if len(latency) > 0:
+        label = (
+            'min: {:.2f} ms\n'.format(np.min(latency * 1.0e-6))
+            + 'avg: {:.2f} ms\n'.format(np.average(latency * 1.0e-6))
+            + 'max: {:.2f} ms'.format(np.max(latency * 1.0e-6))
+        )
+    else:
+        label = 'Latency cannot be calculated'
     return label
 
 

--- a/src/caret_analyze/plot/histogram/histogram_plot.py
+++ b/src/caret_analyze/plot/histogram/histogram_plot.py
@@ -66,6 +66,12 @@ class HistogramPlot(PlotBase):
         Returns
         -------
         pd.DataFrame
+            Histogram dataFrame.
+
+        Raises
+        ------
+        NotImplementedError
+            This module is not implemented.
 
         """
         raise NotImplementedError()
@@ -93,7 +99,8 @@ class HistogramPlot(PlotBase):
 
         Returns
         -------
-        bokeh.plotting.Figure
+        Figure
+            bokeh.plotting.Figure
 
         Raises
         ------

--- a/src/caret_analyze/plot/histogram/histogram_plot_factory.py
+++ b/src/caret_analyze/plot/histogram/histogram_plot_factory.py
@@ -55,11 +55,12 @@ class HistogramPlotFactory:
         Returns
         -------
         HistogramPlot
+            Created instance of HistogramPlot
 
         Raises
         ------
         UnsupportedTypeError
-            Argument metrics is not "frequency", "latency", or "period".
+            Argument metrics is not "frequency", "latency", "period", or "response_time".
 
         """
         metrics_list: list[MetricsType] = []

--- a/src/caret_analyze/plot/message_flow/message_flow_plot.py
+++ b/src/caret_analyze/plot/message_flow/message_flow_plot.py
@@ -47,6 +47,20 @@ class MessageFlowPlot(PlotBase):
         self._rstrip_s = rstrip_s
 
     def to_dataframe(self, xaxis_type: str = 'system_time') -> pd.DataFrame:
+        """
+        Get data in pandas DataFrame format.
+
+        Parameters
+        ----------
+        xaxis_type : str
+            Type of time for timestamp.
+
+        Returns
+        -------
+        pd.DataFrame
+            Message flow dataFrame.
+
+        """
         logger.warning("'to_dataframe' method is not implemented in MessageFlowPlot.")
         return pd.DataFrame()
 
@@ -56,6 +70,28 @@ class MessageFlowPlot(PlotBase):
         ywheel_zoom: bool | None = None,
         full_legends: bool | None = None  # FIXME: not used in message flow
     ) -> Figure:
+        """
+        Get a message flow for each object using the bokeh library.
+
+        Parameters
+        ----------
+        xaxis_type : str
+            Type of x-axis of the line graph to be plotted.
+            "system_time", "index", or "sim_time" can be specified, by default "system_time".
+        ywheel_zoom : bool
+            If True, the drawn graph can be expanded in the y-axis direction
+            by the mouse wheel, by default True.
+        full_legends : bool
+            If True, all legends are drawn
+            even if the number of legends exceeds the threshold, by default False.
+
+        Returns
+        -------
+        Figure
+            bokeh.plotting.Figure
+
+
+        """
         # Set default value
         xaxis_type = xaxis_type or 'system_time'
         ywheel_zoom = ywheel_zoom if ywheel_zoom is not None else True

--- a/src/caret_analyze/plot/message_flow/message_flow_plot_factory.py
+++ b/src/caret_analyze/plot/message_flow/message_flow_plot_factory.py
@@ -32,6 +32,35 @@ class MessageFlowPlotFactory:
         lstrip_s: float = 0,
         rstrip_s: float = 0
     ) -> MessageFlowPlot:
+        """
+        Create instance.
+
+        Parameters
+        ----------
+        target_path : Path
+            Target path.
+        visualize_lib : VisualizeLibInterface
+            Instance of VisualizeLibInterface used for visualization.
+        granularity : str | None
+            Granularity.
+        treat_drop_as_delay : bool
+            Treat drop as delay.
+        lstrip_s : float, optional
+            Start time of cropping range, by default 0.
+        rstrip_s: float, optional
+            End point of cropping range, by default 0.
+
+        Returns
+        -------
+        MessageFlowPlot
+            Created instance of MessageFlowPlot.
+
+        Raises
+        ------
+        InvalidArgumentError
+            Argument granularity is not "raw" or "node".
+
+        """
         granularity = granularity or 'raw'
         if granularity not in ['raw', 'node']:
             raise InvalidArgumentError('granularity must be [ raw / node ]')

--- a/src/caret_analyze/plot/metrics_base.py
+++ b/src/caret_analyze/plot/metrics_base.py
@@ -36,10 +36,33 @@ class MetricsBase(metaclass=ABCMeta):
 
     @property
     def target_objects(self) -> list[TimeSeriesTypes]:
+        """
+        Get target objects.
+
+        Returns
+        -------
+        list[TimeSeriesTypes]
+            target object list.
+
+        """
         return self._target_objects
 
     @abstractmethod
     def to_dataframe(self, xaxis_type: str = 'system_time') -> pd.DataFrame:
+        """
+        Get data in pandas DataFrame format.
+
+        Parameters
+        ----------
+        xaxis_type : str, optional
+            X axis value's type , by default 'system_time'.
+
+        Raises
+        ------
+        NotImplementedError
+            This module is not implemented.
+
+        """
         raise NotImplementedError()
 
     @abstractmethod
@@ -47,6 +70,20 @@ class MetricsBase(metaclass=ABCMeta):
         self,
         xaxis_type: str = 'system_time'
     ) -> list[RecordsInterface]:
+        """
+        Get timeseries records list.
+
+        Parameters
+        ----------
+        xaxis_type : str, optional
+            X axis value's type , by default 'system_time'.
+
+        Raises
+        ------
+        NotImplementedError
+            This module is not implemented.
+
+        """
         raise NotImplementedError()
 
     # TODO: Multi-column DataFrame are difficult for users to handle,

--- a/src/caret_analyze/plot/plot_base.py
+++ b/src/caret_analyze/plot/plot_base.py
@@ -44,6 +44,12 @@ class PlotBase(metaclass=ABCMeta):
         Returns
         -------
         pd.DataFrame
+            Plot base dataFrame
+
+        Raises
+        ------
+        NotImplementedError
+            This module is not implemented.
 
         """
         raise NotImplementedError()
@@ -71,6 +77,11 @@ class PlotBase(metaclass=ABCMeta):
         -------
         bokeh.plotting.Figure
 
+        Raises
+        ------
+        NotImplementedError
+            This module is not implemented.
+
         """
         raise NotImplementedError()
 
@@ -95,11 +106,6 @@ class PlotBase(metaclass=ABCMeta):
         full_legends : bool
             If True, all legends are drawn
             even if the number of legends exceeds the threshold.
-
-        Raises
-        ------
-        UnsupportedTypeError
-            Argument xaxis_type is not "system_time", "index", or "sim_time".
 
         """
         p = self.figure(xaxis_type, ywheel_zoom, full_legends)
@@ -131,11 +137,6 @@ class PlotBase(metaclass=ABCMeta):
         full_legends : bool
             If True, all legends are drawn
             even if the number of legends exceeds the threshold.
-
-        Raises
-        ------
-        UnsupportedTypeError
-            Argument xaxis_type is not "system_time", "index", or "sim_time".
 
         """
         p = self.figure(xaxis_type, ywheel_zoom, full_legends)

--- a/src/caret_analyze/plot/plot_facade.py
+++ b/src/caret_analyze/plot/plot_facade.py
@@ -62,6 +62,7 @@ class Plot:
         Returns
         -------
         StackedBarPlot
+            Created instance of StackedBarPlot.
 
         """
         visualize_lib = VisualizeLibFactory.create_instance()
@@ -90,6 +91,7 @@ class Plot:
         Returns
         -------
         PlotBase
+            Created instance of period PlotBase.
 
         """
         visualize_lib = VisualizeLibFactory.create_instance()
@@ -113,6 +115,7 @@ class Plot:
         Returns
         -------
         PlotBase
+            Created instance of frequency PlotBase.
 
         """
         visualize_lib = VisualizeLibFactory.create_instance()
@@ -136,6 +139,7 @@ class Plot:
         Returns
         -------
         PlotBase
+            Created instance of latency PlotBase.
 
         """
         visualize_lib = VisualizeLibFactory.create_instance()
@@ -163,6 +167,7 @@ class Plot:
         Returns
         -------
         PlotBase
+            Created instance of response_time PlotBase.
 
         """
         visualize_lib = VisualizeLibFactory.create_instance()
@@ -195,6 +200,7 @@ class Plot:
         Returns
         -------
         CallbackSchedulingPlot
+            Created instance of CallbackSchedulingPlot.
 
         """
         visualize_lib = VisualizeLibFactory.create_instance()
@@ -234,6 +240,7 @@ class Plot:
         Returns
         -------
         MessageFlowPlot
+            Created instance of MessageFlowPlot.
 
         """
         visualize_lib = VisualizeLibFactory.create_instance()
@@ -259,6 +266,7 @@ class Plot:
         Returns
         -------
         PlotBase
+            Created instance of frequency PlotBase.
 
         """
         visualize_lib = VisualizeLibFactory.create_instance()
@@ -282,6 +290,7 @@ class Plot:
         Returns
         -------
         PlotBase
+            Created instance of latency PlotBase.
 
         """
         visualize_lib = VisualizeLibFactory.create_instance()
@@ -305,6 +314,7 @@ class Plot:
         Returns
         -------
         PlotBase
+            Created instance of period PlotBase.
 
         """
         visualize_lib = VisualizeLibFactory.create_instance()
@@ -332,6 +342,7 @@ class Plot:
         Returns
         -------
         PlotBase
+            Created instance of response_time PlotBase.
 
         """
         visualize_lib = VisualizeLibFactory.create_instance()

--- a/src/caret_analyze/plot/stacked_bar/latency_stacked_bar.py
+++ b/src/caret_analyze/plot/stacked_bar/latency_stacked_bar.py
@@ -50,6 +50,11 @@ class LatencyStackedBar:
         pd.DataFrame
             Latency dataframe.
 
+        Raises
+        ------
+        NotImplementedError
+            Argument xaxis_type is not "system_time" or "sim_time".
+
         """
         # NOTE: returned columns aren't used because they don't include 'start time'
         # TODO: delete 1e-6
@@ -108,6 +113,11 @@ class LatencyStackedBar:
         RecordsInterface
             Response time records of the path.
 
+        Raises
+        ------
+        ValueError
+            - Case is not "all", "best", "worst", or "worst-with-external-latency".
+
         """
         response_time = ResponseTime(target_object.to_records(),
                                      columns=target_object.column_names)
@@ -134,4 +144,13 @@ class LatencyStackedBar:
 
     @property
     def target_objects(self) -> Path:
+        """
+        Get target objects.
+
+        Returns
+        -------
+        Path
+            target objects.
+
+        """
         return self._target_objects

--- a/src/caret_analyze/plot/stacked_bar/stacked_bar_plot.py
+++ b/src/caret_analyze/plot/stacked_bar/stacked_bar_plot.py
@@ -42,7 +42,27 @@ class StackedBarPlot(PlotBase):
         ywheel_zoom: bool | None = True,
         full_legends: bool | None = False,
     ) -> Figure:
+        """
+        Get figure for each object using the bokeh library.
 
+        Parameters
+        ----------
+        xaxis_type : str
+            Type of x-axis of the line graph to be plotted.
+            "system_time", "index", or "sim_time" can be specified, by default "system_time".
+        ywheel_zoom : bool
+            If True, the drawn graph can be expanded in the y-axis direction
+            by the mouse wheel, by default True.
+        full_legends : bool
+            If True, all legends are drawn
+            even if the number of legends exceeds the threshold, by default False.
+
+        Returns
+        -------
+        Figure
+            bokeh.plotting.Figure
+
+        """
         # Set default value
         xaxis_type = xaxis_type or 'system_time'
         ywheel_zoom = ywheel_zoom if ywheel_zoom is not None else True
@@ -57,5 +77,19 @@ class StackedBarPlot(PlotBase):
         )
 
     def to_dataframe(self, xaxis_type: str = 'system_time') -> pd.DataFrame:
+        """
+        Get stacked bar data in pandas DataFrame format.
+
+        Parameters
+        ----------
+        xaxis_type : str, optional
+            X axis value's type , by default 'system_time'.
+
+        Returns
+        -------
+        pd.DataFrame
+            Stacked bar dataframe.
+
+        """
         # return super().to_dataframe(xaxis_type)
         return self._metrics.to_dataframe(xaxis_type)

--- a/src/caret_analyze/plot/stacked_bar/stacked_bar_plot_factory.py
+++ b/src/caret_analyze/plot/stacked_bar/stacked_bar_plot_factory.py
@@ -47,7 +47,14 @@ class StackedBarPlotFactory:
         Returns
         -------
         StackedBarPlot
-            StackedBarPlot
+            Created instance of StackedBarPlot.
+
+        Raises
+        ------
+        NotImplementedError
+            This metrics is not implemented.
+        UnsupportedTypeError
+            Argument granularity is not "metrics" or "percentage".
 
         """
         if metrics == 'latency':

--- a/src/caret_analyze/plot/timeseries/frequency_timeseries.py
+++ b/src/caret_analyze/plot/timeseries/frequency_timeseries.py
@@ -20,11 +20,54 @@ import pandas as pd
 
 from ..metrics_base import MetricsBase
 from ..util import get_clock_converter
-from ...common import ClockConverter, Util
+from ...common import Util
 from ...record import Frequency, RecordsInterface
 from ...runtime import CallbackBase, Communication, Publisher, Subscription
 
 TimeSeriesTypes = CallbackBase | Communication | (Publisher | Subscription)
+
+
+def _get_frequency_computing_timestamp_offset_ns(timeseries_record: RecordsInterface) -> int:
+    """
+    Calculate the offset time for frequency calculation.
+
+    Parameters
+    ----------
+    timeseries_record : RecordsInterface
+        Timeseries record.
+
+    Returns
+    -------
+    int
+        Offset in nanoseconds. The offset is half the interval time.
+        For example, if the frequency is 1Hz, the interval is 500ms.
+
+    Notes
+    -----
+    If the data frequency is 1Hz and calculated without an offset,
+    the output may become unstable. For instance, if the interval is 999ms,
+    no data is included, resulting in 0Hz. Conversely, if the interval is 1001ms,
+    two data points are included, resulting in 2Hz.
+    Using an offset ensures stable calculations.
+
+    """
+    if len(timeseries_record) == 0:
+        return 0
+
+    # Get timestamp array
+    timestamp_column_name = timeseries_record.columns[0]
+    timestamp_list = timeseries_record.get_column_series(timestamp_column_name)
+    if len(timestamp_list) < 2:
+        return 0
+    if timestamp_list[0] is None or timestamp_list[1] is None:
+        return 0
+
+    # Calculate timestamp offset
+    # Approximate period estimation using the first two timestamps.
+    # Accuracy is not critical, as the offset only needs to prevent boundary collisions.
+    timestamp_diff = int(timestamp_list[1]) - int(timestamp_list[0])
+    timestamp_offset_ns = int(timestamp_diff / 2)
+    return timestamp_offset_ns
 
 
 class FrequencyTimeSeries(MetricsBase):
@@ -111,26 +154,30 @@ class FrequencyTimeSeries(MetricsBase):
                     return False
 
         timeseries_records_list: list[RecordsInterface] = [
-            _.to_records() for _ in self._target_objects
+            obj.to_records() for obj in self._target_objects
         ]
 
-        converter: ClockConverter | None = None
         if xaxis_type == 'sim_time':
             converter = get_clock_converter(self._target_objects)
+        else:
+            converter = None
 
         min_time, max_time = self._get_timestamp_range(timeseries_records_list)
 
         frequency_timeseries_list: list[RecordsInterface] = []
         for records in timeseries_records_list:
+            offset_ns = _get_frequency_computing_timestamp_offset_ns(records)
             frequency = Frequency(
                 records,
                 row_filter=row_filter_communication
                 if isinstance(records, Communication) else None
             )
-            frequency_timeseries_list.append(frequency.to_records(
-                base_timestamp=min_time, until_timestamp=max_time,
+            frequency_record = frequency.to_records(
+                base_timestamp=min_time + offset_ns,
+                until_timestamp=max_time,
                 converter=converter
-            ))
+            )
+            frequency_timeseries_list.append(frequency_record)
 
         return frequency_timeseries_list
 

--- a/src/caret_analyze/plot/timeseries/period_timeseries.py
+++ b/src/caret_analyze/plot/timeseries/period_timeseries.py
@@ -47,11 +47,6 @@ class PeriodTimeSeries(MetricsBase):
             "system_time", "index", or "sim_time" can be specified.
             The default is "system_time".
 
-        Raises
-        ------
-        UnsupportedTypeError
-            Argument xaxis_type is not "system_time", "index", or "sim_time".
-
         Returns
         -------
         pd.DataFrame

--- a/src/caret_analyze/plot/timeseries/response_time_timeseries.py
+++ b/src/caret_analyze/plot/timeseries/response_time_timeseries.py
@@ -95,6 +95,11 @@ class ResponseTimeTimeSeries(MetricsBase):
         list[RecordsInterface]
             Response time records list of all target objects.
 
+        Raises
+        ------
+        ValueError
+            - Case is not "all", "best", "worst", or "worst-with-external-latency".
+
         """
         timeseries_records_list: list[RecordsInterface] = [
             _.to_records() for _ in self._target_objects

--- a/src/caret_analyze/plot/timeseries/timeseries_plot.py
+++ b/src/caret_analyze/plot/timeseries/timeseries_plot.py
@@ -50,6 +50,11 @@ class TimeSeriesPlot(PlotBase):
             Type of time for timestamp.
             "system_time", "index", or "sim_time" can be specified, by default "system_time".
 
+        Returns
+        -------
+        pd.DataFrame
+            Time series plot DataFrame.
+
         Raises
         ------
         UnsupportedTypeError
@@ -86,7 +91,8 @@ class TimeSeriesPlot(PlotBase):
 
         Returns
         -------
-        bokeh.plotting.Figure
+        Figure
+            bokeh.plotting.Figure
 
         Raises
         ------

--- a/src/caret_analyze/plot/timeseries/timeseries_plot_factory.py
+++ b/src/caret_analyze/plot/timeseries/timeseries_plot_factory.py
@@ -58,6 +58,7 @@ class TimeSeriesPlotFactory:
         Returns
         -------
         TimeSeriesPlot
+            Created instance of TimeSeriesPlot.
 
         Raises
         ------

--- a/src/caret_analyze/plot/util.py
+++ b/src/caret_analyze/plot/util.py
@@ -26,6 +26,20 @@ TimeSeriesTypes = CallbackBase | Communication | (Publisher | Subscription) | Pa
 def get_clock_converter(
     target_objects: Sequence[TimeSeriesTypes],
 ) -> ClockConverter:
+    """
+    Construct an instance to convert between simulation time and system time from time series data.
+
+    Parameters
+    ----------
+    target_objects : Sequence[TimeSeriesTypes]
+        TimeSeriesTypes target objects.
+
+    Returns
+    -------
+    ClockConverter
+        converter instance.
+
+    """
     records_range = Range([to.to_records() for to in target_objects])
     frame_min, frame_max = records_range.get_range()
     if isinstance(target_objects[0], Communication):

--- a/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/bokeh.py
@@ -58,6 +58,35 @@ class Bokeh(VisualizeLibInterface):
         lstrip_s: float,
         rstrip_s: float
     ) -> Figure:
+        """
+        Get message flow figure.
+
+        Parameters
+        ----------
+        target_path : Path
+            The target path.
+        xaxis_type : str, optional
+            Type of x-axis of the line graph to be plotted.
+            "system_time", "index", or "sim_time" can be specified.
+            The default is "system_time".
+        ywheel_zoom : bool, optional
+            If True, the drawn graph can be expanded in the y-axis direction
+            by the mouse wheel.
+        granularity : str
+            Granularity.
+        treat_drop_as_delay : bool
+            Treat drop as delay.
+        lstrip_s : float, optional
+            Start time of cropping range, by default 0.
+        rstrip_s: float, optional
+            End point of cropping range, by default 0.
+
+        Returns
+        -------
+        bokeh.plotting.Figure
+            Figure of message flow.
+
+        """
         message_flow = BokehMessageFlow(
             target_path, xaxis_type, ywheel_zoom, granularity,
             treat_drop_as_delay, lstrip_s, rstrip_s,
@@ -72,6 +101,33 @@ class Bokeh(VisualizeLibInterface):
         full_legends: bool,
         case: str,  # all, best, worst or worst-with-external-latency
     ) -> Figure:
+        """
+        Get a stacked bar figure.
+
+        Parameters
+        ----------
+        metrics : MetricsBase
+            Metrics to be y-axis in visualization.
+        xaxis_type : str
+            Type of x-axis of the line graph to be plotted.
+            "system_time", "index", or "sim_time" can be specified.
+            The default is "system_time".
+        ywheel_zoom : bool
+            If True, the drawn graph can be expanded in the y-axis direction
+            by the mouse wheel.
+        full_legends : bool
+            If True, all legends are drawn
+            even if the number of legends exceeds the threshold.
+        case : str
+            Parameter specifying all, best, worst, or worst-with-external-latency.
+            Use to create Response time timeseries graph.
+
+        Returns
+        -------
+        bokeh.plotting.Figure
+            Figure of stacked bar.
+
+        """
         stacked_bar = BokehStackedBar(metrics, xaxis_type, ywheel_zoom, full_legends, case)
         return stacked_bar.create_figure()
 
@@ -113,6 +169,7 @@ class Bokeh(VisualizeLibInterface):
         Returns
         -------
         bokeh.plotting.Figure
+            Figure of callback scheduling.
 
         """
         callback_scheduling = BokehCallbackSched(
@@ -150,7 +207,6 @@ class Bokeh(VisualizeLibInterface):
             Parameter specifying all, best, worst, or worst-with-external-latency.
             Use to create Response time timeseries graph.
 
-
         Returns
         -------
         bokeh.plotting.Figure
@@ -185,14 +241,16 @@ class Bokeh(VisualizeLibInterface):
         case : str
             Parameter specifying all, best, worst, or worst-with-external-latency.
             Use to create Response time histogram graph.
-        converter: ClockConverter
-            Time conversion function at sim_time.
-
 
         Returns
         -------
         bokeh.plotting.Figure
             Figure of histogram.
+
+        Raises
+        ------
+        NotImplementedError
+            Argument metrics_name is not "frequency", "period", "latency", or "response_time".
 
         """
         legend_manager = LegendManager()

--- a/src/caret_analyze/plot/visualize_lib/bokeh/callback_scheduling.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/callback_scheduling.py
@@ -51,6 +51,15 @@ class BokehCallbackSched:
         self._rstrip_s = rstrip_s
 
     def create_figure(self) -> Figure:
+        """
+        Create Bokeh callback sched figure.
+
+        Returns
+        -------
+        bokeh.plotting.Figure
+            Figure of Bokeh callback sched.
+
+        """
         # Initialize figure
         title = ('Callback Scheduling in '
                  f"[{'/'.join([cbg.callback_group_name for cbg in self._callback_groups])}].")
@@ -180,6 +189,15 @@ class CallbackSchedRectSource:
 
     @property
     def rect_y_base(self) -> float:
+        """
+        Get rect y_base.
+
+        Returns
+        -------
+        float
+            rect y_base.
+
+        """
         return self._rect_y_base
 
     def create_hover(self, options: dict[str, Any] = {}) -> HoverTool:
@@ -194,6 +212,7 @@ class CallbackSchedRectSource:
         Returns
         -------
         HoverTool
+            Created hover.
 
         """
         return self._hover_keys.create_hover(options)
@@ -210,6 +229,7 @@ class CallbackSchedRectSource:
         Returns
         -------
         ColumnDataSource
+            Generated callback scheduling rect source
 
         """
         rect_source = ColumnDataSource(data={
@@ -276,6 +296,7 @@ class CallbackSchedBarSource:
         Returns
         -------
         HoverTool
+            Created hover.
 
         """
         return self._hover_keys.create_hover(options)
@@ -294,6 +315,7 @@ class CallbackSchedBarSource:
         Returns
         -------
         ColumnDataSource
+            Generated callback scheduling bar source
 
         """
         rect = RectValues(

--- a/src/caret_analyze/plot/visualize_lib/bokeh/message_flow.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/message_flow.py
@@ -54,6 +54,15 @@ class BokehMessageFlow:
         self._rstrip_s = rstrip_s
 
     def create_figure(self) -> Figure:
+        """
+        Create message flow figure.
+
+        Returns
+        -------
+        bokeh.plotting.Figure
+            Figure of message flow.
+
+        """
         # Initialize figure
         fig = init_figure(
             f'Message flow of {self._target_path.path_name}', self._ywheel_zoom, self._xaxis_type)
@@ -135,6 +144,20 @@ class MessageFlowRectSource:
         self._hover_source = HoverSource(self._hover_keys)
 
     def create_hover(self, options: dict[str, Any] = {}) -> HoverTool:
+        """
+        Create HoverTool based on the legend keys.
+
+        Parameters
+        ----------
+        options : dict, optional
+            Additional options, by default {}
+
+        Returns
+        -------
+        HoverTool
+            Created hover.
+
+        """
         return self._hover_keys.create_hover(options)
 
     def generate(
@@ -164,6 +187,7 @@ class MessageFlowRectSource:
         Returns
         -------
         ColumnDataSource
+            Generated message flow rect source
 
         """
         rect_source = ColumnDataSource(data={
@@ -221,6 +245,20 @@ class MessageFlowLineSource:
         self._hover_keys = HoverKeysFactory.create_instance('message_flow_line', target_path)
 
     def create_hover(self, options: dict[str, Any] = {}) -> HoverTool:
+        """
+        Create HoverTool based on the legend keys.
+
+        Parameters
+        ----------
+        options : dict, optional
+            Additional options, by default {}
+
+        Returns
+        -------
+        HoverTool
+            Created hover.
+
+        """
         return self._hover_keys.create_hover(options)
 
     def generate(
@@ -244,6 +282,7 @@ class MessageFlowLineSource:
         Returns
         -------
         ColumnDataSource
+            Generated message flow line source
 
         """
         tick_labels = YAxisProperty(df)
@@ -322,14 +361,25 @@ class YAxisProperty:
 
     @property
     def values(self):
+        """Get values."""
         return list(self._tick_labels.keys())
 
     @property
     def labels(self):
+        """Get labels."""
         return list(self._tick_labels.values())
 
     @property
     def labels_dict(self) -> dict[int, str]:
+        """
+        Get labels dict.
+
+        Returns
+        -------
+        dict[int, str]
+            Tick labels.
+
+        """
         return self._tick_labels
 
 
@@ -348,10 +398,38 @@ class YAxisValues:
         return indexes
 
     def get_start_indexes(self, search_name) -> list[int]:
+        """
+        Get start indexes.
+
+        Parameters
+        ----------
+        search_name
+            The target name.
+
+        Returns
+        -------
+        list[int]
+            Start index of search results.
+
+        """
         indexes = self._search_values(search_name)
         return list((indexes) * -1)
 
     def get_end_values(self, search_name) -> list[int]:
+        """
+        Get end indexes.
+
+        Parameters
+        ----------
+        search_name
+            The target name.
+
+        Returns
+        -------
+        list[int]
+            End index of search results.
+
+        """
         indexes = self._search_values(search_name)
         return list((indexes + 1) * -0.5)
 
@@ -371,6 +449,27 @@ class FormatterFactory():
 
     @classmethod
     def create(self, path: Path, granularity: str) -> DataFrameFormatter:
+        """
+        Create formatter.
+
+        Parameters
+        ----------
+        path : Path
+            The target path.
+        granularity : str
+            Granularity of chain with two value; [raw/node].
+
+        Returns
+        -------
+        DataFrameFormatter
+            Raw level formatter.
+
+        Raises
+        ------
+        NotImplementedError
+            Argument metrics_name is not "raw" or "node".
+
+        """
         if granularity == 'raw':
             return RawLevelFormatter(path)
         elif granularity == 'node':
@@ -389,6 +488,17 @@ class RawLevelFormatter(DataFrameFormatter):
         return None
 
     def rename_columns(self, df: pd.DataFrame, path: Path) -> None:
+        """
+        Rename columns.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            The target pd data frame.
+        path : Path
+            The target path.
+
+        """
         renames = {}
         for column_name in df.columns:
             if '_timestamp' in column_name:
@@ -404,6 +514,15 @@ class NodeLevelFormatter(DataFrameFormatter):
         self._path = path
 
     def remove_columns(self, df: pd.DataFrame) -> None:
+        """
+        Remove columns.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            The target pd data frame.
+
+        """
         raw_level_formatter = RawLevelFormatter(self._path)
         raw_level_formatter.remove_columns(df)
 
@@ -430,6 +549,17 @@ class NodeLevelFormatter(DataFrameFormatter):
         df.drop(drop_columns, axis=1, inplace=True)
 
     def rename_columns(self, df: pd.DataFrame, path: Path) -> None:
+        """
+        Rename columns.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            The target pd data frame.
+        path : Path
+            The target path.
+
+        """
         renames = {}
         for column_name in df.columns:
             if '_timestamp' in column_name:
@@ -456,6 +586,15 @@ class Offset:
 
     @property
     def value(self) -> int:
+        """
+        Get offset value.
+
+        Returns
+        -------
+        int
+            Offset value.
+
+        """
         return self._offset
 
 

--- a/src/caret_analyze/plot/visualize_lib/bokeh/stacked_bar.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/stacked_bar.py
@@ -39,6 +39,15 @@ class BokehStackedBar:
         self._case = case
 
     def create_figure(self) -> Figure:
+        """
+        Create Bokeh stacked bar figure.
+
+        Returns
+        -------
+        bokeh.plotting.Figure
+            Figure of Bokeh stacked bar.
+
+        """
         # NOTE: relation between stacked bar graph and data struct
         # # data = {
         # #     a : [a1, a2, a3],
@@ -219,12 +228,30 @@ class StackedBarSource:
         return new_values
 
     def add_label_data_to_stacked_bar(self, stacked_bar: list[GraphRenderer]):
+        """
+        Add 'label' data to each bar due to display hover.
+
+        Parameters
+        ----------
+        stacked_bar : list[GraphRenderer]
+            Stacked bar lists.
+
+        """
         # add 'label' data to each bar due to display hover
         x_len = min([len(v) for v in self._data.values()])
         for bar in stacked_bar:
             bar.data_source.add([bar.name] * x_len, 'label')
 
     def add_latency_data_to_stacked_bar(self, stacked_bar: list[GraphRenderer]):
+        """
+        Add 'latency' data to each bar due to display hover.
+
+        Parameters
+        ----------
+        stacked_bar : list[GraphRenderer]
+            Stacked bar lists.
+
+        """
         # add 'latency' data to each bar due to display hover
         for bar in stacked_bar:
             bar.data_source.add(['latency = ' + str(latency)
@@ -233,6 +260,15 @@ class StackedBarSource:
     def to_source(
         self,
     ) -> dict[str, list[int | float]]:
+        """
+        Get stacked bar source.
+
+        Returns
+        -------
+        dict[str, list[int | float]]
+            Stacked bar source.
+
+        """
         # NOTE: Using `ColumnDataSource`, it is not possible
         # NOTE: to display a different hover for each stack (cause unknown).
         # convert timestamp to latency

--- a/src/caret_analyze/plot/visualize_lib/bokeh/timeseries.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/timeseries.py
@@ -50,6 +50,20 @@ class BokehTimeSeries:
         self._case = case
 
     def create_figure(self) -> Figure:
+        """
+        Create figure.
+
+        Returns
+        -------
+        bokeh.plotting.Figure
+            Figure of bokeh time series.
+
+        Raises
+        ------
+        NotImplementedError
+            Argument y_axis_label is not "frequency", "period", "latency", or "response_time".
+
+        """
         target_objects = self._metrics.target_objects
         timeseries_records_list = self._metrics.to_timeseries_records_list(self._xaxis_type)
 
@@ -143,6 +157,7 @@ class LineSource:
         Returns
         -------
         HoverTool
+            Created hover.
 
         """
         return self._hover_keys.create_hover(options)

--- a/src/caret_analyze/plot/visualize_lib/bokeh/util/color_selector.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/util/color_selector.py
@@ -29,6 +29,25 @@ class ColorSelectorFactory:
 
     @staticmethod
     def create_instance(coloring_rule: str) -> ColorSelectorInterface:
+        """
+        Create ColorSelector instance.
+
+        Parameters
+        ----------
+        coloring_rule : str
+            Coloring rule.
+
+        Returns
+        -------
+        ColorSelectorInterface
+            Created ColorSelector instance.
+
+        Raises
+        ------
+        InvalidArgumentError
+            Argument coloring_rule is not "unique", "callback", "callback_group", or "node".
+
+        """
         if coloring_rule == 'unique':
             return ColorSelectorUnique()
 
@@ -83,6 +102,7 @@ class ColorSelectorInterface:
         Returns
         -------
         Color
+            color interface
 
         """
         color_hash = self._get_color_hash(node_name, cbg_name, callback_name)

--- a/src/caret_analyze/plot/visualize_lib/bokeh/util/hover.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/util/hover.py
@@ -131,6 +131,11 @@ class HoverKeysBase(metaclass=ABCMeta):
         list[str]
             all hover keys
 
+        Raises
+        ------
+        NotImplementedError
+            This module is not implemented.
+
         """
         raise NotImplementedError()
 
@@ -146,6 +151,7 @@ class HoverKeysBase(metaclass=ABCMeta):
         Returns
         -------
         HoverTool
+            Created HoverTool
 
         """
         tips_str = '<div style="width:400px; word-wrap: break-word;">'
@@ -178,6 +184,15 @@ class CallbackSchedBarKeys(HoverKeysBase):
             )
 
     def to_list(self) -> list[str]:
+        """
+        Get CallbackSchedBarKeys.
+
+        Returns
+        -------
+        list[str]
+            Key lists
+
+        """
         return ['legend_label', 'node_name', 'callback_name',
                 'callback_type', 'callback_param', 'symbol']
 
@@ -194,6 +209,15 @@ class CallbackSchedRectKeys(HoverKeysBase):
             )
 
     def to_list(self) -> list[str]:
+        """
+        Get CallbackSchedRectKeys.
+
+        Returns
+        -------
+        list[str]
+            Key lists
+
+        """
         return ['legend_label', 'callback_start', 'callback_end', 'latency']
 
 
@@ -214,6 +238,15 @@ class TimeSeriesKeys(HoverKeysBase):
             )
 
     def to_list(self) -> list[str]:
+        """
+        Get TimeSeriesKeys.
+
+        Returns
+        -------
+        list[str]
+            Key lists
+
+        """
         hover_keys: list[str]
         if isinstance(self._target_object, CallbackBase):
             hover_keys = ['legend_label', 'node_name', 'callback_name', 'callback_type',
@@ -239,6 +272,15 @@ class MessageFlowLineKeys(HoverKeysBase):
             raise InvalidArgumentError("'target_object' must be Path in message flow.")
 
     def to_list(self) -> list[str]:
+        """
+        Get MessageFlowLineKeys.
+
+        Returns
+        -------
+        list[str]
+            Key lists
+
+        """
         return ['t_start', 't_end', 'latency', 't_offset', 'index']
 
 
@@ -252,6 +294,15 @@ class MessageFlowRectKeys(HoverKeysBase):
             raise InvalidArgumentError("'target_object' must be Path in message flow.")
 
     def to_list(self) -> list[str]:
+        """
+        Get MessageFlowRectKeys.
+
+        Returns
+        -------
+        list[str]
+            Key lists
+
+        """
         return ['t_start', 't_end', 'latency', 't_offset',
                 'callback_type', 'callback_param', 'symbol']
 
@@ -266,6 +317,15 @@ class StackedBarKeys(HoverKeysBase):
             raise InvalidArgumentError("'target_object' must be Path in stacked bar graph.")
 
     def to_list(self) -> list[str]:
+        """
+        Get StackedBarKeys.
+
+        Returns
+        -------
+        list[str]
+            Key lists
+
+        """
         return ['label', 'latency']
 
 

--- a/src/caret_analyze/plot/visualize_lib/bokeh/util/util.py
+++ b/src/caret_analyze/plot/visualize_lib/bokeh/util/util.py
@@ -60,6 +60,31 @@ def init_figure(
     y_axis_label: str | None = None,
     x_axis_label: str | None = None,
 ) -> Figure:
+    """
+    Initialize figure.
+
+    Parameters
+    ----------
+    title : str
+        The target title.
+    ywheel_zoom : bool, optional
+        If True, the drawn graph can be expanded in the y-axis direction
+        by the mouse wheel.
+    xaxis_type : str, optional
+        Type of x-axis of the line graph to be plotted.
+        "system_time", "index", or "sim_time" can be specified.
+        The default is "system_time".
+    y_axis_label : str | None
+        Label of y-axis of the line graph to be plotted.
+    x_axis_label : str | None
+        Label of x-axis of the line graph to be plotted.
+
+    Returns
+    -------
+    bokeh.plotting.Figure
+        Figure of rect values.
+
+    """
     if x_axis_label is None:
         if xaxis_type == 'system_time':
             x_axis_label = 'system time [s]'
@@ -135,6 +160,20 @@ def apply_x_axis_offset(
 
 
 def get_callback_param_desc(callback: CallbackBase):
+    """
+    Get callback parameter desc.
+
+    Parameters
+    ----------
+    callback : CallbackBase
+        Callback base.
+
+    Raises
+    ------
+    UnsupportedTypeError
+        Unsupported type CallbackBase.
+
+    """
     if isinstance(callback, TimerCallback):
         return f'period_ns = {callback.period_ns}'
 

--- a/src/caret_analyze/plot/visualize_lib/visualize_lib_factory.py
+++ b/src/caret_analyze/plot/visualize_lib/visualize_lib_factory.py
@@ -33,9 +33,12 @@ class VisualizeLibFactory:
         Returns
         -------
         VisualizeLibInterface
+            Created instance of VisualizeLibInterface.
 
         Raises
         ------
+        NotImplementedError
+            Specified use_package is not implemented.
         UnsupportedTypeError
             Argument use_package is not "bokeh" or "graphviz".
 

--- a/src/caret_analyze/plot/visualize_lib/visualize_lib_interface.py
+++ b/src/caret_analyze/plot/visualize_lib/visualize_lib_interface.py
@@ -42,6 +42,38 @@ class VisualizeLibInterface(metaclass=ABCMeta):
         lstrip_s: float,
         rstrip_s: float
     ) -> Figure:
+        """
+        Get message flow.
+
+        Parameters
+        ----------
+        target_path : Path
+            Target path.
+        xaxis_type : str
+            Type of x-axis of the line graph to be plotted.
+        ywheel_zoom : bool
+            If True, the drawn graph can be expanded in the y-axis direction
+            by the mouse wheel.
+        granularity : str
+            Granularity.
+        treat_drop_as_delay : bool
+            Treat drop as delay.
+        lstrip_s : float, optional
+            Start time of cropping range.
+        rstrip_s: float, optional
+            End point of cropping range.
+
+        Returns
+        -------
+        Figure
+            Figure of message flow.
+
+        Raises
+        ------
+        NotImplementedError
+            This module is not implemented.
+
+        """
         raise NotImplementedError()
 
     @abstractmethod
@@ -55,6 +87,42 @@ class VisualizeLibInterface(metaclass=ABCMeta):
         lstrip_s: float,
         rstrip_s: float
     ) -> Figure:
+        """
+        Get callback scheduling figure.
+
+        Parameters
+        ----------
+        callback_groups : Sequence[CallbackGroup]
+            The target callback groups.
+        xaxis_type : str, optional
+            Type of x-axis of the line graph to be plotted.
+            "system_time", "index", or "sim_time" can be specified.
+            The default is "system_time".
+        ywheel_zoom : bool, optional
+            If True, the drawn graph can be expanded in the y-axis direction
+            by the mouse wheel.
+        full_legends : bool, optional
+            If True, all legends are drawn
+            even if the number of legends exceeds the threshold.
+        coloring_rule : str, optional
+            The unit of color change
+            There are there rules which are [callback/callback_group/node], by default 'callback'
+        lstrip_s : float, optional
+            Start time of cropping range.
+        rstrip_s: float, optional
+            End point of cropping range.
+
+        Returns
+        -------
+        Figure
+            Figure of callback scheduling.
+
+        Raises
+        ------
+        NotImplementedError
+            This module is not implemented.
+
+        """
         raise NotImplementedError()
 
     @abstractmethod
@@ -66,6 +134,38 @@ class VisualizeLibInterface(metaclass=ABCMeta):
         full_legends: bool,
         case: str
     ) -> Figure:
+        """
+        Get a timeseries figure.
+
+        Parameters
+        ----------
+        metrics : MetricsBase
+            Metrics to be y-axis in visualization.
+        xaxis_type : str
+            Type of x-axis of the line graph to be plotted.
+            "system_time", "index", or "sim_time" can be specified.
+            The default is "system_time".
+        ywheel_zoom : bool
+            If True, the drawn graph can be expanded in the y-axis direction
+            by the mouse wheel.
+        full_legends : bool
+            If True, all legends are drawn
+            even if the number of legends exceeds the threshold.
+        case : str
+            Parameter specifying all, best, worst, or worst-with-external-latency.
+            Use to create Response time timeseries graph.
+
+        Returns
+        -------
+        Figure
+            Figure of timeseries.
+
+        Raises
+        ------
+        NotImplementedError
+            This module is not implemented.
+
+        """
         raise NotImplementedError()
 
     @abstractmethod
@@ -77,6 +177,36 @@ class VisualizeLibInterface(metaclass=ABCMeta):
         full_legends: bool,
         case: str,
     ) -> Figure:
+        """
+        Get stacked bar.
+
+        Parameters
+        ----------
+        metrics : MetricsBase
+            Metrics.
+        xaxis_type : str
+            Type of x-axis of the line graph to be plotted.
+        ywheel_zoom : bool
+            If True, the drawn graph can be expanded in the y-axis direction
+            by the mouse wheel.
+        full_legends : bool
+            If True, all legends are drawn
+            even if the number of legends exceeds the threshold, by default False.
+        case : str
+            Parameter specifying all, best, worst, or worst-with-external-latency.
+            Use to create Response time timeseries graph.
+
+        Returns
+        -------
+        Figure
+            Figure of stacked bar.
+
+        Raises
+        ------
+        NotImplementedError
+            This module is not implemented.
+
+        """
         raise NotImplementedError()
 
     def histogram(
@@ -87,4 +217,33 @@ class VisualizeLibInterface(metaclass=ABCMeta):
         metrics_name: str,
         case: str | None = None
     ) -> Figure:
+        """
+        Get a histogram figure.
+
+        Parameters
+        ----------
+        hist_list : list[list[int]]
+            Data array of histogram to be visualized.
+        bins : list[float]
+            Data array of bins of histogram.
+        target_objects : list[CallbackBase | Communication | Path]
+            Object array to be visualized.
+        metrics_name : str
+            Name of metrics.
+            "frequency", "latency", "period" or "response_time" can be specified.
+        case : str
+            Parameter specifying all, best, worst, or worst-with-external-latency.
+            Use to create Response time histogram graph.
+
+        Returns
+        -------
+        Figure
+            Figure of histogram.
+
+        Raises
+        ------
+        NotImplementedError
+            This module is not implemented.
+
+        """
         raise NotImplementedError()

--- a/src/caret_analyze/record/records_service/frequency.py
+++ b/src/caret_analyze/record/records_service/frequency.py
@@ -140,6 +140,7 @@ class Frequency:
             timestamp_array = np.round(convert_vector(timestamp_array)).astype(np.int64)
 
         timestamp_array = timestamp_array[timestamp_array >= base_timestamp]
+        timestamp_array = timestamp_array[timestamp_array <= until_timestamp]
         if len(timestamp_array) == 0:
             return [base_timestamp], [0]
 

--- a/src/caret_analyze/record/records_service/stacked_bar.py
+++ b/src/caret_analyze/record/records_service/stacked_bar.py
@@ -131,14 +131,13 @@ class StackedBar:
             elif 'rclcpp_publish' in column:
                 topic_name = column.split('/')[:-2]
                 rename_map[column] = '/'.join(topic_name)
+            elif 'rmw_take' in column:
+                node_name = column.split('/')[:-2]
+                rename_map[column] = '/'.join(node_name)
             elif 'callback_start' in column:
                 node_name = column.split('/')[:-2]
                 rename_map[column] = '/'.join(node_name)
             elif 'callback_end' in column:
-                node_name = column.split('/')[:-2]
-                rename_map[column] = '/'.join(node_name)
-                rename_map[column] += '_end'
-            elif 'rmw_take' in column:
                 node_name = column.split('/')[:-2]
                 rename_map[column] = '/'.join(node_name)
                 rename_map[column] += '_end'

--- a/src/caret_analyze/record/records_service/stacked_bar.py
+++ b/src/caret_analyze/record/records_service/stacked_bar.py
@@ -138,6 +138,10 @@ class StackedBar:
                 node_name = column.split('/')[:-2]
                 rename_map[column] = '/'.join(node_name)
                 rename_map[column] += '_end'
+            elif 'rmw_take' in column:
+                node_name = column.split('/')[:-2]
+                rename_map[column] = '/'.join(node_name)
+                rename_map[column] += '_end'
 
         return rename_map
 

--- a/src/caret_analyze/runtime/application.py
+++ b/src/caret_analyze/runtime/application.py
@@ -196,8 +196,6 @@ class Application(Summarizable):
             Occurs when the given argument type is invalid.
         ItemNotFoundError
             Occurs when no items were found.
-        MultipleItemFoundError
-            Occurs when several items were found.
 
         """
         if not isinstance(path_name, str):
@@ -233,7 +231,7 @@ class Application(Summarizable):
         InvalidArgumentError
             Given argument type is invalid.
         ItemNotFoundError
-            Failed to find an item that matches the condition.
+            Occurs when no items were found.
 
         """
         if not isinstance(executor_name, str):
@@ -280,7 +278,7 @@ class Application(Summarizable):
 
         Returns
         -------
-        CallbackBase
+        CallbackGroup
             callback group that matches the condition.
 
         Raises
@@ -288,9 +286,7 @@ class Application(Summarizable):
         InvalidArgumentError
             Given argument type is invalid.
         ItemNotFoundError
-            Failed to find an item that matches the condition.
-        MultipleItemFoundError
-            Failed to identify an item that matches the condition.
+            Occurs when no items were found.
 
         """
         if not isinstance(callback_group_name, str):
@@ -338,9 +334,7 @@ class Application(Summarizable):
         InvalidArgumentError
             Given argument type is invalid.
         ItemNotFoundError
-            Failed to find an item that matches the condition.
-        MultipleItemFoundError
-            Failed to identify an item that matches the condition.
+            Occurs when no items were found.
 
         """
         if not isinstance(publisher_node_name, str) or \
@@ -518,7 +512,7 @@ class Application(Summarizable):
         InvalidArgumentError
             Occurs when the given argument type is invalid.
         ItemNotFoundError
-            Failed to find an item that matches the condition.
+            Occurs when no items were found.
 
         """
         if not isinstance(topic_name, str):
@@ -556,8 +550,6 @@ class Application(Summarizable):
         ------
         InvalidArgumentError
             Occurs when the given argument type is invalid.
-        ItemNotFoundError
-            Failed to find an item that matches the condition.
 
         """
         if not isinstance(topic_name, str):
@@ -582,15 +574,13 @@ class Application(Summarizable):
 
         Returns
         -------
-        list[Publisher]
+        list[Subscription]
             subscriptions that match the condition.
 
         Raises
         ------
         InvalidArgumentError
             Occurs when the given argument type is invalid.
-        ItemNotFoundError
-            Failed to find an item that matches the condition.
 
         """
         if not isinstance(topic_name, str):
@@ -622,6 +612,8 @@ class Application(Summarizable):
         ------
         InvalidArgumentError
             Occurs when the given argument type is invalid.
+        ItemNotFoundError
+            Occurs when no items were found.
 
         """
         if not isinstance(node_name, str):
@@ -641,7 +633,7 @@ class Application(Summarizable):
     @property
     def node_paths(self) -> list[NodePathStructValue]:
         """
-        Get paths.
+        Get node paths.
 
         Returns
         -------
@@ -671,8 +663,6 @@ class Application(Summarizable):
             Occurs when the given argument type is invalid.
         ItemNotFoundError
             Occurs when no items were found.
-        MultipleItemFoundError
-            Occurs when several items were found.
 
         """
         if not isinstance(node_name, str):
@@ -705,8 +695,6 @@ class Application(Summarizable):
             Occurs when the given argument type is invalid.
         ItemNotFoundError
             Occurs when no items were found.
-        MultipleItemFoundError
-            Occurs when several items were found.
 
         """
         if not isinstance(callback_name, str):
@@ -732,15 +720,6 @@ class Application(Summarizable):
         -------
         list[CallbackBase]
             callbacks that match the condition.
-
-        Raises
-        ------
-        InvalidArgumentError
-            Occurs when the given argument type is invalid.
-        ItemNotFoundError
-            Occurs when no items were found.
-        MultipleItemFoundError
-            Occurs when several items were found.
 
         """
         def is_match_regex(callback: CallbackBase):
@@ -781,7 +760,7 @@ class Application(Summarizable):
         Returns
         -------
         Summary
-            Summary info.
+            Summary about value objects and runtime data objects.
 
         """
         return Summary({

--- a/src/caret_analyze/runtime/callback_group.py
+++ b/src/caret_analyze/runtime/callback_group.py
@@ -160,6 +160,8 @@ class CallbackGroup(Summarizable):
             Occurs when the given argument type is invalid.
         ItemNotFoundError
             Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
 
         """
         if not isinstance(callback_name, str):

--- a/src/caret_analyze/runtime/communication.py
+++ b/src/caret_analyze/runtime/communication.py
@@ -237,6 +237,15 @@ class Communication(PathBase, Summarizable):
 
     @property
     def column_names(self) -> list[str]:
+        """
+        Get column names.
+
+        Returns
+        -------
+        list[str]
+            Column names of this communication.
+
+        """
         records = self.to_records()
         return records.columns
 

--- a/src/caret_analyze/runtime/communication.py
+++ b/src/caret_analyze/runtime/communication.py
@@ -294,13 +294,12 @@ class Communication(PathBase, Summarizable):
         """
         assert self._records_provider is not None
         records = self._records_provider.communication_records(self._val)
-        # if self.use_take_manually and records:
-        #     records.drop_columns([records.columns[-1]])
 
         return records
 
-    @property
     def use_take_manually(self) -> bool:
+        # TODO: Refactor whether the communication uses 'take' should be determinable
+        # from the Subscription alone, rather than from Communication.
         callback_groups = self.subscribe_node.callback_groups
         if callback_groups is None:
             return False

--- a/src/caret_analyze/runtime/communication.py
+++ b/src/caret_analyze/runtime/communication.py
@@ -297,6 +297,22 @@ class Communication(PathBase, Summarizable):
 
         return records
 
+
+    def to_take_records(self) -> RecordsInterface:
+        """
+        Calculate records.
+
+        Returns
+        -------
+        RecordsInterface
+            communication latency (publish-subscribe).
+
+        """
+        assert self._records_provider is not None
+        records = self._records_provider._compose_inter_proc_take_comm_records(self._val)
+
+        return records
+
     def use_take_manually(self) -> bool:
         # TODO: Refactor whether the communication uses 'take' should be determinable
         # from the Subscription alone, rather than from Communication.

--- a/src/caret_analyze/runtime/node.py
+++ b/src/caret_analyze/runtime/node.py
@@ -394,13 +394,6 @@ class Node(Summarizable):
         list[CallbackBase]
             callbacks that match the condition.
 
-        Raises
-        ------
-        InvalidArgumentError
-            Occurs when the given argument type is invalid.
-        ItemNotFoundError
-            Occurs when no items were found.
-
         """
         callbacks = []
         for callback_name in callback_names:

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -245,6 +245,7 @@ class RecordsMerged:
 
             # adjust the columns for the case that the message is not taken by callback
             if is_match_column(right_records.columns[0], 'source_timestamp'):
+            # if isinstance(target_, Communication) and target_.use_take_manually:
                 left_records.drop_columns([left_records.columns[-1]])
 
             if left_records.columns[-1] != right_records.columns[0]:

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -244,9 +244,8 @@ class RecordsMerged:
             right_records.rename_columns(rename_rule)
 
             # adjust the columns for the case that the message is not taken by callback
-            if is_match_column(right_records.columns[0], 'source_timestamp'):
-            # if isinstance(target_, Communication) and target_.use_take_manually:
-                left_records.drop_columns([left_records.columns[-1]])
+            if isinstance(target, Communication) and target.use_take_manually():
+                right_records.drop_columns([right_records.columns[-1]])
 
             if left_records.columns[-1] != right_records.columns[0]:
                 raise InvalidRecordsError('left columns[-1] != right columns[0]')

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -222,12 +222,12 @@ class RecordsMerged:
                     raise InvalidRecordsError(msg)
             first_element = targets[0].to_records()
 
-        left_records: RecordsInterface = first_element 
+        left_records: RecordsInterface = first_element
 
         rename_rule = column_merger.append_columns_and_return_rename_rule(left_records)
         left_records.rename_columns(rename_rule)
         # Handle case where first_element might have no columns
-        first_column = left_records.columns[0] if left_records.columns else None 
+        first_column = left_records.columns[0] if left_records.columns else None
 
         last_communication_record = None
         for item in reversed(targets):
@@ -236,7 +236,7 @@ class RecordsMerged:
                 break
 
         take_records_applied_for_last_communication: bool = False
-        
+
         for target_, target in zip(targets[:-1], targets[1:]):
             right_records: RecordsInterface = target.to_records()
 
@@ -266,7 +266,7 @@ class RecordsMerged:
             if should_drop_last_column:
                 if len(right_records.columns) > 0:
                     columns_to_remove = [right_records.columns[-1]]
-                    # For take records in the middle of a path, 
+                    # For take records in the middle of a path,
                     # delete both callback_start_timestamp and rmw_take_timestamp
                     # and make source_timestamp the final column
                     if len(right_records.columns) >= 2 and "rmw_take_timestamp" in right_records.columns[-2]:
@@ -278,7 +278,7 @@ class RecordsMerged:
 
             if left_records.columns[-1] != right_records.columns[0]:
                 raise InvalidRecordsError(f'{left_records.columns[-1]=} != {right_records.columns[0]=}')
-            
+
             left_stamp_key = left_records.columns[-1]
             right_stamp_key = right_records.columns[0]
 
@@ -346,7 +346,7 @@ class RecordsMerged:
                 msg = 'Since the path cannot be extended, '
                 msg += 'the merge process for the last callback record is skipped.'
                 logger.info(msg)
-        
+
         logger.info('Finished merging path records.')
         left_records.sort(first_column)
 
@@ -379,7 +379,7 @@ class RecordsMerged:
             column_to_rename = None
             new_column_name = None
             for col_name in reversed(left_records.columns):
-                # ex. 
+                # ex.
                 # "/planning/scenario_planning/velocity_smoother/trajectory/rmw_take_timestamp/0"
                 # match.group(1): "/0" (suffix)
                 match = re.match(r'(?:.*)/rmw_take_timestamp(?:/(\d+))?', col_name)

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -230,7 +230,6 @@ class RecordsMerged:
         first_column = left_records.columns[0] if left_records.columns else None 
 
         last_communication_in_full_list = None
-        replace_communication_to_rmw_take_list = None
         for item in reversed(targets):
             if isinstance(item, Communication):
                 last_communication_in_full_list = item
@@ -365,7 +364,7 @@ class RecordsMerged:
 
         # remove rmw_take columns except for the last one
         rmw_cols = [col for col in left_records.columns if ('rmw_take' in col) ]
-        is_last_take = targets[-2].use_take_manually()
+        is_last_take = isinstance(targets[-2], Communication) and targets[-2].use_take_manually()
         if is_last_take:
             drop_rmw_cols = rmw_cols[:-1]
         else:

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -43,6 +43,22 @@ class ColumnMerger():
         records: RecordsInterface,
         column_name: str
     ) -> str:
+        """
+        Append column.
+
+        Parameters
+        ----------
+        records : RecordsInterface
+            Records interface.
+        column_name : str
+            Column name.
+
+        Returns
+        -------
+        str
+            Append column name.
+
+        """
         key = column_name
 
         if key == records.columns[0] and len(self._count) > 0 and key in self._count.keys():
@@ -61,6 +77,20 @@ class ColumnMerger():
         self,
         records: RecordsInterface,
     ) -> list[str]:
+        """
+        Append columns.
+
+        Parameters
+        ----------
+        records : RecordsInterface
+            Records interface.
+
+        Returns
+        -------
+        list[str]
+            Renamed columns.
+
+        """
         renamed_columns: list[str] = []
         for column in records.columns:
             renamed_columns.append(
@@ -72,6 +102,20 @@ class ColumnMerger():
         self,
         records: RecordsInterface,
     ) -> dict[str, str]:
+        """
+        Append columns and return rename rule.
+
+        Parameters
+        ----------
+        records : RecordsInterface
+            Records interface.
+
+        Returns
+        -------
+        dict[str, str]
+            Renamed rule.
+
+        """
         renamed_columns: list[str] = self.append_columns(records)
         return self._to_rename_rule(records.columns, renamed_columns)
 
@@ -79,6 +123,15 @@ class ColumnMerger():
     def column_names(
         self
     ) -> list[str]:
+        """
+        Get column names.
+
+        Returns
+        -------
+        list[str]
+            Column names.
+
+        """
         return self._column_names
 
     @staticmethod
@@ -104,6 +157,24 @@ class RecordsMerged:
         include_first_callback: bool = False,
         include_last_callback: bool = False
     ) -> None:
+        """
+        Construct an instance.
+
+        Parameters
+        ----------
+        merge_targets : list[NodePath | Communication]
+            Merge targets.
+        include_first_callback : bool
+            Flags for including the processing time of the first callback in the path analysis.
+        include_last_callback : bool
+            Flags for including the processing time of the last callback in the path analysis.
+
+        Raises
+        ------
+        InvalidArgumentError
+            There are no records to be merged.
+
+        """
         if len(merge_targets) == 0:
             raise InvalidArgumentError('There are no records to be merged.')
         self._data = self._merge_records(
@@ -113,6 +184,15 @@ class RecordsMerged:
 
     @property
     def data(self) -> RecordsInterface:
+        """
+        Get data.
+
+        Returns
+        -------
+        RecordsInterface
+            Records data.
+
+        """
         return self._data
 
     @staticmethod
@@ -304,6 +384,15 @@ class Path(PathBase, Summarizable):
 
     @property
     def include_first_callback(self) -> bool:
+        """
+        Get include first callback.
+
+        Returns
+        -------
+        bool
+            Flags for including the processing time of the first callback in the path analysis.
+
+        """
         return self._include_first_callback
 
     @include_first_callback.setter
@@ -312,6 +401,15 @@ class Path(PathBase, Summarizable):
 
     @property
     def include_last_callback(self) -> bool:
+        """
+        Get include last callback.
+
+        Returns
+        -------
+        bool
+            Flags for including the processing time of the last callback in the path analysis.
+
+        """
         return self._include_last_callback
 
     @include_last_callback.setter
@@ -319,6 +417,15 @@ class Path(PathBase, Summarizable):
         self._include_last_callback = include_last_callback
 
     def to_records(self) -> RecordsInterface:
+        """
+        Calculate records.
+
+        Returns
+        -------
+        RecordsInterface
+            Execution time of each operation.
+
+        """
         if (self._include_first_callback, self._include_last_callback) \
                 not in self.__records_cache.keys():
             try:
@@ -374,6 +481,24 @@ class Path(PathBase, Summarizable):
         return is_valid
 
     def get_child(self, name: str):
+        """
+        Get child.
+
+        Parameters
+        ----------
+        name : str
+            Topic name or node name.
+
+        Raises
+        ------
+        InvalidArgumentError
+            Occurs when the given argument type is invalid.
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         # TODO(hsgwa): This function is not needed. Remove.
 
         if not isinstance(name, str):

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -267,7 +267,7 @@ class RecordsMerged:
                 if len(right_records.columns) > 0:
                     columns_to_remove = [right_records.columns[-1]]
                     # For take records in the middle of a path, 
-                    # delete both callback_start_taimestamp and rmw_take_timestamp
+                    # delete both callback_start_timestamp and rmw_take_timestamp
                     # and make source_timestamp the final column
                     if len(right_records.columns) >= 2 and "rmw_take_timestamp" in right_records.columns[-2]:
                         columns_to_remove.append(right_records.columns[-2])

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -371,7 +371,7 @@ class RecordsMerged:
             for col_name in reversed(last_communication_record.column_names):
                 # ex. "/planning/planning_validator/callback_6/callback_start_timestamp"
                 # match.group(1): "/planning/planning_validator" (node name)
-                match = re.match(r'(.*)(?:/callback_\d+)?/callback_start_timestamp(?:/\d+)?', col_name)
+                match = re.match(r'(.+?)(?:/callback_\d+)?/callback_start_timestamp(?:/\d+)?', col_name)
                 if match:
                     extracted_node_name = match.group(1)
                     break

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -294,7 +294,6 @@ class RecordsMerged:
                             isinstance(target_.message_context, CallbackChain)
 
             if is_sequential:
-                print("!!! 1-9")
                 left_records = merge_sequential(
                     left_records=left_records,
                     right_records=right_records,

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -373,7 +373,6 @@ class RecordsMerged:
                 # match.group(1): "/planning/planning_validator" (node name)
                 match = re.match(r'(.*)/callback_\d+/callback_start_timestamp(?:/\d+)?', col_name)
                 if match:
-                    print(f"### match: {match.group(0)=} {match.group(1)=}")
                     extracted_node_name = match.group(1)
                     break
 

--- a/src/caret_analyze/runtime/path_base.py
+++ b/src/caret_analyze/runtime/path_base.py
@@ -183,6 +183,11 @@ class PathBase(metaclass=ABCMeta):
             time[ns], latency[ns]
             len(time) == len(latency)
 
+        Raises
+        ------
+        InvalidRecordsError
+            Failed to find any records.
+
         """
         df = self.to_dataframe(
             remove_dropped, treat_drop_as_delay, lstrip_s, rstrip_s, shaper=shaper)

--- a/src/caret_analyze/runtime/runtime_loaded.py
+++ b/src/caret_analyze/runtime/runtime_loaded.py
@@ -51,6 +51,17 @@ class RuntimeLoaded():
         architecture: Architecture,
         provider: RecordsProvider | RuntimeDataProvider
     ) -> None:
+        """
+        Construct an instance.
+
+        Parameters
+        ----------
+        architecture : Architecture
+            Architecture.
+        provider : RecordsProvider | RuntimeDataProvider
+            Provider.
+
+        """
         nodes_loaded = NodesLoaded(architecture.nodes, provider)
         self._nodes = nodes_loaded.data
 
@@ -68,18 +79,54 @@ class RuntimeLoaded():
 
     @property
     def nodes(self) -> list[Node]:
+        """
+        Get nodes.
+
+        Returns
+        -------
+        list[str]
+            Node list.
+
+        """
         return self._nodes
 
     @property
     def executors(self) -> list[Executor]:
+        """
+        Get executors.
+
+        Returns
+        -------
+        list[Executor]
+            Executor list.
+
+        """
         return self._executors
 
     @property
     def communications(self) -> list[Communication]:
+        """
+        Get communications.
+
+        Returns
+        -------
+        list[Communication]
+            Communication list.
+
+        """
         return self._comms
 
     @property
     def paths(self) -> list[Path]:
+        """
+        Get paths.
+
+        Returns
+        -------
+        list[Path]
+            Path list.
+
+        """
         return self._paths
 
 
@@ -89,6 +136,17 @@ class ExecutorsLoaded:
         executors_values: tuple[ExecutorStructValue, ...],
         nodes_loaded: NodesLoaded
     ) -> None:
+        """
+        Construct an instance.
+
+        Parameters
+        ----------
+        executors_values : tuple[ExecutorStructValue, ...]
+            Executors values.
+        nodes_loaded : NodesLoaded
+            Nodes loaded.
+
+        """
         self._data = []
         for exec_val in executors_values:
             try:
@@ -114,6 +172,15 @@ class ExecutorsLoaded:
 
     @property
     def data(self) -> list[Executor]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[Executor]:
+            Executor list.
+
+        """
         return self._data
 
 
@@ -123,6 +190,17 @@ class NodesLoaded:
         node_values: tuple[NodeStructValue, ...],
         provider: RecordsProvider | RuntimeDataProvider
     ) -> None:
+        """
+        Construct an instance.
+
+        Parameters
+        ----------
+        node_values : tuple[NodeStructValue, ...]
+            Node values.
+        provider : RecordsProvider | RuntimeDataProvider
+            Provider.
+
+        """
         self._nodes: list[Node] = []
         for node_value in node_values:
             try:
@@ -181,6 +259,15 @@ class NodesLoaded:
 
     @property
     def callback_groups(self) -> list[CallbackGroup]:
+        """
+        Get callback groups.
+
+        Returns
+        -------
+        list[CallbackGroup]
+            Callback groups list.
+
+        """
         callback_groups: list[CallbackGroup] = []
         for node in self._nodes:
             if node.callback_groups is not None:
@@ -189,10 +276,28 @@ class NodesLoaded:
 
     @property
     def data(self) -> list[Node]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[Node]
+            Node list.
+
+        """
         return self._nodes
 
     @property
     def callbacks(self) -> list[CallbackBase] | None:
+        """
+        Get callbacks.
+
+        Returns
+        -------
+        list[CallbackBase] | None:
+            Callbacks list.
+
+        """
         cbs = []
         for node in self._nodes:
             if node.callbacks is not None:
@@ -203,6 +308,27 @@ class NodesLoaded:
         self,
         callback_group_name: str
     ) -> CallbackGroup:
+        """
+        Find callback group.
+
+        Parameters
+        ----------
+        callback_group_name : str
+            Callback group name to be searched.
+
+        Returns
+        -------
+        CallbackGroup
+            Callback group in search results.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         try:
             callback_groups = self.callback_groups
             if callback_groups is None:
@@ -220,6 +346,27 @@ class NodesLoaded:
         self,
         callback_name: str
     ) -> CallbackBase:
+        """
+        Find callback.
+
+        Parameters
+        ----------
+        callback_name : str
+            Callback name to be searched.
+
+        Returns
+        -------
+        CallbackBase
+            Callback base in search results.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         try:
             cbs = self.callbacks
             if cbs is None:
@@ -237,6 +384,27 @@ class NodesLoaded:
         self,
         node_name: str
     ) -> Node:
+        """
+        Find node.
+
+        Parameters
+        ----------
+        node_name : str
+            Node name to be searched.
+
+        Returns
+        -------
+        Node
+            Node in search results.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         try:
             return Util.find_one(
                 lambda x: x.node_name == node_name,
@@ -254,6 +422,35 @@ class NodesLoaded:
         publisher_construction_order: int | None,
         subscription_construction_order: int | None,
     ) -> NodePath:
+        """
+        Find node path.
+
+        Parameters
+        ----------
+        node_name : str
+            Node name.
+        subscribe_topic_name : str | None
+            Subscribe topic name.
+        publish_topic_name : str | None
+            Publish topic name.
+        publisher_construction_order : int | None
+            Publisher construction order.
+        subscription_construction_order : int | None
+            Subscription construction order.
+
+        Returns
+        -------
+        NodePath
+            Node path in search results.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         try:
             is_target = NodesLoaded.IsTarget(
                 node_name, publish_topic_name, subscribe_topic_name,
@@ -278,6 +475,23 @@ class NodesLoaded:
             publisher_construction_order: int | None = None,
             subscription_construction_order: int | None = None
         ) -> None:
+            """
+            Construct an instance.
+
+            Parameters
+            ----------
+            node_name : str | None
+                Node name used to determine object match.
+            publish_topic_name : str | None
+                Publish topic name used to determine object match.
+            subscribe_topic_name : str | None
+                Subscribe topic name used to determine object match.
+            publisher_construction_order : int | None
+                Publisher construction order used to determine object match.
+            subscription_construction_order : int | None
+                Subscription construction order used to determine object match.
+
+            """
             self._node_name = node_name
             self._publish_topic_name = publish_topic_name
             self._subscribe_topic_name = subscribe_topic_name
@@ -316,6 +530,17 @@ class PublishersLoaded:
         publishers_info: tuple[PublisherStructValue, ...],
         provider: RecordsProvider | RuntimeDataProvider,
     ) -> None:
+        """
+        Construct an instance.
+
+        Parameters
+        ----------
+        publishers_info : tuple[PublisherStructValue, ...]
+            Publishers info.
+        provider : RecordsProvider | RuntimeDataProvider
+            Provider.
+
+        """
         self._pubs = []
         for pub_info in publishers_info:
             try:
@@ -332,6 +557,15 @@ class PublishersLoaded:
 
     @property
     def data(self) -> list[Publisher]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[Publisher]
+            Publisher list.
+
+        """
         return self._pubs
 
     def get_publishers(
@@ -340,6 +574,24 @@ class PublishersLoaded:
         callback_name: str | None,
         topic_name: str | None,
     ) -> list[Publisher]:
+        """
+        Get publishers.
+
+        Parameters
+        ----------
+        node_name : str | None
+            Node name.
+        callback_name : str | None
+            Callback name.
+        topic_name : str | None
+            Topic name.
+
+        Returns
+        -------
+        list[Publisher]
+            Publisher list that matches the condition.
+
+        """
         is_target = PublishersLoaded.IsTarget(node_name, callback_name, topic_name)
         return Util.filter_items(is_target, self._pubs)
 
@@ -350,6 +602,33 @@ class PublishersLoaded:
         topic_name: str | None,
         construction_order: int | None = None
     ) -> Publisher:
+        """
+        Get publisher.
+
+        Parameters
+        ----------
+        node_name : str | None
+            Node name.
+        callback_name : str | None
+            Callback name.
+        topic_name : str | None
+            Topic name.
+        construction_order : int | None
+            Construction order.
+
+        Returns
+        -------
+        Publisher
+            Publisher that matches the condition.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         try:
             is_target = PublishersLoaded.IsTarget(
                 node_name, callback_name, topic_name, construction_order)
@@ -370,6 +649,21 @@ class PublishersLoaded:
             topic_name: str | None,
             construction_order: int | None = None
         ) -> None:
+            """
+            Construct an instance.
+
+            Parameters
+            ----------
+            node_name : str | None
+                Node name used to determine object match.
+            callback_name : str | None
+                Callback name used to determine object match.
+            topic_name : str | None
+                Topic name used to determine object match.
+            construction_order : int | None
+                Construction order used to determine object match.
+
+            """
             self._node_name = node_name
             self._callback_name = callback_name
             self._topic_name = topic_name
@@ -403,6 +697,17 @@ class SubscriptionsLoaded:
         subscriptions_info: tuple[SubscriptionStructValue, ...],
         provider: RecordsProvider | RuntimeDataProvider,
     ) -> None:
+        """
+        Construct an instance.
+
+        Parameters
+        ----------
+        subscriptions_info : tuple[SubscriptionStructValue, ...]
+            Subscriptions info.
+        provider : RecordsProvider | RuntimeDataProvider
+            Provider.
+
+        """
         self._subs = []
         for sub_info in subscriptions_info:
             try:
@@ -419,6 +724,15 @@ class SubscriptionsLoaded:
 
     @property
     def data(self) -> list[Subscription]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[Subscription]
+            Subscription list.
+
+        """
         return self._subs
 
     def get_subscriptions(
@@ -427,6 +741,24 @@ class SubscriptionsLoaded:
         callback_name: str | None,
         topic_name: str | None,
     ) -> list[Subscription]:
+        """
+        Get subscriptions.
+
+        Parameters
+        ----------
+        node_name : str | None
+            Node name.
+        callback_name : str | None
+            Callback name.
+        topic_name : str | None
+            Topic name.
+
+        Returns
+        -------
+        list[Subscription]
+            Subscription list in search results.
+
+        """
         is_target = SubscriptionsLoaded.IsTarget(node_name, callback_name, topic_name)
         return Util.filter_items(is_target, self._subs)
 
@@ -437,6 +769,33 @@ class SubscriptionsLoaded:
         topic_name: str | None,
         construction_order: int | None = None
     ) -> Subscription:
+        """
+        Get subscription.
+
+        Parameters
+        ----------
+        node_name : str | None
+            Node name.
+        callback_name : str | None
+            Callback name.
+        topic_name : str | None
+            Topic name.
+        construction_order : int | None
+            Construction order.
+
+        Returns
+        -------
+        Subscription
+            Subscription in search results.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         try:
             is_target = SubscriptionsLoaded.IsTarget(
                 node_name, callback_name, topic_name, construction_order)
@@ -464,6 +823,21 @@ class SubscriptionsLoaded:
             topic_name: str | None,
             construction_order: int | None = None
         ) -> None:
+            """
+            Construct an instance.
+
+            Parameters
+            ----------
+            node_name : str | None
+                Node name used to determine object match.
+            callback_name : str | None
+                Callback name used to determine object match.
+            topic_name : str | None
+                Topic name used to determine object match.
+            construction_order : int | None
+                Construction order used to determine object match.
+
+            """
             self._node_name = node_name
             self._callback_name = callback_name
             self._topic_name = topic_name
@@ -494,6 +868,17 @@ class TimersLoaded:
         timers_info: tuple[TimerStructValue, ...],
         provider: RecordsProvider | RuntimeDataProvider,
     ) -> None:
+        """
+        Construct an instance.
+
+        Parameters
+        ----------
+        timers_info : tuple[TimerStructValue, ...]
+            Timers info.
+        provider : RecordsProvider | RuntimeDataProvider
+            Provider.
+
+        """
         self._timers = []
         for timer_info in timers_info:
             try:
@@ -510,6 +895,15 @@ class TimersLoaded:
 
     @property
     def data(self) -> list[Timer]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[Timer]
+            Timer list.
+
+        """
         return self._timers
 
     def get_timers(
@@ -519,6 +913,26 @@ class TimersLoaded:
         period_ns: int | None,
         construction_order: int | None,
     ) -> list[Timer]:
+        """
+        Get timers.
+
+        Parameters
+        ----------
+        node_name : str | None
+            Node name.
+        callback_name : str | None
+            Callback name.
+        period_ns : int | None
+            Period ns.
+        construction_order : int | None
+            Construction order.
+
+        Returns
+        -------
+        list[Timer]
+            Timer list in search results.
+
+        """
         is_target = TimersLoaded.IsTarget(
             node_name, callback_name, period_ns, construction_order)
         return Util.filter_items(is_target, self._timers)
@@ -530,6 +944,33 @@ class TimersLoaded:
         period_ns: int | None,
         construction_order: int | None,
     ) -> Timer:
+        """
+        Get timer.
+
+        Parameters
+        ----------
+        node_name : str | None
+            Node name.
+        callback_name : str | None
+            Callback name.
+        period_ns : int | None
+            Period ns.
+        construction_order : int | None
+            Construction order.
+
+        Returns
+        -------
+        Timer
+            Timer in search results..
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         try:
             is_target = TimersLoaded.IsTarget(
                 node_name, callback_name, period_ns, construction_order)
@@ -549,6 +990,21 @@ class TimersLoaded:
             period_ns: int | None,
             construction_order: int | None,
         ) -> None:
+            """
+            Construct an instance.
+
+            Parameters
+            ----------
+            node_name : str | None
+                Node name used to determine object match.
+            callback_name : str | None
+                Callback name used to determine object match.
+            period_ns : str | None
+                Period ns used to determine object match.
+            construction_order : int | None
+                Construction order used to determine object match.
+
+            """
             self._node_name = node_name
             self._callback_name = callback_name
             self._period_ns = period_ns
@@ -583,6 +1039,23 @@ class NodePathsLoaded:
         subscription_loaded: SubscriptionsLoaded,
         callbacks: list[CallbackBase],
     ) -> None:
+        """
+        Construct an instance.
+
+        Parameters
+        ----------
+        node_path_values : tuple[NodePathStructValue, ...]
+            Node path values.
+        provider : RecordsProvider
+            Provider.
+        publisher_loaded : PublishersLoaded
+            Publisher loaded.
+        subscription_loaded : SubscriptionsLoaded
+            Subscription loaded.
+        callbacks : list[CallbackBase]
+            Callbacks.
+
+        """
         self._data = []
         for node_path_value in node_path_values:
             try:
@@ -630,6 +1103,15 @@ class NodePathsLoaded:
 
     @property
     def data(self) -> list[NodePath]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[NodePath]
+            NodePath list.
+
+        """
         return self._data
 
 
@@ -639,6 +1121,17 @@ class VariablePassingsLoaded:
         variable_passings_info: tuple[VariablePassingStructValue, ...],
         provider: RecordsProvider
     ) -> None:
+        """
+        Construct an instance.
+
+        Parameters
+        ----------
+        variable_passings_info : tuple[VariablePassingStructValue, ...]
+            Variable passings info.
+        provider : RecordsProvider
+            Provider.
+
+        """
         self._var_passes = []
         for var_pass in variable_passings_info:
             try:
@@ -658,6 +1151,15 @@ class VariablePassingsLoaded:
 
     @property
     def data(self) -> list[VariablePassing]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[VariablePassing]
+            VariablePassing list.
+
+        """
         return self._var_passes
 
 
@@ -668,6 +1170,19 @@ class PathsLoaded:
         nodes_loaded: NodesLoaded,
         comms_loaded: CommunicationsLoaded,
     ) -> None:
+        """
+        Construct an instance.
+
+        Parameters
+        ----------
+        paths_info : tuple[PathStructValue, ...]
+            Paths info.
+        nodes_loaded : NodesLoaded
+            Nodes loaded.
+        comms_loaded : CommunicationsLoaded
+            Comms loaded.
+
+        """
         self._data = []
         for path_info in paths_info:
             try:
@@ -724,6 +1239,15 @@ class PathsLoaded:
 
     @property
     def data(self) -> list[Path]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[Path]
+            Path list.
+
+        """
         return self._data
 
 
@@ -734,6 +1258,19 @@ class CommunicationsLoaded:
         provider: RecordsProvider,
         nodes_loaded: NodesLoaded,
     ) -> None:
+        """
+        Construct an instance.
+
+        Parameters
+        ----------
+        communication_values : tuple[CommunicationStructValue, ...]
+            Communication values.
+        provider : RecordsProvider
+            Provider.
+        nodes_loaded : NodesLoaded
+            Nodes loaded.
+
+        """
         self._data: list[Communication] = []
         for comm_value in communication_values:
             try:
@@ -744,6 +1281,15 @@ class CommunicationsLoaded:
 
     @property
     def data(self) -> list[Communication]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[Communication]
+            Communication list.
+
+        """
         return self._data
 
     @staticmethod
@@ -788,6 +1334,35 @@ class CommunicationsLoaded:
         publisher_construction_order: int,
         subscription_construction_order: int,
     ) -> Communication:
+        """
+        Find communication.
+
+        Parameters
+        ----------
+        topic_name : str
+            Topic name used for find.
+        publish_node_name : str
+            Publish node name used for find.
+        subscribe_node_name : str
+            Subscribe node name used for find.
+        publisher_construction_order : int
+            Publisher construction order used for find.
+        subscription_construction_order : int
+            Subscription construction order used for find.
+
+        Returns
+        -------
+        Communication
+            Communication in search results.
+
+        Raises
+        ------
+        ItemNotFoundError
+            Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
+
+        """
         def is_target(comm: Communication):
             return comm.publish_node_name == publish_node_name and \
                 comm.subscribe_node_name == subscribe_node_name and \
@@ -817,7 +1392,23 @@ class CallbacksLoaded:
         subscriptions_loaded: SubscriptionsLoaded,
         timers_loaded: TimersLoaded
     ) -> None:
+        """
+        Construct an instance.
 
+        Parameters
+        ----------
+        callback_values : tuple[CallbackStructValue, ...]
+            Callback values.
+        provider : RecordsProvider
+            Provider.
+        publishers_loaded : PublishersLoaded
+            Publishers loaded.
+        subscriptions_loaded : SubscriptionsLoaded
+            Subscriptions loaded.
+        timers_loaded : TimersLoaded
+            Timers loaded.
+
+        """
         # Processes related to services are implemented later.
         def _is_ignore_callback(callback: CallbackStructValue):
             ignore_callback_types = (ServiceCallbackStructValue, )
@@ -872,6 +1463,15 @@ class CallbacksLoaded:
 
     @property
     def data(self) -> list[CallbackBase]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[CallbackBase]
+            CallbackBase list.
+
+        """
         return self._callbacks
 
 
@@ -884,7 +1484,23 @@ class CallbackGroupsLoaded:
         subscriptions_loaded: SubscriptionsLoaded,
         timers_loaded: TimersLoaded
     ) -> None:
+        """
+        Construct an instance.
 
+        Parameters
+        ----------
+        callback_group_value : tuple[CallbackGroupStructValue, ...]
+            Callback group values.
+        provider : RecordsProvider
+            Provider.
+        publishers_loaded : PublishersLoaded
+            Publishers loaded.
+        subscriptions_loaded : SubscriptionsLoaded
+            Subscriptions loaded.
+        timers_loaded : TimersLoaded
+            Timers loaded.
+
+        """
         self._data = []
         for cbg_info in callback_group_value:
             try:
@@ -910,4 +1526,13 @@ class CallbackGroupsLoaded:
 
     @property
     def data(self) -> list[CallbackGroup]:
+        """
+        Get data.
+
+        Returns
+        -------
+        list[CallbackGroup]
+            CallbackGroup list.
+
+        """
         return self._data

--- a/src/caret_analyze/value_objects/callback.py
+++ b/src/caret_analyze/value_objects/callback.py
@@ -37,6 +37,11 @@ class CallbackType(ValueObject):
         name : str
             Callback type name ['timer_callback', 'subscription_callback', 'service_callback'].
 
+        Raises
+        ------
+        ValueError
+            Argument name is not "timer_callback", "subscription_callback", or "service_callback".
+
         """
         if name not in ['timer_callback', 'subscription_callback', 'service_callback']:
             raise ValueError(f'Unsupported callback type: {name}')
@@ -477,7 +482,7 @@ class ServiceCallbackValue(CallbackValue):
         symbol : str
             Symbol name of the service callback.
         service_name : str
-            Service name which the service callback service.
+            Service name which the service callback.
         publish_topics : tuple[PublishTopicInfoValue, ...] | None
             Topic information which the service callback publishes.
         construction_order : int

--- a/src/caret_analyze/value_objects/callback_group.py
+++ b/src/caret_analyze/value_objects/callback_group.py
@@ -28,11 +28,14 @@ class CallbackGroupType(ValueObject):
 
     - MUTUALLY_EXCLUSIVE
     - REENTRANT
+    - UNDEFINED
 
     """
 
     MUTUALLY_EXCLUSIVE: CallbackGroupType
     REENTRANT: CallbackGroupType
+    # TODO: rename UNDEFIND
+    # The CallbackGroup type marked as UNDEFINED here indicates that it is not connected to an Executor.
     UNDEFINED: CallbackGroupType
 
     def __init__(self, name: str) -> None:

--- a/src/caret_analyze/value_objects/callback_group.py
+++ b/src/caret_analyze/value_objects/callback_group.py
@@ -34,7 +34,7 @@ class CallbackGroupType(ValueObject):
 
     MUTUALLY_EXCLUSIVE: CallbackGroupType
     REENTRANT: CallbackGroupType
-    # TODO: rename UNDEFIND
+    # TODO: rename UNDEFINED
     # The CallbackGroup type marked as UNDEFINED here indicates that it is not connected to an Executor.
     UNDEFINED: CallbackGroupType
 

--- a/src/caret_analyze/value_objects/callback_group.py
+++ b/src/caret_analyze/value_objects/callback_group.py
@@ -44,6 +44,11 @@ class CallbackGroupType(ValueObject):
         name : str
             type name ['mutually_exclusive', 'reentrant', 'UNDEFINED']
 
+        Raises
+        ------
+        ValueError
+            Argument name is not "mutually_exclusive", "reentrant", or "UNDEFINED".
+
         """
         if name not in ['mutually_exclusive', 'reentrant', 'UNDEFINED']:
             raise ValueError(f'Unsupported callback group type: {name}')
@@ -122,6 +127,7 @@ class CallbackGroupValue(ValueObject):
         Returns
         -------
         CallbackGroupType
+            callback group type
 
         """
         return self._callback_group_type
@@ -230,6 +236,7 @@ class CallbackGroupStructValue(ValueObject, Summarizable):
         Returns
         -------
         CallbackGroupType
+            callback group type
 
         """
         return self._callback_group_type
@@ -241,7 +248,8 @@ class CallbackGroupStructValue(ValueObject, Summarizable):
 
         Returns
         -------
-        CallbackGroupType name
+        str
+            callback group type name
 
         """
         return self._callback_group_type.type_name
@@ -300,6 +308,15 @@ class CallbackGroupStructValue(ValueObject, Summarizable):
 
     @property
     def summary(self) -> Summary:
+        """
+        Get summary.
+
+        Returns
+        -------
+        Summary
+            Summary about value objects and runtime data objects.
+
+        """
         return Summary({
             'name': self.callback_group_name,
             'type': self.callback_group_type_name,

--- a/src/caret_analyze/value_objects/communication.py
+++ b/src/caret_analyze/value_objects/communication.py
@@ -23,6 +23,7 @@ from ..common import Summarizable, Summary
 
 
 class CommunicationStructValue(ValueObject, Summarizable):
+    """Structured communication struct value."""
 
     def __init__(
         self,
@@ -33,6 +34,25 @@ class CommunicationStructValue(ValueObject, Summarizable):
         publish_callback_values: tuple[CallbackStructValue, ...] | None,
         subscription_callback_value: CallbackStructValue | None,
     ) -> None:
+        """
+        Construct an instance.
+
+        Parameters
+        ----------
+        node_publish : NodeStructValue
+            Node struct value on the publish side.
+        node_subscription : NodeStructValue
+            Node struct value on the subscription side.
+        publisher_value : PublisherStructValue
+            Publisher struct value.
+        subscription_value : SubscriptionStructValue
+            Subscription struct value.
+        publish_callback_values : tuple[CallbackStructValue, ...] | None
+            Publisher callback struct values.
+        subscription_callback_value : CallbackStructValue | None
+            Subscription callback struct value.
+
+        """
         self._publisher_value = publisher_value
         self._subscription_value = subscription_value
         self._topic_name = subscription_value.topic_name
@@ -43,62 +63,188 @@ class CommunicationStructValue(ValueObject, Summarizable):
 
     @property
     def subscribe_node(self) -> NodeStructValue:
+        """
+        Get subscribe node.
+
+        Returns
+        -------
+        NodeStructValue
+            Node struct value on the subscription side.
+
+        """
         return self._node_sub
 
     @property
     def publish_node(self) -> NodeStructValue:
+        """
+        Get publish node.
+
+        Returns
+        -------
+        NodeStructValue
+            Node struct value on the publish side.
+
+        """
         return self._node_pub
 
     @property
     def topic_name(self) -> str:
+        """
+        Get topic name.
+
+        Returns
+        -------
+        str
+            Topic name.
+
+        """
         return self._topic_name
 
     @property
     def publish_callback_names(self) -> tuple[str, ...] | None:
+        """
+        Get publish callback names.
+
+        Returns
+        -------
+        tuple[str, ...] | None
+            Publish callback names.
+
+        """
         if self._publish_callbacks_value is None:
             return None
         return tuple(p.callback_name for p in self._publish_callbacks_value)
 
     @property
     def subscribe_callback_name(self) -> str | None:
+        """
+        Get subscribe callback names.
+
+        Returns
+        -------
+        tuple[str, ...] | None
+            Subscribe callback names.
+
+        """
         if self._subscription_callback_value is None:
             return None
         return self._subscription_callback_value.callback_name
 
     @property
     def publisher(self) -> PublisherStructValue:
+        """
+        Get publisher struct value.
+
+        Returns
+        -------
+        PublisherStructValue
+            Publisher struct value.
+
+        """
         return self._publisher_value
 
     @property
     def subscription(self) -> SubscriptionStructValue:
+        """
+        Get subscription struct value.
+
+        Returns
+        -------
+        SubscriptionStructValue
+            Subscription struct value.
+
+        """
         return self._subscription_value
 
     @property
     def publish_callbacks(self) -> tuple[CallbackStructValue, ...] | None:
+        """
+        Get publish callback value.
+
+        Returns
+        -------
+        tuple[CallbackStructValue, ...] | None
+            Publish callback struct value.
+
+        """
         return self._publish_callbacks_value
 
     @property
     def subscribe_callback(self) -> CallbackStructValue | None:
+        """
+        Get subscribe callback value.
+
+        Returns
+        -------
+        tuple[CallbackStructValue, ...] | None
+            Subscribe callback struct value.
+
+        """
         return self._subscription_callback_value
 
     @property
     def subscribe_node_name(self) -> str:
+        """
+        Get subscribe node name.
+
+        Returns
+        -------
+        str
+            Subscribe node name.
+
+        """
         return self._node_sub.node_name
 
     @property
     def publish_node_name(self) -> str:
+        """
+        Get publish node name.
+
+        Returns
+        -------
+        str
+            Publish node name.
+
+        """
         return self._node_pub.node_name
 
     @property
     def publisher_construction_order(self) -> int:
+        """
+        Get publisher construction order.
+
+        Returns
+        -------
+        int
+            Publisher construction order.
+
+        """
         return self._publisher_value.construction_order
 
     @property
     def subscription_construction_order(self) -> int:
+        """
+        Get subscription construction order.
+
+        Returns
+        -------
+        int
+            Subscription construction order.
+
+        """
         return self._subscription_value.construction_order
 
     @property
     def summary(self) -> Summary:
+        """
+        Get summary.
+
+        Returns
+        -------
+        Summary
+            Summary about value objects and runtime data objects.
+
+        """
         return Summary({
             'topic_name': self.topic_name,
             'publish_node': self.publish_node_name,

--- a/src/caret_analyze/value_objects/message_context.py
+++ b/src/caret_analyze/value_objects/message_context.py
@@ -57,8 +57,8 @@ class MessageContextType(ValueObject):
         """
         Get type name.
 
-        Parameters
-        ----------
+        Returns
+        -------
         str
             Type name.
 
@@ -69,8 +69,8 @@ class MessageContextType(ValueObject):
         """
         Get type name.
 
-        Parameters
-        ----------
+        Returns
+        -------
         str
             Type name.
 
@@ -183,7 +183,7 @@ class MessageContext(ValueObject, Summarizable):
         Returns
         -------
         dict
-            Dict.
+            Dictionary of context type and subscription/publisher topic name.
 
         """
         return {
@@ -251,7 +251,7 @@ class MessageContext(ValueObject, Summarizable):
     @property
     def publisher_construction_order(self) -> int | None:
         """
-        Get publisher topic name.
+        Get publisher construction order.
 
         Returns
         -------
@@ -286,7 +286,7 @@ class MessageContext(ValueObject, Summarizable):
         Returns
         -------
         Summary
-            Summary.
+            Summary about value objects and runtime data objects.
 
         """
         return Summary({
@@ -340,6 +340,11 @@ class MessageContext(ValueObject, Summarizable):
         MessageContext
             Message context.
 
+        Raises
+        ------
+        UnsupportedTypeError
+            Argument context_type_name is not supported.
+
         """
         if context_type_name == str(MessageContextType.CALLBACK_CHAIN):
             return CallbackChain(node_name,
@@ -372,7 +377,12 @@ class MessageContext(ValueObject, Summarizable):
 class UseLatestMessage(MessageContext):
     TYPE_NAME = 'use_latest_message'
 
-    """Use message context"""
+    """
+    Use latest message.
+
+    Latency is calculated from use latest message.
+
+    """
 
     def verify(self) -> bool:
         """
@@ -459,6 +469,23 @@ class CallbackChain(MessageContext):
         publisher: PublisherStructValue | None,
         callbacks: tuple[CallbackStructValue, ...] | None
     ) -> None:
+        """
+        Construct an instance.
+
+        Parameters
+        ----------
+        node_name : str
+            Node name.
+        message_context_dict : dict
+            Message context dict.
+        subscription : SubscriptionStructValue | None
+            Target subscription value.
+        publisher : PublisherStructValue | None
+            Target publisher value.
+        callbacks : tuple[CallbackStructValue, ...] | None
+            Callbacks.
+
+        """
         super().__init__(node_name,
                          message_context_dict,
                          subscription,
@@ -467,6 +494,15 @@ class CallbackChain(MessageContext):
 
     @property
     def context_type(self) -> MessageContextType:
+        """
+        Get context type.
+
+        Returns
+        -------
+        MessageContextType
+            Message context type.
+
+        """
         return MessageContextType.CALLBACK_CHAIN
 
     def is_applicable_path(
@@ -475,17 +511,53 @@ class CallbackChain(MessageContext):
         publisher: PublisherStructValue | None,
         callbacks: tuple[CallbackStructValue, ...] | None
     ) -> bool:
+        """
+        Get applicable path.
+
+        Parameters
+        ----------
+        subscription : SubscriptionStructValue | None
+            Target subscription value.
+        publisher : PublisherStructValue | None
+            Target publisher value.
+        callbacks : tuple[CallbackStructValue, ...] | None
+            Target callbacks.
+
+        Returns
+        -------
+        bool
+            True if applicable path, false otherwise.
+
+        """
         if not super().is_applicable_path(subscription, publisher, callbacks):
             return False
         return self.callbacks == callbacks
 
     def to_dict(self) -> dict:
+        """
+        Get to dict.
+
+        Returns
+        -------
+        dict
+            Dictionary of callback name.
+
+        """
         d = super().to_dict()
         if self.callbacks is not None:
             d['callbacks'] = [_.callback_name for _ in self.callbacks]
         return d
 
     def verify(self) -> bool:
+        """
+        Get verify.
+
+        Returns
+        -------
+        bool
+            Same or difference.
+
+        """
         is_valid = True
         if self.callbacks is None or len(self.callbacks) == 0:
             is_valid = False

--- a/src/caret_analyze/value_objects/node.py
+++ b/src/caret_analyze/value_objects/node.py
@@ -86,7 +86,7 @@ class NodeValue(ValueObject):
 
 class NodeValueWithId(NodeValue):
     """
-    Value object class for representing a node path.
+    Value object class for representing a node with id.
 
     This class has minimal information and no structure,
     and used as the return value of ArchitectureReader.
@@ -434,6 +434,8 @@ class NodeStructValue(ValueObject, Summarizable):
         ------
         ItemNotFoundError
             Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
 
         """
         try:
@@ -475,6 +477,8 @@ class NodeStructValue(ValueObject, Summarizable):
         ------
         ItemNotFoundError
             Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
 
         """
         try:
@@ -516,6 +520,8 @@ class NodeStructValue(ValueObject, Summarizable):
         ------
         ItemNotFoundError
             Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
 
         """
         try:
@@ -557,6 +563,8 @@ class NodeStructValue(ValueObject, Summarizable):
         ------
         ItemNotFoundError
             Occurs when no items were found.
+        MultipleItemFoundError
+            Occurs when several items were found.
 
         """
         try:

--- a/src/caret_analyze/value_objects/path.py
+++ b/src/caret_analyze/value_objects/path.py
@@ -37,8 +37,8 @@ class PathValue(ValueObject):
         """
         Construct an instance.
 
-        Returns
-        -------
+        Parameters
+        ----------
         alias : str
             Alias.
         node_path_values : tuple[NodePathValue, ...]
@@ -81,24 +81,72 @@ class PathStructValue(ValueObject, Summarizable):
         path_name: str | None,
         child: tuple[NodePathStructValue | CommunicationStructValue, ...],
     ) -> None:
+        """
+        Construct an instance.
+
+        Parameters
+        ----------
+        path_name : str | None
+            Path name.
+        child : tuple[NodePathStructValue | CommunicationStructValue, ...]
+            Tuple with alternating elements of NodePath and Communication,
+            which are the elements that make up the Path.
+
+        """
         self._path_name = path_name
         self._child = child
         self._validate(child)
 
     @property
     def path_name(self) -> str | None:
+        """
+        Get path name.
+
+        Returns
+        -------
+        str | None
+            Path name.
+
+        """
         return self._path_name
 
     @property
     def node_names(self) -> tuple[str, ...]:
+        """
+        Get node names.
+
+        Returns
+        -------
+        tuple[str, ...]
+            Node names.
+
+        """
         return tuple(_.node_name for _ in self.node_paths)
 
     @property
     def topic_names(self) -> tuple[str, ...]:
+        """
+        Get topic names.
+
+        Returns
+        -------
+        tuple[str, ...]
+            Topic names.
+
+        """
         return tuple(_.topic_name for _ in self.communications)
 
     @property
     def child_names(self) -> tuple[str, ...]:
+        """
+        Get child names.
+
+        Returns
+        -------
+        tuple[str, ...]
+            Node name for NodePathStructValue, topic name for CommunicationStructValue.
+
+        """
         names = []
         for child in self.child:
             if isinstance(child, NodePathStructValue):
@@ -109,6 +157,15 @@ class PathStructValue(ValueObject, Summarizable):
 
     @property
     def node_paths(self) -> tuple[NodePathStructValue, ...]:
+        """
+        Get node paths.
+
+        Returns
+        -------
+        tuple[NodePathStructValue, ...]
+            Node paths of Path struct value.
+
+        """
         node_paths = Util.filter_items(
             lambda x: isinstance(x, NodePathStructValue),
             self._child)
@@ -116,6 +173,15 @@ class PathStructValue(ValueObject, Summarizable):
 
     @property
     def communications(self) -> tuple[CommunicationStructValue, ...]:
+        """
+        Get communications.
+
+        Returns
+        -------
+        tuple[CommunicationStructValue, ...]
+            Communications of Path struct value.
+
+        """
         comm_paths = Util.filter_items(
             lambda x: isinstance(x, CommunicationStructValue),
             self._child)
@@ -123,6 +189,15 @@ class PathStructValue(ValueObject, Summarizable):
 
     @property
     def summary(self) -> Summary:
+        """
+        Get summary.
+
+        Returns
+        -------
+        Summary
+            Summary about value objects and runtime data objects.
+
+        """
         d: Summary = Summary()
         d['path'] = []
         for child in self.child:
@@ -142,6 +217,15 @@ class PathStructValue(ValueObject, Summarizable):
 
     @property
     def child(self) -> tuple[NodePathStructValue | CommunicationStructValue, ...]:
+        """
+        Get child.
+
+        Returns
+        -------
+        tuple[NodePathStructValue | CommunicationStructValue, ...]
+            Child of Path struct value.
+
+        """
         return self._child
 
     @staticmethod
@@ -164,6 +248,15 @@ class PathStructValue(ValueObject, Summarizable):
             raise InvalidArgumentError(msg)
 
     def verify(self) -> bool:
+        """
+        Get verify.
+
+        Returns
+        -------
+        bool
+            Verify or not.
+
+        """
         is_valid = True
 
         for child in self.node_paths[1:-1]:

--- a/src/caret_analyze/value_objects/publisher.py
+++ b/src/caret_analyze/value_objects/publisher.py
@@ -74,7 +74,7 @@ class PublisherValue(ValueObject):
         Returns
         -------
         str
-            Node id.
+            Node name.
 
         """
         return self._node_name
@@ -245,7 +245,7 @@ class PublisherStructValue(ValueObject, Summarizable):
         Returns
         -------
         Summary
-            Summary.
+            Summary about value objects and runtime data objects.
 
         """
         return Summary({

--- a/src/caret_analyze/value_objects/service.py
+++ b/src/caret_analyze/value_objects/service.py
@@ -84,12 +84,12 @@ class ServiceValue(ValueObject):
     @property
     def service_name(self) -> str:
         """
-        Get node name.
+        Get service name.
 
         Returns
         -------
         str
-            Node name.
+            Service name.
 
         """
         return self._service_name
@@ -167,12 +167,12 @@ class ServiceStructValue(ValueObject, Summarizable):
     @property
     def service_name(self) -> str:
         """
-        Get node name.
+        Get service name.
 
         Returns
         -------
         str
-            Node name.
+            Service name.
 
         """
         return self._service_name

--- a/src/caret_analyze/value_objects/subscription.py
+++ b/src/caret_analyze/value_objects/subscription.py
@@ -243,7 +243,7 @@ class SubscriptionStructValue(ValueObject, Summarizable):
         Returns
         -------
         Summary
-            Summary info.
+            Summary about value objects and runtime data objects.
 
         """
         return Summary({

--- a/src/caret_analyze/value_objects/timer.py
+++ b/src/caret_analyze/value_objects/timer.py
@@ -201,7 +201,7 @@ class TimerStructValue(ValueObject, Summarizable):
         Returns
         -------
         Summary
-            Summary info.
+            Summary about value objects and runtime data objects.
 
         """
         return Summary({

--- a/src/caret_analyze/value_objects/value_object.py
+++ b/src/caret_analyze/value_objects/value_object.py
@@ -121,16 +121,15 @@ class ValueObject():
                     d[attr] = value
         return d
 
-    def __generate_public_attrs(self):
-        attrs = inspect.getmembers(self)
+    # cache
+    _public_attrs_cache = None
 
-        # ignore private variables and Constant variables
-        attrs = list(filter(
-            lambda x: x[0][0] != '_' and x[0][0].islower(), attrs
-        ))
-        for attr in attrs:
-            key, value = attr[0], attr[1]
-            # ignore callable
-            if callable(value):
-                continue
-            yield key
+    def __generate_public_attrs(self):
+        if self._public_attrs_cache is None:
+            attrs = inspect.getmembers(self)
+            self._public_attrs_cache = tuple(
+                # Exclude private variables, constants, and callable attributes
+                key for key, value in attrs
+                if key[0] != '_' and key[0].islower() and not callable(value)
+            )
+        yield from self._public_attrs_cache

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-setuptools>=68.2.2
+setuptools>=68.2.2,<80.0.0
 colorcet
 pandas>=2.1.1
 bokeh>=3,<3.7.0

--- a/src/test/architecture/test_architecture.py
+++ b/src/test/architecture/test_architecture.py
@@ -415,6 +415,9 @@ class TestArchitecture:
         mocker.patch.object(comm_mock_0, 'publisher_construction_order', 0)
         comm_mock_struct_0 = mocker.Mock(spec=CommunicationStructValue)
         mocker.patch.object(comm_mock_0, 'to_value', return_value=comm_mock_struct_0)
+        callback_0 = mocker.Mock()
+        mocker.patch.object(callback_0, 'construction_order', 1)
+        mocker.patch.object(comm_mock_0, 'subscribe_callback', callback_0)
 
         mocker.patch.object(comm_mock_1, 'publish_node_name', '1')
         mocker.patch.object(comm_mock_1, 'subscribe_node_name', '2')
@@ -423,6 +426,9 @@ class TestArchitecture:
         mocker.patch.object(comm_mock_1, 'publisher_construction_order', 0)
         comm_mock_struct_1 = mocker.Mock(spec=CommunicationStructValue)
         mocker.patch.object(comm_mock_1, 'to_value', return_value=comm_mock_struct_1)
+        callback_1 = mocker.Mock()
+        mocker.patch.object(callback_1, 'construction_order', 2)
+        mocker.patch.object(comm_mock_1, 'subscribe_callback', callback_1)
 
         mocker.patch.object(loaded_mock, 'nodes', [node_mock_0, node_mock_1, node_mock_2])
         mocker.patch.object(loaded_mock, 'paths', [])

--- a/src/test/infra/lttng/test_latency_definitions.py
+++ b/src/test/infra/lttng/test_latency_definitions.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from logging import WARNING
+
 from caret_analyze.exceptions import UnsupportedNodeRecordsError
 from caret_analyze.infra.lttng import Lttng, RecordsProviderLttng
 from caret_analyze.infra.lttng.bridge import LttngBridge
@@ -1463,8 +1465,8 @@ class TestCommunicationRecords:
                     f'{communication.topic_name}/rclcpp_publish_timestamp': 1,
                     f'{communication.topic_name}/rcl_publish_timestamp': 2,
                     f'{communication.topic_name}/dds_write_timestamp': 3,
-                    # f'{communication.topic_name}/message_timestamp': message_stamp,
                     f'{communication.topic_name}/source_timestamp': 9,
+                    f'{communication.topic_name}/rmw_take_timestamp': pd.NA if has_dispatch else 5,
                     f'{callback.callback_name}/callback_start_timestamp': 16,
                 }
             ],
@@ -1472,8 +1474,8 @@ class TestCommunicationRecords:
                 f'{communication.topic_name}/rclcpp_publish_timestamp',
                 f'{communication.topic_name}/rcl_publish_timestamp',
                 f'{communication.topic_name}/dds_write_timestamp',
-                # f'{communication.topic_name}/message_timestamp',
                 f'{communication.topic_name}/source_timestamp',
+                f'{communication.topic_name}/rmw_take_timestamp',
                 f'{callback.callback_name}/callback_start_timestamp',
             ],
             dtype='Int64'
@@ -1605,21 +1607,26 @@ class TestCommunicationRecords:
                 {
                     f'{communication.topic_name}/rclcpp_publish_timestamp': 1,
                     f'{communication.topic_name}/source_timestamp': 9,
+                    f'{communication.topic_name}/rmw_take_timestamp': pd.NA,
                     f'{callback.callback_name}/callback_start_timestamp': 16,
                 },
                 {
                     f'{communication.topic_name}/rclcpp_publish_timestamp': 17,
                     f'{communication.topic_name}/source_timestamp': 109,
+                    f'{communication.topic_name}/rmw_take_timestamp': pd.NA,
+                    f'{callback.callback_name}/callback_start_timestamp': pd.NA,
                 },
                 {
                     f'{communication.topic_name}/rclcpp_publish_timestamp': 19,
                     f'{communication.topic_name}/source_timestamp': 209,
+                    f'{communication.topic_name}/rmw_take_timestamp': pd.NA,
                     f'{callback.callback_name}/callback_start_timestamp': 22,
                 }
             ],
             columns=[
                 f'{communication.topic_name}/rclcpp_publish_timestamp',
                 f'{communication.topic_name}/source_timestamp',
+                f'{communication.topic_name}/rmw_take_timestamp',
                 f'{callback.callback_name}/callback_start_timestamp',
             ],
             dtype='Int64'
@@ -2065,4 +2072,8 @@ class TestSimTimeConverter:
 
         assert (s100 == d100)
         assert (s300 == d300)
-        assert 'Out-of-range time is used to convert sim_time' in caplog.messages[0]
+        assert 'Out-of-range time is used to convert sim_time' in caplog.text
+        assert caplog.records[0].levelno == WARNING
+        #captured = capsys.readouterr()
+        #assert 'Out-of-range time is used to convert sim_time' in captured.err
+

--- a/src/test/infra/lttng/test_latency_definitions.py
+++ b/src/test/infra/lttng/test_latency_definitions.py
@@ -2073,5 +2073,4 @@ class TestSimTimeConverter:
         assert (s300 == d300)
         assert 'Out-of-range time is used to convert sim_time' in caplog.text
         assert caplog.records[0].levelno == WARNING
-        #captured = capsys.readouterr()
         #assert 'Out-of-range time is used to convert sim_time' in captured.err

--- a/src/test/infra/lttng/test_latency_definitions.py
+++ b/src/test/infra/lttng/test_latency_definitions.py
@@ -2069,11 +2069,9 @@ class TestSimTimeConverter:
         converter = provider.get_sim_time_converter(min_ns, max_ns)
         d100 = converter.convert(100)
         d300 = converter.convert(300)
-
         assert (s100 == d100)
         assert (s300 == d300)
         assert 'Out-of-range time is used to convert sim_time' in caplog.text
         assert caplog.records[0].levelno == WARNING
         #captured = capsys.readouterr()
         #assert 'Out-of-range time is used to convert sim_time' in captured.err
-

--- a/src/test/plot/timeseries/test_frequency_timeseries.py
+++ b/src/test/plot/timeseries/test_frequency_timeseries.py
@@ -15,6 +15,8 @@
 from caret_analyze.plot.timeseries.frequency_timeseries import FrequencyTimeSeries
 from caret_analyze.record import ColumnValue
 from caret_analyze.record.record_factory import RecordFactory, RecordsFactory
+from caret_analyze.runtime.callback import CallbackBase
+import pandas as pd
 
 
 def create_expect_records(records_raw):
@@ -29,7 +31,7 @@ def create_expect_records(records_raw):
     return records
 
 
-class TestFrequencyTimeSeries:
+class TestGetTimestampRange:
 
     def test_get_timestamp_range_normal(self, mocker):
         records0 = create_expect_records([
@@ -90,3 +92,45 @@ class TestFrequencyTimeSeries:
 
         assert min_ts == 0
         assert max_ts == 1
+
+
+def create_sample_record(record_raw_list: list[dict]) -> RecordsFactory:
+    records = RecordsFactory.create_instance()
+    columns = [ColumnValue(key) for key in record_raw_list[0].keys()]
+    for column in columns:
+        records.append_column(column, [])
+
+    for record_raw in record_raw_list:
+        record = RecordFactory.create_instance(record_raw)
+        records.append(record)
+    return records
+
+
+class TestFrequencyTimeSeries:
+
+    def test_sample_record_to_dataframe(self, mocker):
+        records = create_sample_record([
+                {'timestamp': 1, 'some_data': 2},
+                {'timestamp': 2, 'some_data': 3}
+        ])
+        except_freq_df = pd.DataFrame(
+            data=[
+                {'timestamp [ns]': 1, 'frequency [Hz]': 2}
+            ]
+        )
+
+        cb_mock = mocker.Mock(spec=CallbackBase)
+        mocker.patch.object(cb_mock, 'to_records', return_value=records)
+        mocker.patch.object(cb_mock, 'column_names', ['timestamp', 'some_data'])
+
+        # Check if mock works as expected
+        assert cb_mock.to_records() == records
+        assert cb_mock.column_names == ['timestamp', 'some_data']
+
+        frequency_timeseries = FrequencyTimeSeries([cb_mock])
+
+        actual_df = frequency_timeseries.to_dataframe('timestamp')
+        actual_df.columns = actual_df.columns.droplevel(0)  # MultiIndex to single index
+
+        actual_df = actual_df.astype(except_freq_df.dtypes.to_dict())  # Type conversion
+        assert actual_df.equals(except_freq_df)

--- a/src/test/plot/timeseries/test_frequency_timeseries.py
+++ b/src/test/plot/timeseries/test_frequency_timeseries.py
@@ -94,31 +94,22 @@ class TestGetTimestampRange:
         assert max_ts == 1
 
 
-def create_sample_record(record_raw_list: list[dict]) -> RecordsFactory:
-    records = RecordsFactory.create_instance()
-    columns = [ColumnValue(key) for key in record_raw_list[0].keys()]
-    for column in columns:
-        records.append_column(column, [])
-
-    for record_raw in record_raw_list:
-        record = RecordFactory.create_instance(record_raw)
-        records.append(record)
-    return records
-
-
 class TestFrequencyTimeSeries:
 
-    def test_sample_record_to_dataframe(self, mocker):
-        records = create_sample_record([
-                {'timestamp': 1, 'some_data': 2},
-                {'timestamp': 2, 'some_data': 3}
-        ])
-        except_freq_df = pd.DataFrame(
-            data=[
-                {'timestamp [ns]': 1, 'frequency [Hz]': 2}
-            ]
-        )
+    @staticmethod
+    def create_sample_record(record_raw_list: list[dict]) -> RecordsFactory:
+        records = RecordsFactory.create_instance()
+        columns = [ColumnValue(key) for key in record_raw_list[0].keys()]
+        for column in columns:
+            records.append_column(column, [])
 
+        for record_raw in record_raw_list:
+            record = RecordFactory.create_instance(record_raw)
+            records.append(record)
+        return records
+
+    def get_frequency_dataframe(self, mocker, input_records: list[dict]):
+        records = TestFrequencyTimeSeries.create_sample_record(input_records)
         cb_mock = mocker.Mock(spec=CallbackBase)
         mocker.patch.object(cb_mock, 'to_records', return_value=records)
         mocker.patch.object(cb_mock, 'column_names', ['timestamp', 'some_data'])
@@ -128,9 +119,24 @@ class TestFrequencyTimeSeries:
         assert cb_mock.column_names == ['timestamp', 'some_data']
 
         frequency_timeseries = FrequencyTimeSeries([cb_mock])
-
         actual_df = frequency_timeseries.to_dataframe('timestamp')
-        actual_df.columns = actual_df.columns.droplevel(0)  # MultiIndex to single index
+        actual_df.columns = actual_df.columns.droplevel(0)
 
+        return actual_df
+
+    def test_to_dataframe_remove_last_period(self, mocker):
+        records = [
+            {'timestamp': 1, 'some_data': 2},
+            {'timestamp': 2, 'some_data': 3},
+            {'timestamp': 1000000001, 'some_data': 4},
+        ]
+        except_freq_df = pd.DataFrame(
+            data=[
+                {'timestamp [ns]': 1, 'frequency [Hz]': 2}
+            ]
+        )
+
+        actual_df = self.get_frequency_dataframe(mocker, records)
         actual_df = actual_df.astype(except_freq_df.dtypes.to_dict())  # Type conversion
+
         assert actual_df.equals(except_freq_df)

--- a/src/test/runtime/test_path.py
+++ b/src/test/runtime/test_path.py
@@ -248,6 +248,7 @@ class TestRecordsMerged:
         )
 
         comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(comm_path, 'use_take_manually', return_value=False)
         mocker.patch.object(
             comm_path, 'to_records',
             return_value=RecordsCppImpl(
@@ -336,6 +337,7 @@ class TestRecordsMerged:
         )
 
         comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(comm_path, 'use_take_manually', return_value=False)
         mocker.patch.object(
             comm_path, 'to_records',
             return_value=RecordsCppImpl(
@@ -416,6 +418,7 @@ class TestRecordsMerged:
         )
 
         comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(comm_path, 'use_take_manually', return_value=False)
         mocker.patch.object(
             comm_path, 'to_records',
             return_value=RecordsCppImpl(
@@ -501,6 +504,7 @@ class TestRecordsMerged:
         )
 
         comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(comm_path, 'use_take_manually', return_value=False)
         mocker.patch.object(
             comm_path, 'to_records',
             return_value=RecordsCppImpl(
@@ -578,6 +582,7 @@ class TestRecordsMerged:
 
     def test_take_impl_case(self, mocker):
         comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(comm_path, 'use_take_manually', return_value=True)
         topic0 = 'topic_0'
         topic1 = 'topic_1'
         mocker.patch.object(
@@ -596,7 +601,7 @@ class TestRecordsMerged:
                     ColumnValue(f'{topic0}/rcl_publish_timestamp'),
                     ColumnValue(f'{topic0}/dds_write_timestamp'),
                     ColumnValue(f'{topic0}/source_timestamp'),
-                    ColumnValue(f'{topic0}/callback_start_timestamp'),
+                    # ColumnValue(f'{topic0}/callback_start_timestamp'),
                 ]
             )
         )
@@ -686,6 +691,7 @@ class TestRecordsMerged:
         )
 
         comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(comm_path, 'use_take_manually', return_value=False)
         mocker.patch.object(
             comm_path, 'to_records',
             return_value=RecordsCppImpl(
@@ -759,6 +765,7 @@ class TestRecordsMerged:
         topic0 = 'topic_0'
         topic1 = 'topic_1'
         comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(comm_path, 'use_take_manually', return_value=True)
         mocker.patch.object(
             comm_path, 'to_records',
             return_value=RecordsCppImpl(


### PR DESCRIPTION
## Description

If the last node in the path uses take-method, use rmw_take_timestamp to calculate latency.

the message flow, it is represented as “node name + rmw_take_timestamp” as shown in the figure.
<img width="1088" height="220" alt="image" src="https://github.com/user-attachments/assets/d66db441-4f22-4982-9679-28920dd7af03" />


## Related links

[https://tier4.atlassian.net/browse/RT2-2480](https://tier4.atlassian.net/browse/RT2-2480)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
