### PR TITLE
fix: require tag:deploy-docs label only for doc-related PRs

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -5,12 +5,6 @@ on:
     branches:
       - main
       - galactic
-    paths:
-      - mkdocs.yaml
-      - "**/*.md"
-      - "**/*.svg"
-      - "**/*.png"
-      - "**/*.jpg"
     tags:
       - "[0-9]+.[0-9]+*"
   pull_request_target:
@@ -18,6 +12,12 @@ on:
       - opened
       - synchronize
       - labeled
+    paths:
+      - mkdocs.yaml
+      - "**/*.md"
+      - "**/*.svg"
+      - "**/*.png"
+      - "**/*.jpg"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

Require tag:deploy-docs label only for doc-related in deploy-docs ci.

## Related links

[https://tier4.atlassian.net/browse/SYSPERF-136](https://tier4.atlassian.net/browse/SYSPERF-136)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
