### PR TITLE
fix: add reorder-versions.yaml to workflow from autoware-documentation

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,3 +1,7 @@
 {
   "import": ["@tier4/cspell-dicts/caret/cspell-ext.json"]
+  "words": [
+    "tonumber",
+    "ltrimstr"
+  ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -1,7 +1,3 @@
 {
   "import": ["@tier4/cspell-dicts/caret/cspell-ext.json"]
-  "words": [
-    "tonumber",
-    "ltrimstr"
-  ]
 }

--- a/.github/workflows/reorder-versions.yaml
+++ b/.github/workflows/reorder-versions.yaml
@@ -1,3 +1,4 @@
+# cspell:ignore tonumber ltrimstr
 name: reorder-versions
 
 on:

--- a/.github/workflows/reorder-versions.yaml
+++ b/.github/workflows/reorder-versions.yaml
@@ -1,0 +1,106 @@
+name: reorder-versions
+
+on:
+  workflow_call:
+    secrets:
+      token:
+        description: GitHub token
+        required: true
+  workflow_dispatch:
+
+jobs:
+  reorder-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+
+      - name: Show existing versions.json
+        run: |
+          cat versions.json
+        shell: bash
+
+      - name: Reorder versions.json
+        run: |
+          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+
+          jq --arg DEFAULT_BRANCH "$DEFAULT_BRANCH" '
+            . as $all |
+            [
+              # 1. Default branch
+              ($all | map(select(.version == $DEFAULT_BRANCH))[]),
+
+              # 2. numeric versions like 1.4
+              ($all
+                | map(select(.version | test("^[0-9]+\\.[0-9]+$")))
+                | sort_by(.version | split(".") | map(tonumber))
+                | reverse
+                | .[]
+              ),
+
+              # 3. PR versions: pr-123
+              ($all
+                | map(select(.version | test("^pr-[0-9]+$")))
+                | sort_by(.version | ltrimstr("pr-") | tonumber)
+                | reverse
+                | .[]
+              ),
+
+              # 4. everything else (other branches)
+              ($all
+                | map(select(.version | test("^(main|[0-9]+\\.[0-9]+|pr-[0-9]+)$") | not))
+                | sort_by(.version)
+                | .[]
+              )
+            ]
+          ' versions.json > versions.sorted.json
+        shell: bash
+
+      - name: Show sorted versions.json
+        run: |
+          cat versions.sorted.json
+        shell: bash
+
+      - name: Validate element count matches
+        run: |
+          COUNT_ORIG=$(jq 'length' versions.json)
+          COUNT_SORTED=$(jq 'length' versions.sorted.json)
+
+          echo "Original count: $COUNT_ORIG"
+          echo "Sorted count:   $COUNT_SORTED"
+
+          if [ "$COUNT_ORIG" -ne "$COUNT_SORTED" ]; then
+            echo "ERROR: Element count mismatch! Sorting likely broke the structure."
+            exit 1
+          fi
+        shell: bash
+
+      - name: Show diff
+        run: |
+          diff -u versions.json versions.sorted.json || true
+        shell: bash
+
+      - name: Replace versions.json
+        run: |
+          mv versions.sorted.json versions.json
+        shell: bash
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ github.event_name == 'workflow_dispatch' && secrets.GITHUB_TOKEN || secrets.token }}
+
+      - name: Commit and push changes
+        run: |
+          # Commit only if changed
+          if git diff --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+
+          git add versions.json
+          git commit -m "Reorder versions.json"
+          git push
+        shell: bash


### PR DESCRIPTION
## Description

The CI workflow delete-closed-pr-docs.yaml was failing to fetch the called workflow ./.github/workflows/reorder-versions.yaml, causing a "workflow not found" error.
Added the missing reorder-versions.yaml file from the upstream repository.

## Related links

[https://github.com/tier4/caret_analyze/pull/600](https://github.com/tier4/caret_analyze/pull/600)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
