### PR TITLE
fix: last node of path use take-method

### DIFF
--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -246,7 +246,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
             Columns
 
             - [topic_name]/source_timestamp
-            - rmw_take_timestamp
+            - [topic_name]/rmw_take_timestamp
 
         Raises
         ------

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1092,7 +1092,6 @@ class RecordsProviderLttng(RuntimeDataProvider):
             - [topic_name]/dds_write_timestamp (Optional)
             - [topic_name]/source_timestamp
             - [topic_name]/rmw_take_timestamp
-            - [topic_name]/callback_start_timestamp (copied from rmw_take_timestamp)
 
         """
         publisher = comm_value.publisher

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1115,37 +1115,6 @@ class RecordsProviderLttng(RuntimeDataProvider):
 
         records = self._source.inter_take_comm_records(publisher_handles, rmw_handle)
 
-        num_rows = len(records.data)
-
-        empty_uint64_values = [0] * num_rows
-
-        column_name_str = COLUMN_NAME.CALLBACK_START_TIMESTAMP
-
-        if column_name_str not in records.columns:
-            try:
-                column_value_object_to_pass = ColumnValue(column_name_str)
-                records.append_column(column_value_object_to_pass, empty_uint64_values)
-            except Exception as e:
-                msg = (f"Failed to append column '{column_name_str}': {e}")
-                raise RuntimeError(msg) from e
-
-        # copy rmw_take_timestamp to callback_start_timestamp
-        try:
-            rmw_take_raw_values = records.get_column_series(COLUMN_NAME.RMW_TAKE_TIMESTAMP)
-
-            # Replace None in the list with a value that can be converted to uint64_t "0"
-            rmw_take_values_for_cpp = [v if v is not None else 0 for v in rmw_take_raw_values]
-
-            if COLUMN_NAME.CALLBACK_START_TIMESTAMP in records.columns:
-                records.drop_columns([COLUMN_NAME.CALLBACK_START_TIMESTAMP])
-
-            callback_start_column_value_for_copy = ColumnValue(COLUMN_NAME.CALLBACK_START_TIMESTAMP)
-            records.append_column(callback_start_column_value_for_copy, rmw_take_values_for_cpp)
-
-        except Exception as e:
-            msg = f"Failed to copy: {e}"
-            raise RuntimeError(msg) from e
-
         columns = [COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP]
         try:
             if COLUMN_NAME.RCL_PUBLISH_TIMESTAMP in records.columns:
@@ -1155,7 +1124,7 @@ class RecordsProviderLttng(RuntimeDataProvider):
             columns += [
                 COLUMN_NAME.SOURCE_TIMESTAMP,
                 COLUMN_NAME.RMW_TAKE_TIMESTAMP,
-                COLUMN_NAME.CALLBACK_START_TIMESTAMP,
+                #COLUMN_NAME.CALLBACK_START_TIMESTAMP,
             ]
         except Exception as e:
             msg = f"Column list construction failed: {e}"

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -2021,6 +2021,7 @@ class FilteredRecordsSource:
             - dds_write_timestamp (Optional)
             - message_timestamp
             - source_timestamp
+            - rmw_take_timestamp (Optional)
 
         """
         pub_records = self.publish_records(publisher_handles)
@@ -2043,8 +2044,6 @@ class FilteredRecordsSource:
             COLUMN_NAME.PUBLISHER_HANDLE,
             COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP,
         ]
-        if COLUMN_NAME.RMW_TAKE_TIMESTAMP in merged.columns:
-            columns.append(COLUMN_NAME.RMW_TAKE_TIMESTAMP)
         if COLUMN_NAME.RCL_PUBLISH_TIMESTAMP in merged.columns:
             columns.append(COLUMN_NAME.RCL_PUBLISH_TIMESTAMP)
         if COLUMN_NAME.DDS_WRITE_TIMESTAMP in merged.columns:
@@ -2053,6 +2052,8 @@ class FilteredRecordsSource:
             COLUMN_NAME.MESSAGE_TIMESTAMP,
             COLUMN_NAME.SOURCE_TIMESTAMP
         ]
+        if COLUMN_NAME.RMW_TAKE_TIMESTAMP in merged.columns:
+            columns.append(COLUMN_NAME.RMW_TAKE_TIMESTAMP)
         drop = list(set(merged.columns) - set(columns))
         merged.drop_columns(drop)
         merged.reindex(columns)

--- a/src/caret_analyze/infra/lttng/records_provider_lttng.py
+++ b/src/caret_analyze/infra/lttng/records_provider_lttng.py
@@ -1056,7 +1056,10 @@ class RecordsProviderLttng(RuntimeDataProvider):
             columns.append(COLUMN_NAME.DDS_WRITE_TIMESTAMP)
         columns += [
             COLUMN_NAME.SOURCE_TIMESTAMP,
-            COLUMN_NAME.RMW_TAKE_TIMESTAMP,
+        ]
+        if COLUMN_NAME.RMW_TAKE_TIMESTAMP in records.columns:
+            columns.append(COLUMN_NAME.RMW_TAKE_TIMESTAMP)
+        columns += [
             COLUMN_NAME.CALLBACK_START_TIMESTAMP,
         ]
 
@@ -2040,8 +2043,9 @@ class FilteredRecordsSource:
             COLUMN_NAME.CALLBACK_START_TIMESTAMP,
             COLUMN_NAME.PUBLISHER_HANDLE,
             COLUMN_NAME.RCLCPP_PUBLISH_TIMESTAMP,
-            COLUMN_NAME.RMW_TAKE_TIMESTAMP,
         ]
+        if COLUMN_NAME.RMW_TAKE_TIMESTAMP in merged.columns:
+            columns.append(COLUMN_NAME.RMW_TAKE_TIMESTAMP)
         if COLUMN_NAME.RCL_PUBLISH_TIMESTAMP in merged.columns:
             columns.append(COLUMN_NAME.RCL_PUBLISH_TIMESTAMP)
         if COLUMN_NAME.DDS_WRITE_TIMESTAMP in merged.columns:

--- a/src/caret_analyze/infra/lttng/records_source.py
+++ b/src/caret_analyze/infra/lttng/records_source.py
@@ -398,10 +398,10 @@ class RecordsSource():
         )
         rmw_sub_records.drop_columns(
             [
-                COLUMN_NAME.RMW_TAKE_TIMESTAMP,
+                # COLUMN_NAME.RMW_TAKE_TIMESTAMP,
                 COLUMN_NAME.TID,
                 COLUMN_NAME.MESSAGE,
-                COLUMN_NAME.RMW_SUBSCRIPTION_HANDLE,
+                # COLUMN_NAME.RMW_SUBSCRIPTION_HANDLE,
             ]
         )
 
@@ -412,6 +412,7 @@ class RecordsSource():
                 ColumnValue(COLUMN_NAME.CALLBACK_OBJECT),
                 ColumnValue(COLUMN_NAME.IS_INTRA_PROCESS),
                 ColumnValue(COLUMN_NAME.SOURCE_TIMESTAMP),
+                ColumnValue(COLUMN_NAME.RMW_TAKE_TIMESTAMP),
             ]
         )
         inter_proc_subscribe.concat(dispatch_sub_records)

--- a/src/caret_analyze/plot/graphviz/chain_latency.py
+++ b/src/caret_analyze/plot/graphviz/chain_latency.py
@@ -128,11 +128,14 @@ def to_label(latency: np.ndarray) -> str:
 
     """
     latency = latency[[not pd.isnull(_) for _ in latency]]
-    label = (
-        'min: {:.2f} ms\n'.format(np.min(latency * 1.0e-6))
-        + 'avg: {:.2f} ms\n'.format(np.average(latency * 1.0e-6))
-        + 'max: {:.2f} ms'.format(np.max(latency * 1.0e-6))
-    )
+    if len(latency) > 0:
+        label = (
+            'min: {:.2f} ms\n'.format(np.min(latency * 1.0e-6))
+            + 'avg: {:.2f} ms\n'.format(np.average(latency * 1.0e-6))
+            + 'max: {:.2f} ms'.format(np.max(latency * 1.0e-6))
+        )
+    else:
+        label = 'Latency cannot be calculated'
     return label
 
 

--- a/src/caret_analyze/record/records_service/stacked_bar.py
+++ b/src/caret_analyze/record/records_service/stacked_bar.py
@@ -131,14 +131,13 @@ class StackedBar:
             elif 'rclcpp_publish' in column:
                 topic_name = column.split('/')[:-2]
                 rename_map[column] = '/'.join(topic_name)
+            elif 'rmw_take' in column:
+                node_name = column.split('/')[:-2]
+                rename_map[column] = '/'.join(node_name)
             elif 'callback_start' in column:
                 node_name = column.split('/')[:-2]
                 rename_map[column] = '/'.join(node_name)
             elif 'callback_end' in column:
-                node_name = column.split('/')[:-2]
-                rename_map[column] = '/'.join(node_name)
-                rename_map[column] += '_end'
-            elif 'rmw_take' in column:
                 node_name = column.split('/')[:-2]
                 rename_map[column] = '/'.join(node_name)
                 rename_map[column] += '_end'

--- a/src/caret_analyze/record/records_service/stacked_bar.py
+++ b/src/caret_analyze/record/records_service/stacked_bar.py
@@ -138,6 +138,10 @@ class StackedBar:
                 node_name = column.split('/')[:-2]
                 rename_map[column] = '/'.join(node_name)
                 rename_map[column] += '_end'
+            elif 'rmw_take' in column:
+                node_name = column.split('/')[:-2]
+                rename_map[column] = '/'.join(node_name)
+                rename_map[column] += '_end'
 
         return rename_map
 

--- a/src/caret_analyze/runtime/communication.py
+++ b/src/caret_analyze/runtime/communication.py
@@ -294,13 +294,12 @@ class Communication(PathBase, Summarizable):
         """
         assert self._records_provider is not None
         records = self._records_provider.communication_records(self._val)
-        # if self.use_take_manually and records:
-        #     records.drop_columns([records.columns[-1]])
 
         return records
 
-    @property
     def use_take_manually(self) -> bool:
+        # TODO: Refactor whether the communication uses 'take' should be determinable
+        # from the Subscription alone, rather than from Communication.
         callback_groups = self.subscribe_node.callback_groups
         if callback_groups is None:
             return False

--- a/src/caret_analyze/runtime/communication.py
+++ b/src/caret_analyze/runtime/communication.py
@@ -297,6 +297,22 @@ class Communication(PathBase, Summarizable):
 
         return records
 
+
+    def to_take_records(self) -> RecordsInterface:
+        """
+        Calculate records.
+
+        Returns
+        -------
+        RecordsInterface
+            communication latency (publish-subscribe).
+
+        """
+        assert self._records_provider is not None
+        records = self._records_provider._compose_inter_proc_take_comm_records(self._val)
+
+        return records
+
     def use_take_manually(self) -> bool:
         # TODO: Refactor whether the communication uses 'take' should be determinable
         # from the Subscription alone, rather than from Communication.

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -245,6 +245,7 @@ class RecordsMerged:
 
             # adjust the columns for the case that the message is not taken by callback
             if is_match_column(right_records.columns[0], 'source_timestamp'):
+            # if isinstance(target_, Communication) and target_.use_take_manually:
                 left_records.drop_columns([left_records.columns[-1]])
 
             if left_records.columns[-1] != right_records.columns[0]:

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -244,9 +244,8 @@ class RecordsMerged:
             right_records.rename_columns(rename_rule)
 
             # adjust the columns for the case that the message is not taken by callback
-            if is_match_column(right_records.columns[0], 'source_timestamp'):
-            # if isinstance(target_, Communication) and target_.use_take_manually:
-                left_records.drop_columns([left_records.columns[-1]])
+            if isinstance(target, Communication) and target.use_take_manually():
+                right_records.drop_columns([right_records.columns[-1]])
 
             if left_records.columns[-1] != right_records.columns[0]:
                 raise InvalidRecordsError('left columns[-1] != right columns[0]')

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -230,7 +230,6 @@ class RecordsMerged:
         first_column = left_records.columns[0] if left_records.columns else None 
 
         last_communication_in_full_list = None
-        replace_communication_to_rmw_take_list = None
         for item in reversed(targets):
             if isinstance(item, Communication):
                 last_communication_in_full_list = item
@@ -365,7 +364,7 @@ class RecordsMerged:
 
         # remove rmw_take columns except for the last one
         rmw_cols = [col for col in left_records.columns if ('rmw_take' in col) ]
-        is_last_take = targets[-2].use_take_manually()
+        is_last_take = isinstance(targets[-2], Communication) and targets[-2].use_take_manually()
         if is_last_take:
             drop_rmw_cols = rmw_cols[:-1]
         else:

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -371,7 +371,7 @@ class RecordsMerged:
             for col_name in reversed(last_communication_record.column_names):
                 # ex. "/planning/planning_validator/callback_6/callback_start_timestamp"
                 # match.group(1): "/planning/planning_validator" (node name)
-                match = re.match(r'(.*)(?:/callback_\d+)?/callback_start_timestamp(?:/\d+)?', col_name)
+                match = re.match(r'(.+?)(?:/callback_\d+)?/callback_start_timestamp(?:/\d+)?', col_name)
                 if match:
                     extracted_node_name = match.group(1)
                     break

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -294,7 +294,6 @@ class RecordsMerged:
                             isinstance(target_.message_context, CallbackChain)
 
             if is_sequential:
-                print("!!! 1-9")
                 left_records = merge_sequential(
                     left_records=left_records,
                     right_records=right_records,

--- a/src/caret_analyze/runtime/path.py
+++ b/src/caret_analyze/runtime/path.py
@@ -373,7 +373,6 @@ class RecordsMerged:
                 # match.group(1): "/planning/planning_validator" (node name)
                 match = re.match(r'(.*)/callback_\d+/callback_start_timestamp(?:/\d+)?', col_name)
                 if match:
-                    print(f"### match: {match.group(0)=} {match.group(1)=}")
                     extracted_node_name = match.group(1)
                     break
 

--- a/src/caret_analyze/value_objects/callback_group.py
+++ b/src/caret_analyze/value_objects/callback_group.py
@@ -28,11 +28,14 @@ class CallbackGroupType(ValueObject):
 
     - MUTUALLY_EXCLUSIVE
     - REENTRANT
+    - UNDEFINED
 
     """
 
     MUTUALLY_EXCLUSIVE: CallbackGroupType
     REENTRANT: CallbackGroupType
+    # TODO: rename UNDEFIND
+    # The CallbackGroup type marked as UNDEFINED here indicates that it is not connected to an Executor.
     UNDEFINED: CallbackGroupType
 
     def __init__(self, name: str) -> None:

--- a/src/test/infra/lttng/test_latency_definitions.py
+++ b/src/test/infra/lttng/test_latency_definitions.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from logging import WARNING
+
 from caret_analyze.exceptions import UnsupportedNodeRecordsError
 from caret_analyze.infra.lttng import Lttng, RecordsProviderLttng
 from caret_analyze.infra.lttng.bridge import LttngBridge
@@ -1463,8 +1465,8 @@ class TestCommunicationRecords:
                     f'{communication.topic_name}/rclcpp_publish_timestamp': 1,
                     f'{communication.topic_name}/rcl_publish_timestamp': 2,
                     f'{communication.topic_name}/dds_write_timestamp': 3,
-                    # f'{communication.topic_name}/message_timestamp': message_stamp,
                     f'{communication.topic_name}/source_timestamp': 9,
+                    f'{communication.topic_name}/rmw_take_timestamp': pd.NA if has_dispatch else 5,
                     f'{callback.callback_name}/callback_start_timestamp': 16,
                 }
             ],
@@ -1472,8 +1474,8 @@ class TestCommunicationRecords:
                 f'{communication.topic_name}/rclcpp_publish_timestamp',
                 f'{communication.topic_name}/rcl_publish_timestamp',
                 f'{communication.topic_name}/dds_write_timestamp',
-                # f'{communication.topic_name}/message_timestamp',
                 f'{communication.topic_name}/source_timestamp',
+                f'{communication.topic_name}/rmw_take_timestamp',
                 f'{callback.callback_name}/callback_start_timestamp',
             ],
             dtype='Int64'
@@ -1605,21 +1607,26 @@ class TestCommunicationRecords:
                 {
                     f'{communication.topic_name}/rclcpp_publish_timestamp': 1,
                     f'{communication.topic_name}/source_timestamp': 9,
+                    f'{communication.topic_name}/rmw_take_timestamp': pd.NA,
                     f'{callback.callback_name}/callback_start_timestamp': 16,
                 },
                 {
                     f'{communication.topic_name}/rclcpp_publish_timestamp': 17,
                     f'{communication.topic_name}/source_timestamp': 109,
+                    f'{communication.topic_name}/rmw_take_timestamp': pd.NA,
+                    f'{callback.callback_name}/callback_start_timestamp': pd.NA,
                 },
                 {
                     f'{communication.topic_name}/rclcpp_publish_timestamp': 19,
                     f'{communication.topic_name}/source_timestamp': 209,
+                    f'{communication.topic_name}/rmw_take_timestamp': pd.NA,
                     f'{callback.callback_name}/callback_start_timestamp': 22,
                 }
             ],
             columns=[
                 f'{communication.topic_name}/rclcpp_publish_timestamp',
                 f'{communication.topic_name}/source_timestamp',
+                f'{communication.topic_name}/rmw_take_timestamp',
                 f'{callback.callback_name}/callback_start_timestamp',
             ],
             dtype='Int64'
@@ -2065,4 +2072,8 @@ class TestSimTimeConverter:
 
         assert (s100 == d100)
         assert (s300 == d300)
-        assert 'Out-of-range time is used to convert sim_time' in caplog.messages[0]
+        assert 'Out-of-range time is used to convert sim_time' in caplog.text
+        assert caplog.records[0].levelno == WARNING
+        #captured = capsys.readouterr()
+        #assert 'Out-of-range time is used to convert sim_time' in captured.err
+

--- a/src/test/runtime/test_path.py
+++ b/src/test/runtime/test_path.py
@@ -248,6 +248,7 @@ class TestRecordsMerged:
         )
 
         comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(comm_path, 'use_take_manually', return_value=False)
         mocker.patch.object(
             comm_path, 'to_records',
             return_value=RecordsCppImpl(
@@ -336,6 +337,7 @@ class TestRecordsMerged:
         )
 
         comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(comm_path, 'use_take_manually', return_value=False)
         mocker.patch.object(
             comm_path, 'to_records',
             return_value=RecordsCppImpl(
@@ -416,6 +418,7 @@ class TestRecordsMerged:
         )
 
         comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(comm_path, 'use_take_manually', return_value=False)
         mocker.patch.object(
             comm_path, 'to_records',
             return_value=RecordsCppImpl(
@@ -501,6 +504,7 @@ class TestRecordsMerged:
         )
 
         comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(comm_path, 'use_take_manually', return_value=False)
         mocker.patch.object(
             comm_path, 'to_records',
             return_value=RecordsCppImpl(
@@ -578,6 +582,7 @@ class TestRecordsMerged:
 
     def test_take_impl_case(self, mocker):
         comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(comm_path, 'use_take_manually', return_value=True)
         topic0 = 'topic_0'
         topic1 = 'topic_1'
         mocker.patch.object(
@@ -596,7 +601,7 @@ class TestRecordsMerged:
                     ColumnValue(f'{topic0}/rcl_publish_timestamp'),
                     ColumnValue(f'{topic0}/dds_write_timestamp'),
                     ColumnValue(f'{topic0}/source_timestamp'),
-                    ColumnValue(f'{topic0}/callback_start_timestamp'),
+                    # ColumnValue(f'{topic0}/callback_start_timestamp'),
                 ]
             )
         )
@@ -686,6 +691,7 @@ class TestRecordsMerged:
         )
 
         comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(comm_path, 'use_take_manually', return_value=False)
         mocker.patch.object(
             comm_path, 'to_records',
             return_value=RecordsCppImpl(
@@ -759,6 +765,7 @@ class TestRecordsMerged:
         topic0 = 'topic_0'
         topic1 = 'topic_1'
         comm_path = mocker.Mock(spec=Communication)
+        mocker.patch.object(comm_path, 'use_take_manually', return_value=True)
         mocker.patch.object(
             comm_path, 'to_records',
             return_value=RecordsCppImpl(


### PR DESCRIPTION
## Description

If the last node in the path uses take-method, use rmw_take_timestamp to calculate latency.

the message flow, it is represented as “node name + rmw_take_timestamp” as shown in the figure.

<img width="867" height="214" alt="image" src="https://github.com/user-attachments/assets/e2a491d4-6228-4be7-b73e-8925c48bb4c1" />


## Related links

https://tier4.atlassian.net/browse/RT2-2480

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
