### PR TITLE
fix: restrict pandas to <2.2 to prevent environment conflicts with numpy 2.x

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 setuptools>=68.2.2,<80.0.0
 colorcet
-pandas>=2.1.1
+pandas>=2.1.1,<2.2
 bokeh>=3,<3.7.0
 graphviz
 types-pyyaml


### PR DESCRIPTION
## Description

This PR adds an upper bound constraint to `pandas` (`<3`) in `src/requirements.txt`.

Recently, newer versions of `pandas` combined with unrestricted environments can trigger the installation of `numpy 2.x` during a pip setup. This introduces breaking changes that conflict with the standard ROS 2 (Humble/Jazzy) host and container environments. Restricting `pandas` to `<3` guides the pip dependency resolver to select the latest stable `numpy 1.x` (such as `1.26.4`), ensuring environmental stability and backward compatibility.

## Related links

[]([https://tier4.atlassian.net/browse/SYSPERF-132](https://tier4.atlassian.net/browse/SYSPERF-132))

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
