### PR TITLE
fix: remove setuptools in requirements.txt

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,3 @@
-setuptools>=68.2.2,<80.0.0
 colorcet
 pandas>=2.1.1,<2.2
 bokeh~=3.8.2


### PR DESCRIPTION
## Description

A security alert issued a warning regarding the setuptools version in `requirements.txt`.
In ROS 2, setuptools can be installed via rosdep, so I will stop installing it manually.
CVE-2026-59890

## Related links

[https://tier4.atlassian.net/browse/SYSPERF-145](https://tier4.atlassian.net/browse/SYSPERF-145)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
