### PR TITLE
fix(ci): remove duplicated keys and non-existent reorder-versions call

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -45,7 +45,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest: false
           mkdocs-requirements-txt: ./mkdocs-requirements.txt
-          mkdocs-requirements-txt: mkdocs-requirements.txt
 
   deploy-docs-push:
     if: ${{ github.event_name == 'push' }}
@@ -62,7 +61,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest: false
           mkdocs-requirements-txt: ./mkdocs-requirements.txt
-          mkdocs-requirements-txt: mkdocs-requirements.txt
 
   deploy-docs-workflow-dispatch:
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -79,20 +77,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest: false
           mkdocs-requirements-txt: ./mkdocs-requirements.txt
-          mkdocs-requirements-txt: mkdocs-requirements.txt
-
-  reorder-versions-json:
-    needs:
-      - deploy-docs-pr
-      - deploy-docs-push
-      - deploy-docs-workflow-dispatch
-    if: |
-      always() &&
-      (
-        needs.deploy-docs-pr.result == 'success' ||
-        needs.deploy-docs-push.result == 'success' ||
-        needs.deploy-docs-workflow-dispatch.result == 'success'
-      )
-    uses: ./.github/workflows/reorder-versions.yaml
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This PR fixes CI / Pre-commit failure caused by syntax and configuration errors in `.github/workflows/deploy-docs.yaml`.

### Changes
- Removed duplicated `mkdocs-requirements-txt` keys within the `with` section of `deploy-docs-pr`, `deploy-docs-push`, and `deploy-docs-workflow-dispatch` jobs to resolve the yaml parsing error.
- Removed the entire `reorder-versions-json` job since `.github/workflows/reorder-versions.yaml` does not exist in this repository, which was causing workflow parsing failures.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
