### PR TITLE
fix: sync-files ci error

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -17,21 +17,21 @@
     - source: .github/workflows/github-release.yaml
     - source: cliff.toml
 
-- repository: autowarefoundation/autoware-documentation
-  files:
-    # - source: .github/workflows/deploy-docs.yaml
-    #   pre-commands: |
-    #     sd -s -- \
-    #     '      - "**/*.jpg"' \
-    #     '      - "**/*.jpg"
-    #           - "**/*.py"' \
-    #     {source}
-    #     sd -- \
-    #     '          latest: (.*)' \
-    #     '          latest: $1
-    #               mkdocs-requirements-txt: ./mkdocs-requirements.txt' \
-    #     {source}
-    # - source: .github/workflows/delete-closed-pr-docs.yaml
+# - repository: autowarefoundation/autoware-documentation
+#   files:
+#     - source: .github/workflows/deploy-docs.yaml
+#       pre-commands: |
+#         sd -s -- \
+#         '      - "**/*.jpg"' \
+#         '      - "**/*.jpg"
+#               - "**/*.py"' \
+#         {source}
+#         sd -- \
+#         '          latest: (.*)' \
+#         '          latest: $1
+#                   mkdocs-requirements-txt: ./mkdocs-requirements.txt' \
+#         {source}
+#     - source: .github/workflows/delete-closed-pr-docs.yaml
 
 - repository: tier4/caret_common
   files:


### PR DESCRIPTION
## Description

Since `sync-files` causes a CI error, comment out the `autoware-documentation` repository and its associated files in the `sync-files.yaml` configuration file.

## Related links

[https://tier4.atlassian.net/browse/SYSPERF-136](https://tier4.atlassian.net/browse/SYSPERF-136)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
