### PR TITLE
fix: jazzy empty callback group filter

### DIFF
--- a/src/caret_analyze/infra/lttng/lttng_info.py
+++ b/src/caret_analyze/infra/lttng/lttng_info.py
@@ -1438,6 +1438,21 @@ class DataFrameFormatted:
         # Remove duplicates to make it unique.
         callback_groups.drop_duplicate()
 
+        # Remove callback groups that have no actual callbacks.
+        # This can happen with Jazzy's single_threaded_executor which records
+        # an internal callback_group via callback_group_to_executor_entity_collector
+        # but never adds any callbacks to it via callback_group_add_* events.
+        valid_cbg_addrs: set[int] = set()
+        valid_cbg_addrs.update(data.callback_group_timer.df.index)
+        valid_cbg_addrs.update(data.callback_group_subscription.df.index)
+        valid_cbg_addrs.update(data.callback_group_service.df.index)
+        valid_cbg_addrs.update(data.callback_group_client.df.index)
+        if len(valid_cbg_addrs) > 0:
+            cbg_df = callback_groups.df
+            callback_groups._df = cbg_df[
+                cbg_df['callback_group_addr'].isin(valid_cbg_addrs)
+            ]
+
         executor_duplicated_indexes = []
         for _, group in callback_groups.df.groupby('callback_group_addr'):
             if len(group) >= 2:

--- a/src/caret_analyze/infra/lttng/lttng_info.py
+++ b/src/caret_analyze/infra/lttng/lttng_info.py
@@ -1447,6 +1447,15 @@ class DataFrameFormatted:
         valid_cbg_addrs.update(data.callback_group_subscription.df.index)
         valid_cbg_addrs.update(data.callback_group_service.df.index)
         valid_cbg_addrs.update(data.callback_group_client.df.index)
+        # Include agnocast callback groups as well.
+        # Agnocast subscriptions/timers use callback_group_addr as a column,
+        # not as the index, unlike ROS 2 standard callback_group_* data.
+        if len(data.agnocast_subscriptions.df) > 0:
+            valid_cbg_addrs.update(
+                data.agnocast_subscriptions.df['callback_group_addr'].values)
+        if len(data.agnocast_timers.df) > 0:
+            valid_cbg_addrs.update(
+                data.agnocast_timers.df['callback_group_addr'].values)
         if len(valid_cbg_addrs) > 0:
             cbg_df = callback_groups.df
             callback_groups._df = cbg_df[


### PR DESCRIPTION
## Description

ROS 2 Jazzy's `single_threaded_executor` records internal empty callback groups, causing analysis errors. Added a filter in `_build_cbg()` to exclude callback groups with no actual callbacks.

## Related links

[https://tier4.atlassian.net/browse/SYSPERF-148](https://tier4.atlassian.net/browse/SYSPERF-148)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [ ] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [ ] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] (Optional) The PR has been properly tested with CARET_report verification.
- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
